### PR TITLE
feat: add usuario infrastructure and validation fix

### DIFF
--- a/src/main/java/controller/CategoriaController.java
+++ b/src/main/java/controller/CategoriaController.java
@@ -1,0 +1,124 @@
+// path: src/main/java/controller/CategoriaController.java
+package controller;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import dao.api.CategoriaDao;
+import exception.CategoriaException;
+import infra.Logger;
+import model.Categoria;
+
+public class CategoriaController {
+
+    private final CategoriaDao dao;
+
+    public CategoriaController(CategoriaDao dao) {
+        this.dao = dao;
+    }
+
+    public void criar(Categoria categoria) {
+        Logger.info("CategoriaController.criar - inicio");
+        if (categoria == null) {
+            throw new CategoriaException("Categoria não pode ser nula");
+        }
+        if (categoria.getIdCategoria() == null) {
+            throw new CategoriaException("Id da Categoria é obrigatório");
+        }
+        if (categoria.getNome() == null || categoria.getNome().isEmpty()) {
+            throw new CategoriaException("Nome da Categoria é obrigatório");
+        }
+        dao.create(categoria);
+        Logger.info("CategoriaController.criar - sucesso");
+    }
+
+    public Categoria atualizar(Categoria categoria) {
+        Logger.info("CategoriaController.atualizar - inicio");
+        if (categoria == null || categoria.getIdCategoria() == null) {
+            throw new CategoriaException("Categoria ou Id não pode ser nulo");
+        }
+        if (categoria.getNome() == null || categoria.getNome().isEmpty()) {
+            throw new CategoriaException("Nome da Categoria é obrigatório");
+        }
+        Categoria updated = dao.update(categoria);
+        Logger.info("CategoriaController.atualizar - sucesso");
+        return updated;
+    }
+
+    public void remover(Integer id) {
+        Logger.info("CategoriaController.remover - inicio");
+        if (id == null) {
+            throw new CategoriaException("Id da Categoria é obrigatório");
+        }
+        dao.deleteById(id);
+        Logger.info("CategoriaController.remover - sucesso");
+    }
+
+    public Categoria buscarPorId(Integer id) {
+        Logger.info("CategoriaController.buscarPorId - inicio");
+        if (id == null) {
+            throw new CategoriaException("Id da Categoria é obrigatório");
+        }
+        Categoria c = dao.findById(id);
+        Logger.info("CategoriaController.buscarPorId - sucesso");
+        return c;
+    }
+
+    public List<Categoria> listar() {
+        Logger.info("CategoriaController.listar - inicio");
+        List<Categoria> list = dao.findAll();
+        Logger.info("CategoriaController.listar - sucesso");
+        return list;
+    }
+
+    public List<Categoria> listar(int page, int size) {
+        Logger.info("CategoriaController.listar(page) - inicio");
+        List<Categoria> list = dao.findAll(page, size);
+        Logger.info("CategoriaController.listar(page) - sucesso");
+        return list;
+    }
+
+    public List<Categoria> buscarPorNome(String nome) {
+        Logger.info("CategoriaController.buscarPorNome - inicio");
+        if (nome == null || nome.isEmpty()) {
+            throw new CategoriaException("Nome não pode ser vazio");
+        }
+        List<Categoria> list = dao.findByNome(nome);
+        Logger.info("CategoriaController.buscarPorNome - sucesso");
+        return list;
+    }
+
+    public List<Categoria> buscarPorDescricao(String descricao) {
+        Logger.info("CategoriaController.buscarPorDescricao - inicio");
+        if (descricao == null || descricao.isEmpty()) {
+            throw new CategoriaException("Descrição não pode ser vazia");
+        }
+        List<Categoria> list = dao.findByDescricao(descricao);
+        Logger.info("CategoriaController.buscarPorDescricao - sucesso");
+        return list;
+    }
+
+    public List<Categoria> buscarPorDataCriacao(LocalDate data) {
+        Logger.info("CategoriaController.buscarPorDataCriacao - inicio");
+        if (data == null) {
+            throw new CategoriaException("Data de criação não pode ser nula");
+        }
+        List<Categoria> list = dao.findByDataCriacao(data);
+        Logger.info("CategoriaController.buscarPorDataCriacao - sucesso");
+        return list;
+    }
+
+    public List<Categoria> pesquisar(Categoria filtro) {
+        Logger.info("CategoriaController.pesquisar - inicio");
+        List<Categoria> list = dao.search(filtro);
+        Logger.info("CategoriaController.pesquisar - sucesso");
+        return list;
+    }
+
+    public List<Categoria> pesquisar(Categoria filtro, int page, int size) {
+        Logger.info("CategoriaController.pesquisar(page) - inicio");
+        List<Categoria> list = dao.search(filtro, page, size);
+        Logger.info("CategoriaController.pesquisar(page) - sucesso");
+        return list;
+    }
+}

--- a/src/main/java/controller/UsuarioController.java
+++ b/src/main/java/controller/UsuarioController.java
@@ -1,0 +1,135 @@
+// path: src/main/java/controller/UsuarioController.java
+package controller;
+
+import java.util.List;
+
+import dao.api.UsuarioDao;
+import exception.UsuarioException;
+import infra.Logger;
+import model.Usuario;
+
+public class UsuarioController {
+
+    private final UsuarioDao dao;
+
+    public UsuarioController(UsuarioDao dao) {
+        this.dao = dao;
+    }
+
+    public void criar(Usuario usuario) {
+        Logger.info("UsuarioController.criar - inicio");
+        if (usuario == null) {
+            throw new UsuarioException("Usuario não pode ser nulo");
+        }
+        if (usuario.getIdUsuario() == null) {
+            throw new UsuarioException("Id do Usuario é obrigatório");
+        }
+        if (usuario.getNome() == null || usuario.getNome().isEmpty()) {
+            throw new UsuarioException("Nome do Usuario é obrigatório");
+        }
+        if (usuario.getSenha() == null || usuario.getSenha().isEmpty()) {
+            throw new UsuarioException("Senha do Usuario é obrigatória");
+        }
+        if (usuario.getEmail() == null || usuario.getEmail().isEmpty()) {
+            throw new UsuarioException("Email do Usuario é obrigatório");
+        }
+        dao.create(usuario);
+        Logger.info("UsuarioController.criar - sucesso");
+    }
+
+    public Usuario atualizar(Usuario usuario) {
+        Logger.info("UsuarioController.atualizar - inicio");
+        if (usuario == null || usuario.getIdUsuario() == null) {
+            throw new UsuarioException("Usuario ou Id não pode ser nulo");
+        }
+        if (usuario.getNome() == null || usuario.getNome().isEmpty()) {
+            throw new UsuarioException("Nome do Usuario é obrigatório");
+        }
+        if (usuario.getSenha() == null || usuario.getSenha().isEmpty()) {
+            throw new UsuarioException("Senha do Usuario é obrigatória");
+        }
+        if (usuario.getEmail() == null || usuario.getEmail().isEmpty()) {
+            throw new UsuarioException("Email do Usuario é obrigatório");
+        }
+        Usuario updated = dao.update(usuario);
+        Logger.info("UsuarioController.atualizar - sucesso");
+        return updated;
+    }
+
+    public void remover(Integer id) {
+        Logger.info("UsuarioController.remover - inicio");
+        if (id == null) {
+            throw new UsuarioException("Id do Usuario é obrigatório");
+        }
+        dao.deleteById(id);
+        Logger.info("UsuarioController.remover - sucesso");
+    }
+
+    public Usuario buscarPorId(Integer id) {
+        Logger.info("UsuarioController.buscarPorId - inicio");
+        if (id == null) {
+            throw new UsuarioException("Id do Usuario é obrigatório");
+        }
+        Usuario u = dao.findById(id);
+        Logger.info("UsuarioController.buscarPorId - sucesso");
+        return u;
+    }
+
+    public List<Usuario> listar() {
+        Logger.info("UsuarioController.listar - inicio");
+        List<Usuario> list = dao.findAll();
+        Logger.info("UsuarioController.listar - sucesso");
+        return list;
+    }
+
+    public List<Usuario> listar(int page, int size) {
+        Logger.info("UsuarioController.listar(page) - inicio");
+        List<Usuario> list = dao.findAll(page, size);
+        Logger.info("UsuarioController.listar(page) - sucesso");
+        return list;
+    }
+
+    public List<Usuario> buscarPorNome(String nome) {
+        Logger.info("UsuarioController.buscarPorNome - inicio");
+        if (nome == null || nome.isEmpty()) {
+            throw new UsuarioException("Nome não pode ser vazio");
+        }
+        List<Usuario> list = dao.findByNome(nome);
+        Logger.info("UsuarioController.buscarPorNome - sucesso");
+        return list;
+    }
+
+    public List<Usuario> buscarPorSenha(String senha) {
+        Logger.info("UsuarioController.buscarPorSenha - inicio");
+        if (senha == null || senha.isEmpty()) {
+            throw new UsuarioException("Senha não pode ser vazia");
+        }
+        List<Usuario> list = dao.findBySenha(senha);
+        Logger.info("UsuarioController.buscarPorSenha - sucesso");
+        return list;
+    }
+
+    public List<Usuario> buscarPorEmail(String email) {
+        Logger.info("UsuarioController.buscarPorEmail - inicio");
+        if (email == null || email.isEmpty()) {
+            throw new UsuarioException("Email não pode ser vazio");
+        }
+        List<Usuario> list = dao.findByEmail(email);
+        Logger.info("UsuarioController.buscarPorEmail - sucesso");
+        return list;
+    }
+
+    public List<Usuario> pesquisar(Usuario filtro) {
+        Logger.info("UsuarioController.pesquisar - inicio");
+        List<Usuario> list = dao.search(filtro);
+        Logger.info("UsuarioController.pesquisar - sucesso");
+        return list;
+    }
+
+    public List<Usuario> pesquisar(Usuario filtro, int page, int size) {
+        Logger.info("UsuarioController.pesquisar(page) - inicio");
+        List<Usuario> list = dao.search(filtro, page, size);
+        Logger.info("UsuarioController.pesquisar(page) - sucesso");
+        return list;
+    }
+}

--- a/src/main/java/dao/api/CategoriaDao.java
+++ b/src/main/java/dao/api/CategoriaDao.java
@@ -1,0 +1,36 @@
+// path: src/main/java/dao/api/CategoriaDao.java
+package dao.api;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import exception.CategoriaException;
+import model.Categoria;
+
+public interface CategoriaDao {
+    void create(Categoria categoria) throws CategoriaException;
+
+    Categoria update(Categoria categoria) throws CategoriaException;
+
+    void deleteById(Integer id) throws CategoriaException;
+
+    Categoria findById(Integer id) throws CategoriaException;
+
+    Categoria findWithBlobsById(Integer id) throws CategoriaException;
+
+    List<Categoria> findAll();
+
+    List<Categoria> findAll(int page, int size);
+
+    List<Categoria> findByNome(String nome);
+
+    List<Categoria> findByDescricao(String descricao);
+
+    List<Categoria> findByDataCriacao(LocalDate dataCriacao);
+
+    List<Categoria> findByFoto(byte[] foto);
+
+    List<Categoria> search(Categoria filtro);
+
+    List<Categoria> search(Categoria filtro, int page, int size);
+}

--- a/src/main/java/dao/api/UsuarioDao.java
+++ b/src/main/java/dao/api/UsuarioDao.java
@@ -1,0 +1,35 @@
+// path: src/main/java/dao/api/UsuarioDao.java
+package dao.api;
+
+import java.util.List;
+
+import exception.UsuarioException;
+import model.Usuario;
+
+public interface UsuarioDao {
+    void create(Usuario usuario) throws UsuarioException;
+
+    Usuario update(Usuario usuario) throws UsuarioException;
+
+    void deleteById(Integer id) throws UsuarioException;
+
+    Usuario findById(Integer id) throws UsuarioException;
+
+    Usuario findWithBlobsById(Integer id) throws UsuarioException;
+
+    List<Usuario> findAll();
+
+    List<Usuario> findAll(int page, int size);
+
+    List<Usuario> findByNome(String nome);
+
+    List<Usuario> findBySenha(String senha);
+
+    List<Usuario> findByEmail(String email);
+
+    List<Usuario> findByFoto(byte[] foto);
+
+    List<Usuario> search(Usuario filtro);
+
+    List<Usuario> search(Usuario filtro, int page, int size);
+}

--- a/src/main/java/dao/impl/CategoriaDaoNativeImpl.java
+++ b/src/main/java/dao/impl/CategoriaDaoNativeImpl.java
@@ -1,0 +1,269 @@
+// path: src/main/java/dao/impl/CategoriaDaoNativeImpl.java
+package dao.impl;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import dao.api.CategoriaDao;
+import exception.CategoriaException;
+import infra.EntityManagerUtil;
+import infra.Logger;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import model.Categoria;
+
+public class CategoriaDaoNativeImpl implements CategoriaDao {
+
+    @Override
+    public void create(Categoria categoria) throws CategoriaException {
+        Logger.info("CategoriaDaoNativeImpl.create - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "INSERT INTO Categoria (id_categoria, nome, descricao, foto, data_criacao) " +
+                    "VALUES (:id, :nome, :descricao, :foto, :dataCriacao)";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("id", categoria.getIdCategoria());
+            query.setParameter("nome", categoria.getNome());
+            query.setParameter("descricao", categoria.getDescricao());
+            query.setParameter("foto", categoria.getFoto());
+            query.setParameter("dataCriacao", categoria.getDataCriacao());
+            query.executeUpdate();
+            em.getTransaction().commit();
+            Logger.info("CategoriaDaoNativeImpl.create - sucesso");
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("CategoriaDaoNativeImpl.create - erro", e);
+            throw new CategoriaException("Erro ao criar Categoria", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Categoria update(Categoria categoria) throws CategoriaException {
+        Logger.info("CategoriaDaoNativeImpl.update - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "UPDATE Categoria SET nome=:nome, descricao=:descricao, foto=:foto, data_criacao=:dataCriacao " +
+                    "WHERE id_categoria=:id";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("nome", categoria.getNome());
+            query.setParameter("descricao", categoria.getDescricao());
+            query.setParameter("foto", categoria.getFoto());
+            query.setParameter("dataCriacao", categoria.getDataCriacao());
+            query.setParameter("id", categoria.getIdCategoria());
+            int updated = query.executeUpdate();
+            if (updated == 0) {
+                throw new CategoriaException("Categoria não encontrada: id=" + categoria.getIdCategoria());
+            }
+            em.getTransaction().commit();
+            Logger.info("CategoriaDaoNativeImpl.update - sucesso");
+            return findById(categoria.getIdCategoria());
+        } catch (CategoriaException e) {
+            em.getTransaction().rollback();
+            Logger.error("CategoriaDaoNativeImpl.update - erro", e);
+            throw e;
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("CategoriaDaoNativeImpl.update - erro", e);
+            throw new CategoriaException("Erro ao atualizar Categoria", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public void deleteById(Integer id) throws CategoriaException {
+        Logger.info("CategoriaDaoNativeImpl.deleteById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "DELETE FROM Categoria WHERE id_categoria=:id";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("id", id);
+            int deleted = query.executeUpdate();
+            if (deleted == 0) {
+                throw new CategoriaException("Categoria não encontrada: id=" + id);
+            }
+            em.getTransaction().commit();
+            Logger.info("CategoriaDaoNativeImpl.deleteById - sucesso");
+        } catch (CategoriaException e) {
+            em.getTransaction().rollback();
+            Logger.error("CategoriaDaoNativeImpl.deleteById - erro", e);
+            throw e;
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("CategoriaDaoNativeImpl.deleteById - erro", e);
+            throw new CategoriaException("Erro ao deletar Categoria", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Categoria findById(Integer id) throws CategoriaException {
+        Logger.info("CategoriaDaoNativeImpl.findById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_categoria, nome, descricao, foto, data_criacao FROM Categoria WHERE id_categoria=:id";
+            Query query = em.createNativeQuery(sql, Categoria.class);
+            query.setParameter("id", id);
+            Categoria c = (Categoria) query.getSingleResult();
+            Logger.info("CategoriaDaoNativeImpl.findById - sucesso");
+            return c;
+        } catch (Exception e) {
+            Logger.error("CategoriaDaoNativeImpl.findById - erro", e);
+            throw new CategoriaException("Categoria não encontrada: id=" + id, e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Categoria findWithBlobsById(Integer id) throws CategoriaException {
+        return findById(id);
+    }
+
+    @Override
+    public List<Categoria> findAll() {
+        Logger.info("CategoriaDaoNativeImpl.findAll - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_categoria, nome, descricao, data_criacao FROM Categoria";
+            Query query = em.createNativeQuery(sql, Categoria.class);
+            List<Categoria> list = query.getResultList();
+            Logger.info("CategoriaDaoNativeImpl.findAll - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Categoria> findAll(int page, int size) {
+        Logger.info("CategoriaDaoNativeImpl.findAll(page) - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_categoria, nome, descricao, data_criacao FROM Categoria LIMIT :limit OFFSET :offset";
+            Query query = em.createNativeQuery(sql, Categoria.class);
+            query.setParameter("limit", size);
+            query.setParameter("offset", page * size);
+            List<Categoria> list = query.getResultList();
+            Logger.info("CategoriaDaoNativeImpl.findAll(page) - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Categoria> findByNome(String nome) {
+        Logger.info("CategoriaDaoNativeImpl.findByNome - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_categoria, nome, descricao, data_criacao FROM Categoria WHERE nome=:nome";
+            Query query = em.createNativeQuery(sql, Categoria.class);
+            query.setParameter("nome", nome);
+            List<Categoria> list = query.getResultList();
+            Logger.info("CategoriaDaoNativeImpl.findByNome - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Categoria> findByDescricao(String descricao) {
+        Logger.info("CategoriaDaoNativeImpl.findByDescricao - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_categoria, nome, descricao, data_criacao FROM Categoria WHERE descricao=:descricao";
+            Query query = em.createNativeQuery(sql, Categoria.class);
+            query.setParameter("descricao", descricao);
+            List<Categoria> list = query.getResultList();
+            Logger.info("CategoriaDaoNativeImpl.findByDescricao - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Categoria> findByDataCriacao(java.time.LocalDate dataCriacao) {
+        Logger.info("CategoriaDaoNativeImpl.findByDataCriacao - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_categoria, nome, descricao, data_criacao FROM Categoria WHERE data_criacao=:data";
+            Query query = em.createNativeQuery(sql, Categoria.class);
+            query.setParameter("data", dataCriacao);
+            List<Categoria> list = query.getResultList();
+            Logger.info("CategoriaDaoNativeImpl.findByDataCriacao - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Categoria> findByFoto(byte[] foto) {
+        Logger.info("CategoriaDaoNativeImpl.findByFoto - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_categoria, nome, descricao, foto, data_criacao FROM Categoria WHERE foto=:foto";
+            Query query = em.createNativeQuery(sql, Categoria.class);
+            query.setParameter("foto", foto);
+            List<Categoria> list = query.getResultList();
+            Logger.info("CategoriaDaoNativeImpl.findByFoto - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Categoria> search(Categoria filtro) {
+        return search(filtro, -1, -1);
+    }
+
+    @Override
+    public List<Categoria> search(Categoria filtro, int page, int size) {
+        Logger.info("CategoriaDaoNativeImpl.search - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            StringBuilder sb = new StringBuilder("SELECT id_categoria, nome, descricao, data_criacao FROM Categoria WHERE 1=1");
+            Map<String, Object> params = new HashMap<>();
+            if (filtro.getNome() != null && !filtro.getNome().isEmpty()) {
+                sb.append(" AND nome=:nome");
+                params.put("nome", filtro.getNome());
+            }
+            if (filtro.getDescricao() != null && !filtro.getDescricao().isEmpty()) {
+                sb.append(" AND descricao=:descricao");
+                params.put("descricao", filtro.getDescricao());
+            }
+            if (filtro.getDataCriacao() != null) {
+                sb.append(" AND data_criacao=:dataCriacao");
+                params.put("dataCriacao", filtro.getDataCriacao());
+            }
+            if (page >= 0 && size > 0) {
+                sb.append(" LIMIT :limit OFFSET :offset");
+            }
+            Query query = em.createNativeQuery(sb.toString(), Categoria.class);
+            for (Map.Entry<String, Object> e : params.entrySet()) {
+                query.setParameter(e.getKey(), e.getValue());
+            }
+            if (page >= 0 && size > 0) {
+                query.setParameter("limit", size);
+                query.setParameter("offset", page * size);
+            }
+            List<Categoria> list = query.getResultList();
+            Logger.info("CategoriaDaoNativeImpl.search - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+}

--- a/src/main/java/dao/impl/UsuarioDaoNativeImpl.java
+++ b/src/main/java/dao/impl/UsuarioDaoNativeImpl.java
@@ -1,0 +1,267 @@
+// path: src/main/java/dao/impl/UsuarioDaoNativeImpl.java
+package dao.impl;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import dao.api.UsuarioDao;
+import exception.UsuarioException;
+import infra.EntityManagerUtil;
+import infra.Logger;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import model.Usuario;
+
+public class UsuarioDaoNativeImpl implements UsuarioDao {
+
+    @Override
+    public void create(Usuario usuario) throws UsuarioException {
+        Logger.info("UsuarioDaoNativeImpl.create - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "INSERT INTO Usuario (id_usuario, nome, senha, foto, email) " +
+                    "VALUES (:id, :nome, :senha, :foto, :email)";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("id", usuario.getIdUsuario());
+            query.setParameter("nome", usuario.getNome());
+            query.setParameter("senha", usuario.getSenha());
+            query.setParameter("foto", usuario.getFoto());
+            query.setParameter("email", usuario.getEmail());
+            query.executeUpdate();
+            em.getTransaction().commit();
+            Logger.info("UsuarioDaoNativeImpl.create - sucesso");
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("UsuarioDaoNativeImpl.create - erro", e);
+            throw new UsuarioException("Erro ao criar Usuario", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Usuario update(Usuario usuario) throws UsuarioException {
+        Logger.info("UsuarioDaoNativeImpl.update - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "UPDATE Usuario SET nome=:nome, senha=:senha, foto=:foto, email=:email WHERE id_usuario=:id";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("nome", usuario.getNome());
+            query.setParameter("senha", usuario.getSenha());
+            query.setParameter("foto", usuario.getFoto());
+            query.setParameter("email", usuario.getEmail());
+            query.setParameter("id", usuario.getIdUsuario());
+            int updated = query.executeUpdate();
+            if (updated == 0) {
+                throw new UsuarioException("Usuario não encontrado: id=" + usuario.getIdUsuario());
+            }
+            em.getTransaction().commit();
+            Logger.info("UsuarioDaoNativeImpl.update - sucesso");
+            return findById(usuario.getIdUsuario());
+        } catch (UsuarioException e) {
+            em.getTransaction().rollback();
+            Logger.error("UsuarioDaoNativeImpl.update - erro", e);
+            throw e;
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("UsuarioDaoNativeImpl.update - erro", e);
+            throw new UsuarioException("Erro ao atualizar Usuario", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public void deleteById(Integer id) throws UsuarioException {
+        Logger.info("UsuarioDaoNativeImpl.deleteById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "DELETE FROM Usuario WHERE id_usuario=:id";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("id", id);
+            int deleted = query.executeUpdate();
+            if (deleted == 0) {
+                throw new UsuarioException("Usuario não encontrado: id=" + id);
+            }
+            em.getTransaction().commit();
+            Logger.info("UsuarioDaoNativeImpl.deleteById - sucesso");
+        } catch (UsuarioException e) {
+            em.getTransaction().rollback();
+            Logger.error("UsuarioDaoNativeImpl.deleteById - erro", e);
+            throw e;
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("UsuarioDaoNativeImpl.deleteById - erro", e);
+            throw new UsuarioException("Erro ao deletar Usuario", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Usuario findById(Integer id) throws UsuarioException {
+        Logger.info("UsuarioDaoNativeImpl.findById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_usuario, nome, senha, foto, email FROM Usuario WHERE id_usuario=:id";
+            Query query = em.createNativeQuery(sql, Usuario.class);
+            query.setParameter("id", id);
+            Usuario u = (Usuario) query.getSingleResult();
+            Logger.info("UsuarioDaoNativeImpl.findById - sucesso");
+            return u;
+        } catch (Exception e) {
+            Logger.error("UsuarioDaoNativeImpl.findById - erro", e);
+            throw new UsuarioException("Usuario não encontrado: id=" + id, e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Usuario findWithBlobsById(Integer id) throws UsuarioException {
+        return findById(id);
+    }
+
+    @Override
+    public List<Usuario> findAll() {
+        Logger.info("UsuarioDaoNativeImpl.findAll - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_usuario, nome, senha, email FROM Usuario";
+            Query query = em.createNativeQuery(sql, Usuario.class);
+            List<Usuario> list = query.getResultList();
+            Logger.info("UsuarioDaoNativeImpl.findAll - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Usuario> findAll(int page, int size) {
+        Logger.info("UsuarioDaoNativeImpl.findAll(page) - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_usuario, nome, senha, email FROM Usuario LIMIT :limit OFFSET :offset";
+            Query query = em.createNativeQuery(sql, Usuario.class);
+            query.setParameter("limit", size);
+            query.setParameter("offset", page * size);
+            List<Usuario> list = query.getResultList();
+            Logger.info("UsuarioDaoNativeImpl.findAll(page) - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Usuario> findByNome(String nome) {
+        Logger.info("UsuarioDaoNativeImpl.findByNome - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_usuario, nome, senha, email FROM Usuario WHERE nome=:nome";
+            Query query = em.createNativeQuery(sql, Usuario.class);
+            query.setParameter("nome", nome);
+            List<Usuario> list = query.getResultList();
+            Logger.info("UsuarioDaoNativeImpl.findByNome - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Usuario> findBySenha(String senha) {
+        Logger.info("UsuarioDaoNativeImpl.findBySenha - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_usuario, nome, senha, email FROM Usuario WHERE senha=:senha";
+            Query query = em.createNativeQuery(sql, Usuario.class);
+            query.setParameter("senha", senha);
+            List<Usuario> list = query.getResultList();
+            Logger.info("UsuarioDaoNativeImpl.findBySenha - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Usuario> findByEmail(String email) {
+        Logger.info("UsuarioDaoNativeImpl.findByEmail - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_usuario, nome, senha, email FROM Usuario WHERE email=:email";
+            Query query = em.createNativeQuery(sql, Usuario.class);
+            query.setParameter("email", email);
+            List<Usuario> list = query.getResultList();
+            Logger.info("UsuarioDaoNativeImpl.findByEmail - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Usuario> findByFoto(byte[] foto) {
+        Logger.info("UsuarioDaoNativeImpl.findByFoto - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_usuario, nome, senha, foto, email FROM Usuario WHERE foto=:foto";
+            Query query = em.createNativeQuery(sql, Usuario.class);
+            query.setParameter("foto", foto);
+            List<Usuario> list = query.getResultList();
+            Logger.info("UsuarioDaoNativeImpl.findByFoto - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Usuario> search(Usuario filtro) {
+        return search(filtro, -1, -1);
+    }
+
+    @Override
+    public List<Usuario> search(Usuario filtro, int page, int size) {
+        Logger.info("UsuarioDaoNativeImpl.search - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            StringBuilder sb = new StringBuilder("SELECT id_usuario, nome, senha, email FROM Usuario WHERE 1=1");
+            Map<String, Object> params = new HashMap<>();
+            if (filtro.getNome() != null && !filtro.getNome().isEmpty()) {
+                sb.append(" AND nome=:nome");
+                params.put("nome", filtro.getNome());
+            }
+            if (filtro.getSenha() != null && !filtro.getSenha().isEmpty()) {
+                sb.append(" AND senha=:senha");
+                params.put("senha", filtro.getSenha());
+            }
+            if (filtro.getEmail() != null && !filtro.getEmail().isEmpty()) {
+                sb.append(" AND email=:email");
+                params.put("email", filtro.getEmail());
+            }
+            if (page >= 0 && size > 0) {
+                sb.append(" LIMIT :limit OFFSET :offset");
+            }
+            Query query = em.createNativeQuery(sb.toString(), Usuario.class);
+            for (Map.Entry<String, Object> e : params.entrySet()) {
+                query.setParameter(e.getKey(), e.getValue());
+            }
+            if (page >= 0 && size > 0) {
+                query.setParameter("limit", size);
+                query.setParameter("offset", page * size);
+            }
+            List<Usuario> list = query.getResultList();
+            Logger.info("UsuarioDaoNativeImpl.search - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+}

--- a/src/main/java/exception/CategoriaException.java
+++ b/src/main/java/exception/CategoriaException.java
@@ -1,0 +1,12 @@
+// path: src/main/java/exception/CategoriaException.java
+package exception;
+
+public class CategoriaException extends RuntimeException {
+    public CategoriaException(String message) {
+        super(message);
+    }
+
+    public CategoriaException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/exception/UsuarioException.java
+++ b/src/main/java/exception/UsuarioException.java
@@ -1,0 +1,20 @@
+// path: src/main/java/exception/UsuarioException.java
+package exception;
+
+public class UsuarioException extends RuntimeException {
+    public UsuarioException() {
+        super();
+    }
+
+    public UsuarioException(String message) {
+        super(message);
+    }
+
+    public UsuarioException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public UsuarioException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/infra/EntityManagerUtil.java
+++ b/src/main/java/infra/EntityManagerUtil.java
@@ -1,0 +1,17 @@
+// path: src/main/java/infra/EntityManagerUtil.java
+package infra;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.Persistence;
+
+public class EntityManagerUtil {
+    private static final EntityManagerFactory emf = Persistence.createEntityManagerFactory("rotinamaisPU");
+
+    private EntityManagerUtil() {
+    }
+
+    public static EntityManager getEntityManager() {
+        return emf.createEntityManager();
+    }
+}

--- a/src/main/java/infra/Logger.java
+++ b/src/main/java/infra/Logger.java
@@ -1,0 +1,15 @@
+// path: src/main/java/infra/Logger.java
+package infra;
+
+public class Logger {
+    public static void info(String msg) {
+        System.out.println("INFO: " + msg);
+    }
+
+    public static void error(String msg, Throwable t) {
+        System.err.println("ERROR: " + msg);
+        if (t != null) {
+            t.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/model/Categoria.java
+++ b/src/main/java/model/Categoria.java
@@ -1,0 +1,96 @@
+// path: src/main/java/model/Categoria.java
+package model;
+
+import java.time.LocalDate;
+import java.util.Objects;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "Categoria")
+public class Categoria {
+
+    @Id
+    @Column(name = "id_categoria")
+    private Integer idCategoria;
+
+    @Column(name = "nome")
+    private String nome;
+
+    @Column(name = "descricao")
+    private String descricao;
+
+    @Lob
+    @Column(name = "foto")
+    private byte[] foto;
+
+    @Column(name = "data_criacao")
+    private LocalDate dataCriacao;
+
+    public Integer getIdCategoria() {
+        return idCategoria;
+    }
+
+    public void setIdCategoria(Integer idCategoria) {
+        this.idCategoria = idCategoria;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public String getDescricao() {
+        return descricao;
+    }
+
+    public void setDescricao(String descricao) {
+        this.descricao = descricao;
+    }
+
+    public byte[] getFoto() {
+        return foto;
+    }
+
+    public void setFoto(byte[] foto) {
+        this.foto = foto;
+    }
+
+    public LocalDate getDataCriacao() {
+        return dataCriacao;
+    }
+
+    public void setDataCriacao(LocalDate dataCriacao) {
+        this.dataCriacao = dataCriacao;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Categoria)) return false;
+        Categoria that = (Categoria) o;
+        return Objects.equals(idCategoria, that.idCategoria);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idCategoria);
+    }
+
+    @Override
+    public String toString() {
+        return "Categoria{" +
+                "idCategoria=" + idCategoria +
+                ", nome='" + nome + '\'' +
+                ", descricao='" + descricao + '\'' +
+                ", dataCriacao=" + dataCriacao +
+                '}';
+    }
+}

--- a/src/main/java/model/Usuario.java
+++ b/src/main/java/model/Usuario.java
@@ -1,0 +1,94 @@
+// path: src/main/java/model/Usuario.java
+package model;
+
+import java.util.Objects;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "Usuario")
+public class Usuario {
+
+    @Id
+    @Column(name = "id_usuario")
+    private Integer idUsuario;
+
+    @Column(name = "nome")
+    private String nome;
+
+    @Column(name = "senha")
+    private String senha;
+
+    @Lob
+    @Column(name = "foto")
+    private byte[] foto;
+
+    @Column(name = "email")
+    private String email;
+
+    public Integer getIdUsuario() {
+        return idUsuario;
+    }
+
+    public void setIdUsuario(Integer idUsuario) {
+        this.idUsuario = idUsuario;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public String getSenha() {
+        return senha;
+    }
+
+    public void setSenha(String senha) {
+        this.senha = senha;
+    }
+
+    public byte[] getFoto() {
+        return foto;
+    }
+
+    public void setFoto(byte[] foto) {
+        this.foto = foto;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Usuario)) return false;
+        Usuario that = (Usuario) o;
+        return Objects.equals(idUsuario, that.idUsuario);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idUsuario);
+    }
+
+    @Override
+    public String toString() {
+        return "Usuario{" +
+                "idUsuario=" + idUsuario +
+                ", nome='" + nome + '\'' +
+                ", email='" + email + '\'' +
+                '}';
+    }
+}

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,14 @@
+<!-- path: src/main/resources/META-INF/persistence.xml -->
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence" version="3.0">
+    <persistence-unit name="rotinamaisPU">
+        <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+        <properties>
+            <property name="jakarta.persistence.jdbc.driver" value="org.postgresql.Driver"/>
+            <property name="jakarta.persistence.jdbc.url" value="jdbc:postgresql://localhost:5432/rotinamais"/>
+            <property name="jakarta.persistence.jdbc.user" value="postgres"/>
+            <property name="jakarta.persistence.jdbc.password" value="postgres"/>
+            <property name="hibernate.dialect" value="org.hibernate.dialect.PostgreSQLDialect"/>
+            <property name="hibernate.hbm2ddl.auto" value="none"/>
+        </properties>
+    </persistence-unit>
+</persistence>


### PR DESCRIPTION
## Summary
- implement Usuario entity with native DAO, controller, and custom exception
- switch string validations to `isEmpty` and update Categoria components accordingly

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf64cd49288325890fe7732235f5da