### PR TITLE
feat: add lancamento, exercicio and documento modules

### DIFF
--- a/src/main/java/controller/DocumentoController.java
+++ b/src/main/java/controller/DocumentoController.java
@@ -1,0 +1,164 @@
+// path: src/main/java/controller/DocumentoController.java
+package controller;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import dao.api.DocumentoDao;
+import exception.DocumentoException;
+import infra.Logger;
+import model.Documento;
+
+public class DocumentoController {
+
+    private final DocumentoDao dao;
+
+    public DocumentoController(DocumentoDao dao) {
+        this.dao = dao;
+    }
+
+    public void criar(Documento documento) {
+        Logger.info("DocumentoController.criar - inicio");
+        if (documento == null) {
+            throw new DocumentoException("Documento não pode ser nulo");
+        }
+        if (documento.getIdDocumento() == null) {
+            throw new DocumentoException("Id do Documento é obrigatório");
+        }
+        if (documento.getNome() == null || documento.getNome().isEmpty()) {
+            throw new DocumentoException("Nome do Documento é obrigatório");
+        }
+        dao.create(documento);
+        Logger.info("DocumentoController.criar - sucesso");
+    }
+
+    public Documento atualizar(Documento documento) {
+        Logger.info("DocumentoController.atualizar - inicio");
+        if (documento == null || documento.getIdDocumento() == null) {
+            throw new DocumentoException("Documento ou Id não pode ser nulo");
+        }
+        if (documento.getNome() == null || documento.getNome().isEmpty()) {
+            throw new DocumentoException("Nome do Documento é obrigatório");
+        }
+        Documento updated = dao.update(documento);
+        Logger.info("DocumentoController.atualizar - sucesso");
+        return updated;
+    }
+
+    public void remover(Integer id) {
+        Logger.info("DocumentoController.remover - inicio");
+        if (id == null) {
+            throw new DocumentoException("Id do Documento é obrigatório");
+        }
+        dao.deleteById(id);
+        Logger.info("DocumentoController.remover - sucesso");
+    }
+
+    public Documento buscarPorId(Integer id) {
+        Logger.info("DocumentoController.buscarPorId - inicio");
+        if (id == null) {
+            throw new DocumentoException("Id do Documento é obrigatório");
+        }
+        Documento d = dao.findById(id);
+        Logger.info("DocumentoController.buscarPorId - sucesso");
+        return d;
+    }
+
+    public Documento buscarComArquivosPorId(Integer id) {
+        Logger.info("DocumentoController.buscarComArquivosPorId - inicio");
+        if (id == null) {
+            throw new DocumentoException("Id do Documento é obrigatório");
+        }
+        Documento d = dao.findWithBlobsById(id);
+        Logger.info("DocumentoController.buscarComArquivosPorId - sucesso");
+        return d;
+    }
+
+    public List<Documento> listar() {
+        Logger.info("DocumentoController.listar - inicio");
+        List<Documento> list = dao.findAll();
+        Logger.info("DocumentoController.listar - sucesso");
+        return list;
+    }
+
+    public List<Documento> listar(int page, int size) {
+        Logger.info("DocumentoController.listar(page) - inicio");
+        List<Documento> list = dao.findAll(page, size);
+        Logger.info("DocumentoController.listar(page) - sucesso");
+        return list;
+    }
+
+    public List<Documento> buscarPorNome(String nome) {
+        Logger.info("DocumentoController.buscarPorNome - inicio");
+        if (nome == null || nome.isEmpty()) {
+            throw new DocumentoException("Nome não pode ser vazio");
+        }
+        List<Documento> list = dao.findByNome(nome);
+        Logger.info("DocumentoController.buscarPorNome - sucesso");
+        return list;
+    }
+
+    public List<Documento> buscarPorArquivo(byte[] arquivo) {
+        Logger.info("DocumentoController.buscarPorArquivo - inicio");
+        if (arquivo == null) {
+            throw new DocumentoException("Arquivo não pode ser nulo");
+        }
+        List<Documento> list = dao.findByArquivo(arquivo);
+        Logger.info("DocumentoController.buscarPorArquivo - sucesso");
+        return list;
+    }
+
+    public List<Documento> buscarPorFoto(byte[] foto) {
+        Logger.info("DocumentoController.buscarPorFoto - inicio");
+        if (foto == null) {
+            throw new DocumentoException("Foto não pode ser nula");
+        }
+        List<Documento> list = dao.findByFoto(foto);
+        Logger.info("DocumentoController.buscarPorFoto - sucesso");
+        return list;
+    }
+
+    public List<Documento> buscarPorVideo(byte[] video) {
+        Logger.info("DocumentoController.buscarPorVideo - inicio");
+        if (video == null) {
+            throw new DocumentoException("Video não pode ser nulo");
+        }
+        List<Documento> list = dao.findByVideo(video);
+        Logger.info("DocumentoController.buscarPorVideo - sucesso");
+        return list;
+    }
+
+    public List<Documento> buscarPorData(LocalDate data) {
+        Logger.info("DocumentoController.buscarPorData - inicio");
+        if (data == null) {
+            throw new DocumentoException("Data não pode ser nula");
+        }
+        List<Documento> list = dao.findByData(data);
+        Logger.info("DocumentoController.buscarPorData - sucesso");
+        return list;
+    }
+
+    public List<Documento> buscarPorIdUsuario(Integer idUsuario) {
+        Logger.info("DocumentoController.buscarPorIdUsuario - inicio");
+        if (idUsuario == null) {
+            throw new DocumentoException("Id do usuário não pode ser nulo");
+        }
+        List<Documento> list = dao.findByIdUsuario(idUsuario);
+        Logger.info("DocumentoController.buscarPorIdUsuario - sucesso");
+        return list;
+    }
+
+    public List<Documento> pesquisar(Documento filtro) {
+        Logger.info("DocumentoController.pesquisar - inicio");
+        List<Documento> list = dao.search(filtro);
+        Logger.info("DocumentoController.pesquisar - sucesso");
+        return list;
+    }
+
+    public List<Documento> pesquisar(Documento filtro, int page, int size) {
+        Logger.info("DocumentoController.pesquisar(page) - inicio");
+        List<Documento> list = dao.search(filtro, page, size);
+        Logger.info("DocumentoController.pesquisar(page) - sucesso");
+        return list;
+    }
+}

--- a/src/main/java/controller/ExercicioController.java
+++ b/src/main/java/controller/ExercicioController.java
@@ -1,0 +1,133 @@
+// path: src/main/java/controller/ExercicioController.java
+package controller;
+
+import java.util.List;
+
+import dao.api.ExercicioDao;
+import exception.ExercicioException;
+import infra.Logger;
+import model.Exercicio;
+
+public class ExercicioController {
+
+    private final ExercicioDao dao;
+
+    public ExercicioController(ExercicioDao dao) {
+        this.dao = dao;
+    }
+
+    public void criar(Exercicio exercicio) {
+        Logger.info("ExercicioController.criar - inicio");
+        if (exercicio == null) {
+            throw new ExercicioException("Exercicio não pode ser nulo");
+        }
+        if (exercicio.getIdExercicio() == null) {
+            throw new ExercicioException("Id do Exercicio é obrigatório");
+        }
+        if (exercicio.getNome() == null || exercicio.getNome().isEmpty()) {
+            throw new ExercicioException("Nome do Exercicio é obrigatório");
+        }
+        dao.create(exercicio);
+        Logger.info("ExercicioController.criar - sucesso");
+    }
+
+    public Exercicio atualizar(Exercicio exercicio) {
+        Logger.info("ExercicioController.atualizar - inicio");
+        if (exercicio == null || exercicio.getIdExercicio() == null) {
+            throw new ExercicioException("Exercicio ou Id não pode ser nulo");
+        }
+        if (exercicio.getNome() == null || exercicio.getNome().isEmpty()) {
+            throw new ExercicioException("Nome do Exercicio é obrigatório");
+        }
+        Exercicio updated = dao.update(exercicio);
+        Logger.info("ExercicioController.atualizar - sucesso");
+        return updated;
+    }
+
+    public void remover(Integer id) {
+        Logger.info("ExercicioController.remover - inicio");
+        if (id == null) {
+            throw new ExercicioException("Id do Exercicio é obrigatório");
+        }
+        dao.deleteById(id);
+        Logger.info("ExercicioController.remover - sucesso");
+    }
+
+    public Exercicio buscarPorId(Integer id) {
+        Logger.info("ExercicioController.buscarPorId - inicio");
+        if (id == null) {
+            throw new ExercicioException("Id do Exercicio é obrigatório");
+        }
+        Exercicio e = dao.findById(id);
+        Logger.info("ExercicioController.buscarPorId - sucesso");
+        return e;
+    }
+
+    public List<Exercicio> listar() {
+        Logger.info("ExercicioController.listar - inicio");
+        List<Exercicio> list = dao.findAll();
+        Logger.info("ExercicioController.listar - sucesso");
+        return list;
+    }
+
+    public List<Exercicio> listar(int page, int size) {
+        Logger.info("ExercicioController.listar(page) - inicio");
+        List<Exercicio> list = dao.findAll(page, size);
+        Logger.info("ExercicioController.listar(page) - sucesso");
+        return list;
+    }
+
+    public List<Exercicio> buscarPorNome(String nome) {
+        Logger.info("ExercicioController.buscarPorNome - inicio");
+        if (nome == null || nome.isEmpty()) {
+            throw new ExercicioException("Nome não pode ser vazio");
+        }
+        List<Exercicio> list = dao.findByNome(nome);
+        Logger.info("ExercicioController.buscarPorNome - sucesso");
+        return list;
+    }
+
+    public List<Exercicio> buscarPorCargaLeve(Integer cargaLeve) {
+        Logger.info("ExercicioController.buscarPorCargaLeve - inicio");
+        if (cargaLeve == null) {
+            throw new ExercicioException("Carga leve não pode ser nula");
+        }
+        List<Exercicio> list = dao.findByCargaLeve(cargaLeve);
+        Logger.info("ExercicioController.buscarPorCargaLeve - sucesso");
+        return list;
+    }
+
+    public List<Exercicio> buscarPorCargaMedia(Integer cargaMedia) {
+        Logger.info("ExercicioController.buscarPorCargaMedia - inicio");
+        if (cargaMedia == null) {
+            throw new ExercicioException("Carga média não pode ser nula");
+        }
+        List<Exercicio> list = dao.findByCargaMedia(cargaMedia);
+        Logger.info("ExercicioController.buscarPorCargaMedia - sucesso");
+        return list;
+    }
+
+    public List<Exercicio> buscarPorCargaMaxima(Integer cargaMaxima) {
+        Logger.info("ExercicioController.buscarPorCargaMaxima - inicio");
+        if (cargaMaxima == null) {
+            throw new ExercicioException("Carga máxima não pode ser nula");
+        }
+        List<Exercicio> list = dao.findByCargaMaxima(cargaMaxima);
+        Logger.info("ExercicioController.buscarPorCargaMaxima - sucesso");
+        return list;
+    }
+
+    public List<Exercicio> pesquisar(Exercicio filtro) {
+        Logger.info("ExercicioController.pesquisar - inicio");
+        List<Exercicio> list = dao.search(filtro);
+        Logger.info("ExercicioController.pesquisar - sucesso");
+        return list;
+    }
+
+    public List<Exercicio> pesquisar(Exercicio filtro, int page, int size) {
+        Logger.info("ExercicioController.pesquisar(page) - inicio");
+        List<Exercicio> list = dao.search(filtro, page, size);
+        Logger.info("ExercicioController.pesquisar(page) - sucesso");
+        return list;
+    }
+}

--- a/src/main/java/controller/LancamentoController.java
+++ b/src/main/java/controller/LancamentoController.java
@@ -1,0 +1,158 @@
+// path: src/main/java/controller/LancamentoController.java
+package controller;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import dao.api.LancamentoDao;
+import exception.LancamentoException;
+import infra.Logger;
+import model.Lancamento;
+
+public class LancamentoController {
+
+    private final LancamentoDao dao;
+
+    public LancamentoController(LancamentoDao dao) {
+        this.dao = dao;
+    }
+
+    public void criar(Lancamento lancamento) {
+        Logger.info("LancamentoController.criar - inicio");
+        if (lancamento == null) {
+            throw new LancamentoException("Lancamento não pode ser nulo");
+        }
+        if (lancamento.getIdLancamento() == null) {
+            throw new LancamentoException("Id do Lancamento é obrigatório");
+        }
+        if (lancamento.getValor() == null) {
+            throw new LancamentoException("Valor do Lancamento é obrigatório");
+        }
+        if (lancamento.getIdEvento() == null) {
+            throw new LancamentoException("Id do Evento do Lancamento é obrigatório");
+        }
+        dao.create(lancamento);
+        Logger.info("LancamentoController.criar - sucesso");
+    }
+
+    public Lancamento atualizar(Lancamento lancamento) {
+        Logger.info("LancamentoController.atualizar - inicio");
+        if (lancamento == null || lancamento.getIdLancamento() == null) {
+            throw new LancamentoException("Lancamento ou Id não pode ser nulo");
+        }
+        if (lancamento.getValor() == null) {
+            throw new LancamentoException("Valor do Lancamento é obrigatório");
+        }
+        Lancamento updated = dao.update(lancamento);
+        Logger.info("LancamentoController.atualizar - sucesso");
+        return updated;
+    }
+
+    public void remover(Integer id) {
+        Logger.info("LancamentoController.remover - inicio");
+        if (id == null) {
+            throw new LancamentoException("Id do Lancamento é obrigatório");
+        }
+        dao.deleteById(id);
+        Logger.info("LancamentoController.remover - sucesso");
+    }
+
+    public Lancamento buscarPorId(Integer id) {
+        Logger.info("LancamentoController.buscarPorId - inicio");
+        if (id == null) {
+            throw new LancamentoException("Id do Lancamento é obrigatório");
+        }
+        Lancamento l = dao.findById(id);
+        Logger.info("LancamentoController.buscarPorId - sucesso");
+        return l;
+    }
+
+    public List<Lancamento> listar() {
+        Logger.info("LancamentoController.listar - inicio");
+        List<Lancamento> list = dao.findAll();
+        Logger.info("LancamentoController.listar - sucesso");
+        return list;
+    }
+
+    public List<Lancamento> listar(int page, int size) {
+        Logger.info("LancamentoController.listar(page) - inicio");
+        List<Lancamento> list = dao.findAll(page, size);
+        Logger.info("LancamentoController.listar(page) - sucesso");
+        return list;
+    }
+
+    public List<Lancamento> buscarPorValor(BigDecimal valor) {
+        Logger.info("LancamentoController.buscarPorValor - inicio");
+        if (valor == null) {
+            throw new LancamentoException("Valor não pode ser nulo");
+        }
+        List<Lancamento> list = dao.findByValor(valor);
+        Logger.info("LancamentoController.buscarPorValor - sucesso");
+        return list;
+    }
+
+    public List<Lancamento> buscarPorFixo(Boolean fixo) {
+        Logger.info("LancamentoController.buscarPorFixo - inicio");
+        if (fixo == null) {
+            throw new LancamentoException("Fixo não pode ser nulo");
+        }
+        List<Lancamento> list = dao.findByFixo(fixo);
+        Logger.info("LancamentoController.buscarPorFixo - sucesso");
+        return list;
+    }
+
+    public List<Lancamento> buscarPorDataPagamento(LocalDate dataPagamento) {
+        Logger.info("LancamentoController.buscarPorDataPagamento - inicio");
+        if (dataPagamento == null) {
+            throw new LancamentoException("Data de pagamento não pode ser nula");
+        }
+        List<Lancamento> list = dao.findByDataPagamento(dataPagamento);
+        Logger.info("LancamentoController.buscarPorDataPagamento - sucesso");
+        return list;
+    }
+
+    public List<Lancamento> buscarPorStatus(Integer status) {
+        Logger.info("LancamentoController.buscarPorStatus - inicio");
+        if (status == null) {
+            throw new LancamentoException("Status não pode ser nulo");
+        }
+        List<Lancamento> list = dao.findByStatus(status);
+        Logger.info("LancamentoController.buscarPorStatus - sucesso");
+        return list;
+    }
+
+    public List<Lancamento> buscarPorIdMovimentacao(Integer idMovimentacao) {
+        Logger.info("LancamentoController.buscarPorIdMovimentacao - inicio");
+        if (idMovimentacao == null) {
+            throw new LancamentoException("Id da movimentação não pode ser nulo");
+        }
+        List<Lancamento> list = dao.findByIdMovimentacao(idMovimentacao);
+        Logger.info("LancamentoController.buscarPorIdMovimentacao - sucesso");
+        return list;
+    }
+
+    public List<Lancamento> buscarPorIdEvento(Integer idEvento) {
+        Logger.info("LancamentoController.buscarPorIdEvento - inicio");
+        if (idEvento == null) {
+            throw new LancamentoException("Id do evento não pode ser nulo");
+        }
+        List<Lancamento> list = dao.findByIdEvento(idEvento);
+        Logger.info("LancamentoController.buscarPorIdEvento - sucesso");
+        return list;
+    }
+
+    public List<Lancamento> pesquisar(Lancamento filtro) {
+        Logger.info("LancamentoController.pesquisar - inicio");
+        List<Lancamento> list = dao.search(filtro);
+        Logger.info("LancamentoController.pesquisar - sucesso");
+        return list;
+    }
+
+    public List<Lancamento> pesquisar(Lancamento filtro, int page, int size) {
+        Logger.info("LancamentoController.pesquisar(page) - inicio");
+        List<Lancamento> list = dao.search(filtro, page, size);
+        Logger.info("LancamentoController.pesquisar(page) - sucesso");
+        return list;
+    }
+}

--- a/src/main/java/dao/api/DocumentoDao.java
+++ b/src/main/java/dao/api/DocumentoDao.java
@@ -1,0 +1,41 @@
+// path: src/main/java/dao/api/DocumentoDao.java
+package dao.api;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import exception.DocumentoException;
+import model.Documento;
+
+public interface DocumentoDao {
+
+    void create(Documento documento) throws DocumentoException;
+
+    Documento update(Documento documento) throws DocumentoException;
+
+    void deleteById(Integer id) throws DocumentoException;
+
+    Documento findById(Integer id) throws DocumentoException;
+
+    Documento findWithBlobsById(Integer id) throws DocumentoException;
+
+    List<Documento> findAll();
+
+    List<Documento> findAll(int page, int size);
+
+    List<Documento> findByNome(String nome);
+
+    List<Documento> findByArquivo(byte[] arquivo);
+
+    List<Documento> findByFoto(byte[] foto);
+
+    List<Documento> findByVideo(byte[] video);
+
+    List<Documento> findByData(LocalDate data);
+
+    List<Documento> findByIdUsuario(Integer idUsuario);
+
+    List<Documento> search(Documento filtro);
+
+    List<Documento> search(Documento filtro, int page, int size);
+}

--- a/src/main/java/dao/api/ExercicioDao.java
+++ b/src/main/java/dao/api/ExercicioDao.java
@@ -1,0 +1,34 @@
+// path: src/main/java/dao/api/ExercicioDao.java
+package dao.api;
+
+import java.util.List;
+
+import exception.ExercicioException;
+import model.Exercicio;
+
+public interface ExercicioDao {
+
+    void create(Exercicio exercicio) throws ExercicioException;
+
+    Exercicio update(Exercicio exercicio) throws ExercicioException;
+
+    void deleteById(Integer id) throws ExercicioException;
+
+    Exercicio findById(Integer id) throws ExercicioException;
+
+    List<Exercicio> findAll();
+
+    List<Exercicio> findAll(int page, int size);
+
+    List<Exercicio> findByNome(String nome);
+
+    List<Exercicio> findByCargaLeve(Integer cargaLeve);
+
+    List<Exercicio> findByCargaMedia(Integer cargaMedia);
+
+    List<Exercicio> findByCargaMaxima(Integer cargaMaxima);
+
+    List<Exercicio> search(Exercicio filtro);
+
+    List<Exercicio> search(Exercicio filtro, int page, int size);
+}

--- a/src/main/java/dao/api/LancamentoDao.java
+++ b/src/main/java/dao/api/LancamentoDao.java
@@ -1,0 +1,40 @@
+// path: src/main/java/dao/api/LancamentoDao.java
+package dao.api;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import exception.LancamentoException;
+import model.Lancamento;
+
+public interface LancamentoDao {
+
+    void create(Lancamento lancamento) throws LancamentoException;
+
+    Lancamento update(Lancamento lancamento) throws LancamentoException;
+
+    void deleteById(Integer id) throws LancamentoException;
+
+    Lancamento findById(Integer id) throws LancamentoException;
+
+    List<Lancamento> findAll();
+
+    List<Lancamento> findAll(int page, int size);
+
+    List<Lancamento> findByValor(BigDecimal valor);
+
+    List<Lancamento> findByFixo(Boolean fixo);
+
+    List<Lancamento> findByDataPagamento(LocalDate dataPagamento);
+
+    List<Lancamento> findByStatus(Integer status);
+
+    List<Lancamento> findByIdMovimentacao(Integer idMovimentacao);
+
+    List<Lancamento> findByIdEvento(Integer idEvento);
+
+    List<Lancamento> search(Lancamento filtro);
+
+    List<Lancamento> search(Lancamento filtro, int page, int size);
+}

--- a/src/main/java/dao/impl/DocumentoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/DocumentoDaoNativeImpl.java
@@ -1,0 +1,329 @@
+// path: src/main/java/dao/impl/DocumentoDaoNativeImpl.java
+package dao.impl;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import dao.api.DocumentoDao;
+import exception.DocumentoException;
+import infra.EntityManagerUtil;
+import infra.Logger;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import model.Documento;
+
+public class DocumentoDaoNativeImpl implements DocumentoDao {
+
+    @Override
+    public void create(Documento documento) throws DocumentoException {
+        Logger.info("DocumentoDaoNativeImpl.create - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "INSERT INTO Documento (id_documento, nome, arquivo, foto, video, data, id_usuario) " +
+                    "VALUES (:id, :nome, :arquivo, :foto, :video, :data, :idUsuario)";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("id", documento.getIdDocumento());
+            query.setParameter("nome", documento.getNome());
+            query.setParameter("arquivo", documento.getArquivo());
+            query.setParameter("foto", documento.getFoto());
+            query.setParameter("video", documento.getVideo());
+            query.setParameter("data", documento.getData());
+            query.setParameter("idUsuario", documento.getIdUsuario());
+            query.executeUpdate();
+            em.getTransaction().commit();
+            Logger.info("DocumentoDaoNativeImpl.create - sucesso");
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("DocumentoDaoNativeImpl.create - erro", e);
+            throw new DocumentoException("Erro ao criar Documento", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Documento update(Documento documento) throws DocumentoException {
+        Logger.info("DocumentoDaoNativeImpl.update - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "UPDATE Documento SET nome=:nome, arquivo=:arquivo, foto=:foto, video=:video, data=:data, id_usuario=:idUsuario WHERE id_documento=:id";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("nome", documento.getNome());
+            query.setParameter("arquivo", documento.getArquivo());
+            query.setParameter("foto", documento.getFoto());
+            query.setParameter("video", documento.getVideo());
+            query.setParameter("data", documento.getData());
+            query.setParameter("idUsuario", documento.getIdUsuario());
+            query.setParameter("id", documento.getIdDocumento());
+            int updated = query.executeUpdate();
+            if (updated == 0) {
+                throw new DocumentoException("Documento não encontrado: id=" + documento.getIdDocumento());
+            }
+            em.getTransaction().commit();
+            Logger.info("DocumentoDaoNativeImpl.update - sucesso");
+            return findById(documento.getIdDocumento());
+        } catch (DocumentoException e) {
+            em.getTransaction().rollback();
+            Logger.error("DocumentoDaoNativeImpl.update - erro", e);
+            throw e;
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("DocumentoDaoNativeImpl.update - erro", e);
+            throw new DocumentoException("Erro ao atualizar Documento", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public void deleteById(Integer id) throws DocumentoException {
+        Logger.info("DocumentoDaoNativeImpl.deleteById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "DELETE FROM Documento WHERE id_documento=:id";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("id", id);
+            int deleted = query.executeUpdate();
+            if (deleted == 0) {
+                throw new DocumentoException("Documento não encontrado: id=" + id);
+            }
+            em.getTransaction().commit();
+            Logger.info("DocumentoDaoNativeImpl.deleteById - sucesso");
+        } catch (DocumentoException e) {
+            em.getTransaction().rollback();
+            Logger.error("DocumentoDaoNativeImpl.deleteById - erro", e);
+            throw e;
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("DocumentoDaoNativeImpl.deleteById - erro", e);
+            throw new DocumentoException("Erro ao deletar Documento", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Documento findById(Integer id) throws DocumentoException {
+        Logger.info("DocumentoDaoNativeImpl.findById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_documento, nome, data, id_usuario FROM Documento WHERE id_documento=:id";
+            Query query = em.createNativeQuery(sql, Documento.class);
+            query.setParameter("id", id);
+            Documento d = (Documento) query.getSingleResult();
+            Logger.info("DocumentoDaoNativeImpl.findById - sucesso");
+            return d;
+        } catch (Exception e) {
+            Logger.error("DocumentoDaoNativeImpl.findById - erro", e);
+            throw new DocumentoException("Documento não encontrado: id=" + id, e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Documento findWithBlobsById(Integer id) throws DocumentoException {
+        Logger.info("DocumentoDaoNativeImpl.findWithBlobsById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_documento, nome, arquivo, foto, video, data, id_usuario FROM Documento WHERE id_documento=:id";
+            Query query = em.createNativeQuery(sql, Documento.class);
+            query.setParameter("id", id);
+            Documento d = (Documento) query.getSingleResult();
+            Logger.info("DocumentoDaoNativeImpl.findWithBlobsById - sucesso");
+            return d;
+        } catch (Exception e) {
+            Logger.error("DocumentoDaoNativeImpl.findWithBlobsById - erro", e);
+            throw new DocumentoException("Documento não encontrado: id=" + id, e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Documento> findAll() {
+        Logger.info("DocumentoDaoNativeImpl.findAll - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_documento, nome, data, id_usuario FROM Documento";
+            Query query = em.createNativeQuery(sql, Documento.class);
+            List<Documento> list = query.getResultList();
+            Logger.info("DocumentoDaoNativeImpl.findAll - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Documento> findAll(int page, int size) {
+        Logger.info("DocumentoDaoNativeImpl.findAll(page) - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_documento, nome, data, id_usuario FROM Documento LIMIT :limit OFFSET :offset";
+            Query query = em.createNativeQuery(sql, Documento.class);
+            query.setParameter("limit", size);
+            query.setParameter("offset", page * size);
+            List<Documento> list = query.getResultList();
+            Logger.info("DocumentoDaoNativeImpl.findAll(page) - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Documento> findByNome(String nome) {
+        Logger.info("DocumentoDaoNativeImpl.findByNome - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_documento, nome, data, id_usuario FROM Documento WHERE nome=:nome";
+            Query query = em.createNativeQuery(sql, Documento.class);
+            query.setParameter("nome", nome);
+            List<Documento> list = query.getResultList();
+            Logger.info("DocumentoDaoNativeImpl.findByNome - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Documento> findByArquivo(byte[] arquivo) {
+        Logger.info("DocumentoDaoNativeImpl.findByArquivo - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_documento, nome, arquivo, foto, video, data, id_usuario FROM Documento WHERE arquivo=:arquivo";
+            Query query = em.createNativeQuery(sql, Documento.class);
+            query.setParameter("arquivo", arquivo);
+            List<Documento> list = query.getResultList();
+            Logger.info("DocumentoDaoNativeImpl.findByArquivo - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Documento> findByFoto(byte[] foto) {
+        Logger.info("DocumentoDaoNativeImpl.findByFoto - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_documento, nome, arquivo, foto, video, data, id_usuario FROM Documento WHERE foto=:foto";
+            Query query = em.createNativeQuery(sql, Documento.class);
+            query.setParameter("foto", foto);
+            List<Documento> list = query.getResultList();
+            Logger.info("DocumentoDaoNativeImpl.findByFoto - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Documento> findByVideo(byte[] video) {
+        Logger.info("DocumentoDaoNativeImpl.findByVideo - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_documento, nome, arquivo, foto, video, data, id_usuario FROM Documento WHERE video=:video";
+            Query query = em.createNativeQuery(sql, Documento.class);
+            query.setParameter("video", video);
+            List<Documento> list = query.getResultList();
+            Logger.info("DocumentoDaoNativeImpl.findByVideo - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Documento> findByData(java.time.LocalDate data) {
+        Logger.info("DocumentoDaoNativeImpl.findByData - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_documento, nome, data, id_usuario FROM Documento WHERE data=:data";
+            Query query = em.createNativeQuery(sql, Documento.class);
+            query.setParameter("data", data);
+            List<Documento> list = query.getResultList();
+            Logger.info("DocumentoDaoNativeImpl.findByData - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Documento> findByIdUsuario(Integer idUsuario) {
+        Logger.info("DocumentoDaoNativeImpl.findByIdUsuario - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_documento, nome, data, id_usuario FROM Documento WHERE id_usuario=:idUsuario";
+            Query query = em.createNativeQuery(sql, Documento.class);
+            query.setParameter("idUsuario", idUsuario);
+            List<Documento> list = query.getResultList();
+            Logger.info("DocumentoDaoNativeImpl.findByIdUsuario - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Documento> search(Documento filtro) {
+        return search(filtro, -1, -1);
+    }
+
+    @Override
+    public List<Documento> search(Documento filtro, int page, int size) {
+        Logger.info("DocumentoDaoNativeImpl.search - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            StringBuilder sb = new StringBuilder("SELECT id_documento, nome, data, id_usuario FROM Documento WHERE 1=1");
+            Map<String, Object> params = new HashMap<>();
+            if (filtro.getNome() != null && !filtro.getNome().isEmpty()) {
+                sb.append(" AND nome=:nome");
+                params.put("nome", filtro.getNome());
+            }
+            if (filtro.getArquivo() != null) {
+                sb.append(" AND arquivo=:arquivo");
+                params.put("arquivo", filtro.getArquivo());
+            }
+            if (filtro.getFoto() != null) {
+                sb.append(" AND foto=:foto");
+                params.put("foto", filtro.getFoto());
+            }
+            if (filtro.getVideo() != null) {
+                sb.append(" AND video=:video");
+                params.put("video", filtro.getVideo());
+            }
+            if (filtro.getData() != null) {
+                sb.append(" AND data=:data");
+                params.put("data", filtro.getData());
+            }
+            if (filtro.getIdUsuario() != null) {
+                sb.append(" AND id_usuario=:idUsuario");
+                params.put("idUsuario", filtro.getIdUsuario());
+            }
+            if (page >= 0 && size > 0) {
+                sb.append(" LIMIT :limit OFFSET :offset");
+            }
+            Query query = em.createNativeQuery(sb.toString(), Documento.class);
+            for (Map.Entry<String, Object> e : params.entrySet()) {
+                query.setParameter(e.getKey(), e.getValue());
+            }
+            if (page >= 0 && size > 0) {
+                query.setParameter("limit", size);
+                query.setParameter("offset", page * size);
+            }
+            List<Documento> list = query.getResultList();
+            Logger.info("DocumentoDaoNativeImpl.search - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+}

--- a/src/main/java/dao/impl/ExercicioDaoNativeImpl.java
+++ b/src/main/java/dao/impl/ExercicioDaoNativeImpl.java
@@ -1,0 +1,266 @@
+// path: src/main/java/dao/impl/ExercicioDaoNativeImpl.java
+package dao.impl;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import dao.api.ExercicioDao;
+import exception.ExercicioException;
+import infra.EntityManagerUtil;
+import infra.Logger;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import model.Exercicio;
+
+public class ExercicioDaoNativeImpl implements ExercicioDao {
+
+    @Override
+    public void create(Exercicio exercicio) throws ExercicioException {
+        Logger.info("ExercicioDaoNativeImpl.create - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "INSERT INTO Exercicio (id_exercicio, nome, carga_leve, carga_media, carga_maxima) " +
+                    "VALUES (:id, :nome, :cargaLeve, :cargaMedia, :cargaMaxima)";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("id", exercicio.getIdExercicio());
+            query.setParameter("nome", exercicio.getNome());
+            query.setParameter("cargaLeve", exercicio.getCargaLeve());
+            query.setParameter("cargaMedia", exercicio.getCargaMedia());
+            query.setParameter("cargaMaxima", exercicio.getCargaMaxima());
+            query.executeUpdate();
+            em.getTransaction().commit();
+            Logger.info("ExercicioDaoNativeImpl.create - sucesso");
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("ExercicioDaoNativeImpl.create - erro", e);
+            throw new ExercicioException("Erro ao criar Exercicio", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Exercicio update(Exercicio exercicio) throws ExercicioException {
+        Logger.info("ExercicioDaoNativeImpl.update - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "UPDATE Exercicio SET nome=:nome, carga_leve=:cargaLeve, carga_media=:cargaMedia, carga_maxima=:cargaMaxima WHERE id_exercicio=:id";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("nome", exercicio.getNome());
+            query.setParameter("cargaLeve", exercicio.getCargaLeve());
+            query.setParameter("cargaMedia", exercicio.getCargaMedia());
+            query.setParameter("cargaMaxima", exercicio.getCargaMaxima());
+            query.setParameter("id", exercicio.getIdExercicio());
+            int updated = query.executeUpdate();
+            if (updated == 0) {
+                throw new ExercicioException("Exercicio não encontrado: id=" + exercicio.getIdExercicio());
+            }
+            em.getTransaction().commit();
+            Logger.info("ExercicioDaoNativeImpl.update - sucesso");
+            return findById(exercicio.getIdExercicio());
+        } catch (ExercicioException e) {
+            em.getTransaction().rollback();
+            Logger.error("ExercicioDaoNativeImpl.update - erro", e);
+            throw e;
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("ExercicioDaoNativeImpl.update - erro", e);
+            throw new ExercicioException("Erro ao atualizar Exercicio", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public void deleteById(Integer id) throws ExercicioException {
+        Logger.info("ExercicioDaoNativeImpl.deleteById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "DELETE FROM Exercicio WHERE id_exercicio=:id";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("id", id);
+            int deleted = query.executeUpdate();
+            if (deleted == 0) {
+                throw new ExercicioException("Exercicio não encontrado: id=" + id);
+            }
+            em.getTransaction().commit();
+            Logger.info("ExercicioDaoNativeImpl.deleteById - sucesso");
+        } catch (ExercicioException e) {
+            em.getTransaction().rollback();
+            Logger.error("ExercicioDaoNativeImpl.deleteById - erro", e);
+            throw e;
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("ExercicioDaoNativeImpl.deleteById - erro", e);
+            throw new ExercicioException("Erro ao deletar Exercicio", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Exercicio findById(Integer id) throws ExercicioException {
+        Logger.info("ExercicioDaoNativeImpl.findById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_exercicio, nome, carga_leve, carga_media, carga_maxima FROM Exercicio WHERE id_exercicio=:id";
+            Query query = em.createNativeQuery(sql, Exercicio.class);
+            query.setParameter("id", id);
+            Exercicio e = (Exercicio) query.getSingleResult();
+            Logger.info("ExercicioDaoNativeImpl.findById - sucesso");
+            return e;
+        } catch (Exception e) {
+            Logger.error("ExercicioDaoNativeImpl.findById - erro", e);
+            throw new ExercicioException("Exercicio não encontrado: id=" + id, e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Exercicio> findAll() {
+        Logger.info("ExercicioDaoNativeImpl.findAll - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_exercicio, nome, carga_leve, carga_media, carga_maxima FROM Exercicio";
+            Query query = em.createNativeQuery(sql, Exercicio.class);
+            List<Exercicio> list = query.getResultList();
+            Logger.info("ExercicioDaoNativeImpl.findAll - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Exercicio> findAll(int page, int size) {
+        Logger.info("ExercicioDaoNativeImpl.findAll(page) - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_exercicio, nome, carga_leve, carga_media, carga_maxima FROM Exercicio LIMIT :limit OFFSET :offset";
+            Query query = em.createNativeQuery(sql, Exercicio.class);
+            query.setParameter("limit", size);
+            query.setParameter("offset", page * size);
+            List<Exercicio> list = query.getResultList();
+            Logger.info("ExercicioDaoNativeImpl.findAll(page) - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Exercicio> findByNome(String nome) {
+        Logger.info("ExercicioDaoNativeImpl.findByNome - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_exercicio, nome, carga_leve, carga_media, carga_maxima FROM Exercicio WHERE nome=:nome";
+            Query query = em.createNativeQuery(sql, Exercicio.class);
+            query.setParameter("nome", nome);
+            List<Exercicio> list = query.getResultList();
+            Logger.info("ExercicioDaoNativeImpl.findByNome - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Exercicio> findByCargaLeve(Integer cargaLeve) {
+        Logger.info("ExercicioDaoNativeImpl.findByCargaLeve - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_exercicio, nome, carga_leve, carga_media, carga_maxima FROM Exercicio WHERE carga_leve=:cargaLeve";
+            Query query = em.createNativeQuery(sql, Exercicio.class);
+            query.setParameter("cargaLeve", cargaLeve);
+            List<Exercicio> list = query.getResultList();
+            Logger.info("ExercicioDaoNativeImpl.findByCargaLeve - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Exercicio> findByCargaMedia(Integer cargaMedia) {
+        Logger.info("ExercicioDaoNativeImpl.findByCargaMedia - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_exercicio, nome, carga_leve, carga_media, carga_maxima FROM Exercicio WHERE carga_media=:cargaMedia";
+            Query query = em.createNativeQuery(sql, Exercicio.class);
+            query.setParameter("cargaMedia", cargaMedia);
+            List<Exercicio> list = query.getResultList();
+            Logger.info("ExercicioDaoNativeImpl.findByCargaMedia - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Exercicio> findByCargaMaxima(Integer cargaMaxima) {
+        Logger.info("ExercicioDaoNativeImpl.findByCargaMaxima - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_exercicio, nome, carga_leve, carga_media, carga_maxima FROM Exercicio WHERE carga_maxima=:cargaMaxima";
+            Query query = em.createNativeQuery(sql, Exercicio.class);
+            query.setParameter("cargaMaxima", cargaMaxima);
+            List<Exercicio> list = query.getResultList();
+            Logger.info("ExercicioDaoNativeImpl.findByCargaMaxima - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Exercicio> search(Exercicio filtro) {
+        return search(filtro, -1, -1);
+    }
+
+    @Override
+    public List<Exercicio> search(Exercicio filtro, int page, int size) {
+        Logger.info("ExercicioDaoNativeImpl.search - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            StringBuilder sb = new StringBuilder("SELECT id_exercicio, nome, carga_leve, carga_media, carga_maxima FROM Exercicio WHERE 1=1");
+            Map<String, Object> params = new HashMap<>();
+            if (filtro.getNome() != null && !filtro.getNome().isEmpty()) {
+                sb.append(" AND nome=:nome");
+                params.put("nome", filtro.getNome());
+            }
+            if (filtro.getCargaLeve() != null) {
+                sb.append(" AND carga_leve=:cargaLeve");
+                params.put("cargaLeve", filtro.getCargaLeve());
+            }
+            if (filtro.getCargaMedia() != null) {
+                sb.append(" AND carga_media=:cargaMedia");
+                params.put("cargaMedia", filtro.getCargaMedia());
+            }
+            if (filtro.getCargaMaxima() != null) {
+                sb.append(" AND carga_maxima=:cargaMaxima");
+                params.put("cargaMaxima", filtro.getCargaMaxima());
+            }
+            if (page >= 0 && size > 0) {
+                sb.append(" LIMIT :limit OFFSET :offset");
+            }
+            Query query = em.createNativeQuery(sb.toString(), Exercicio.class);
+            for (Map.Entry<String, Object> e : params.entrySet()) {
+                query.setParameter(e.getKey(), e.getValue());
+            }
+            if (page >= 0 && size > 0) {
+                query.setParameter("limit", size);
+                query.setParameter("offset", page * size);
+            }
+            List<Exercicio> list = query.getResultList();
+            Logger.info("ExercicioDaoNativeImpl.search - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+}

--- a/src/main/java/dao/impl/LancamentoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/LancamentoDaoNativeImpl.java
@@ -1,0 +1,311 @@
+// path: src/main/java/dao/impl/LancamentoDaoNativeImpl.java
+package dao.impl;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import dao.api.LancamentoDao;
+import exception.LancamentoException;
+import infra.EntityManagerUtil;
+import infra.Logger;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import model.Lancamento;
+
+public class LancamentoDaoNativeImpl implements LancamentoDao {
+
+    @Override
+    public void create(Lancamento lancamento) throws LancamentoException {
+        Logger.info("LancamentoDaoNativeImpl.create - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "INSERT INTO Lancamento (id_lancamento, valor, fixo, data_pagamento, status, id_movimentacao, id_evento) " +
+                    "VALUES (:id, :valor, :fixo, :dataPagamento, :status, :idMovimentacao, :idEvento)";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("id", lancamento.getIdLancamento());
+            query.setParameter("valor", lancamento.getValor());
+            query.setParameter("fixo", lancamento.getFixo());
+            query.setParameter("dataPagamento", lancamento.getDataPagamento());
+            query.setParameter("status", lancamento.getStatus());
+            query.setParameter("idMovimentacao", lancamento.getIdMovimentacao());
+            query.setParameter("idEvento", lancamento.getIdEvento());
+            query.executeUpdate();
+            em.getTransaction().commit();
+            Logger.info("LancamentoDaoNativeImpl.create - sucesso");
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("LancamentoDaoNativeImpl.create - erro", e);
+            throw new LancamentoException("Erro ao criar Lancamento", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Lancamento update(Lancamento lancamento) throws LancamentoException {
+        Logger.info("LancamentoDaoNativeImpl.update - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "UPDATE Lancamento SET valor=:valor, fixo=:fixo, data_pagamento=:dataPagamento, status=:status, " +
+                    "id_movimentacao=:idMovimentacao, id_evento=:idEvento WHERE id_lancamento=:id";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("valor", lancamento.getValor());
+            query.setParameter("fixo", lancamento.getFixo());
+            query.setParameter("dataPagamento", lancamento.getDataPagamento());
+            query.setParameter("status", lancamento.getStatus());
+            query.setParameter("idMovimentacao", lancamento.getIdMovimentacao());
+            query.setParameter("idEvento", lancamento.getIdEvento());
+            query.setParameter("id", lancamento.getIdLancamento());
+            int updated = query.executeUpdate();
+            if (updated == 0) {
+                throw new LancamentoException("Lancamento não encontrado: id=" + lancamento.getIdLancamento());
+            }
+            em.getTransaction().commit();
+            Logger.info("LancamentoDaoNativeImpl.update - sucesso");
+            return findById(lancamento.getIdLancamento());
+        } catch (LancamentoException e) {
+            em.getTransaction().rollback();
+            Logger.error("LancamentoDaoNativeImpl.update - erro", e);
+            throw e;
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("LancamentoDaoNativeImpl.update - erro", e);
+            throw new LancamentoException("Erro ao atualizar Lancamento", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public void deleteById(Integer id) throws LancamentoException {
+        Logger.info("LancamentoDaoNativeImpl.deleteById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "DELETE FROM Lancamento WHERE id_lancamento=:id";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("id", id);
+            int deleted = query.executeUpdate();
+            if (deleted == 0) {
+                throw new LancamentoException("Lancamento não encontrado: id=" + id);
+            }
+            em.getTransaction().commit();
+            Logger.info("LancamentoDaoNativeImpl.deleteById - sucesso");
+        } catch (LancamentoException e) {
+            em.getTransaction().rollback();
+            Logger.error("LancamentoDaoNativeImpl.deleteById - erro", e);
+            throw e;
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("LancamentoDaoNativeImpl.deleteById - erro", e);
+            throw new LancamentoException("Erro ao deletar Lancamento", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Lancamento findById(Integer id) throws LancamentoException {
+        Logger.info("LancamentoDaoNativeImpl.findById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_lancamento, valor, fixo, data_pagamento, status, id_movimentacao, id_evento FROM Lancamento WHERE id_lancamento=:id";
+            Query query = em.createNativeQuery(sql, Lancamento.class);
+            query.setParameter("id", id);
+            Lancamento l = (Lancamento) query.getSingleResult();
+            Logger.info("LancamentoDaoNativeImpl.findById - sucesso");
+            return l;
+        } catch (Exception e) {
+            Logger.error("LancamentoDaoNativeImpl.findById - erro", e);
+            throw new LancamentoException("Lancamento não encontrado: id=" + id, e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Lancamento> findAll() {
+        Logger.info("LancamentoDaoNativeImpl.findAll - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_lancamento, valor, fixo, data_pagamento, status, id_movimentacao, id_evento FROM Lancamento";
+            Query query = em.createNativeQuery(sql, Lancamento.class);
+            List<Lancamento> list = query.getResultList();
+            Logger.info("LancamentoDaoNativeImpl.findAll - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Lancamento> findAll(int page, int size) {
+        Logger.info("LancamentoDaoNativeImpl.findAll(page) - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_lancamento, valor, fixo, data_pagamento, status, id_movimentacao, id_evento FROM Lancamento LIMIT :limit OFFSET :offset";
+            Query query = em.createNativeQuery(sql, Lancamento.class);
+            query.setParameter("limit", size);
+            query.setParameter("offset", page * size);
+            List<Lancamento> list = query.getResultList();
+            Logger.info("LancamentoDaoNativeImpl.findAll(page) - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Lancamento> findByValor(java.math.BigDecimal valor) {
+        Logger.info("LancamentoDaoNativeImpl.findByValor - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_lancamento, valor, fixo, data_pagamento, status, id_movimentacao, id_evento FROM Lancamento WHERE valor=:valor";
+            Query query = em.createNativeQuery(sql, Lancamento.class);
+            query.setParameter("valor", valor);
+            List<Lancamento> list = query.getResultList();
+            Logger.info("LancamentoDaoNativeImpl.findByValor - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Lancamento> findByFixo(Boolean fixo) {
+        Logger.info("LancamentoDaoNativeImpl.findByFixo - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_lancamento, valor, fixo, data_pagamento, status, id_movimentacao, id_evento FROM Lancamento WHERE fixo=:fixo";
+            Query query = em.createNativeQuery(sql, Lancamento.class);
+            query.setParameter("fixo", fixo);
+            List<Lancamento> list = query.getResultList();
+            Logger.info("LancamentoDaoNativeImpl.findByFixo - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Lancamento> findByDataPagamento(java.time.LocalDate dataPagamento) {
+        Logger.info("LancamentoDaoNativeImpl.findByDataPagamento - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_lancamento, valor, fixo, data_pagamento, status, id_movimentacao, id_evento FROM Lancamento WHERE data_pagamento=:dataPagamento";
+            Query query = em.createNativeQuery(sql, Lancamento.class);
+            query.setParameter("dataPagamento", dataPagamento);
+            List<Lancamento> list = query.getResultList();
+            Logger.info("LancamentoDaoNativeImpl.findByDataPagamento - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Lancamento> findByStatus(Integer status) {
+        Logger.info("LancamentoDaoNativeImpl.findByStatus - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_lancamento, valor, fixo, data_pagamento, status, id_movimentacao, id_evento FROM Lancamento WHERE status=:status";
+            Query query = em.createNativeQuery(sql, Lancamento.class);
+            query.setParameter("status", status);
+            List<Lancamento> list = query.getResultList();
+            Logger.info("LancamentoDaoNativeImpl.findByStatus - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Lancamento> findByIdMovimentacao(Integer idMovimentacao) {
+        Logger.info("LancamentoDaoNativeImpl.findByIdMovimentacao - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_lancamento, valor, fixo, data_pagamento, status, id_movimentacao, id_evento FROM Lancamento WHERE id_movimentacao=:idMovimentacao";
+            Query query = em.createNativeQuery(sql, Lancamento.class);
+            query.setParameter("idMovimentacao", idMovimentacao);
+            List<Lancamento> list = query.getResultList();
+            Logger.info("LancamentoDaoNativeImpl.findByIdMovimentacao - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Lancamento> findByIdEvento(Integer idEvento) {
+        Logger.info("LancamentoDaoNativeImpl.findByIdEvento - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_lancamento, valor, fixo, data_pagamento, status, id_movimentacao, id_evento FROM Lancamento WHERE id_evento=:idEvento";
+            Query query = em.createNativeQuery(sql, Lancamento.class);
+            query.setParameter("idEvento", idEvento);
+            List<Lancamento> list = query.getResultList();
+            Logger.info("LancamentoDaoNativeImpl.findByIdEvento - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Lancamento> search(Lancamento filtro) {
+        return search(filtro, -1, -1);
+    }
+
+    @Override
+    public List<Lancamento> search(Lancamento filtro, int page, int size) {
+        Logger.info("LancamentoDaoNativeImpl.search - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            StringBuilder sb = new StringBuilder("SELECT id_lancamento, valor, fixo, data_pagamento, status, id_movimentacao, id_evento FROM Lancamento WHERE 1=1");
+            Map<String, Object> params = new HashMap<>();
+            if (filtro.getValor() != null) {
+                sb.append(" AND valor=:valor");
+                params.put("valor", filtro.getValor());
+            }
+            if (filtro.getFixo() != null) {
+                sb.append(" AND fixo=:fixo");
+                params.put("fixo", filtro.getFixo());
+            }
+            if (filtro.getDataPagamento() != null) {
+                sb.append(" AND data_pagamento=:dataPagamento");
+                params.put("dataPagamento", filtro.getDataPagamento());
+            }
+            if (filtro.getStatus() != null) {
+                sb.append(" AND status=:status");
+                params.put("status", filtro.getStatus());
+            }
+            if (filtro.getIdMovimentacao() != null) {
+                sb.append(" AND id_movimentacao=:idMovimentacao");
+                params.put("idMovimentacao", filtro.getIdMovimentacao());
+            }
+            if (filtro.getIdEvento() != null) {
+                sb.append(" AND id_evento=:idEvento");
+                params.put("idEvento", filtro.getIdEvento());
+            }
+            if (page >= 0 && size > 0) {
+                sb.append(" LIMIT :limit OFFSET :offset");
+            }
+            Query query = em.createNativeQuery(sb.toString(), Lancamento.class);
+            for (Map.Entry<String, Object> e : params.entrySet()) {
+                query.setParameter(e.getKey(), e.getValue());
+            }
+            if (page >= 0 && size > 0) {
+                query.setParameter("limit", size);
+                query.setParameter("offset", page * size);
+            }
+            List<Lancamento> list = query.getResultList();
+            Logger.info("LancamentoDaoNativeImpl.search - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+}

--- a/src/main/java/exception/DocumentoException.java
+++ b/src/main/java/exception/DocumentoException.java
@@ -1,0 +1,13 @@
+// path: src/main/java/exception/DocumentoException.java
+package exception;
+
+public class DocumentoException extends RuntimeException {
+
+    public DocumentoException(String message) {
+        super(message);
+    }
+
+    public DocumentoException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/exception/ExercicioException.java
+++ b/src/main/java/exception/ExercicioException.java
@@ -1,0 +1,13 @@
+// path: src/main/java/exception/ExercicioException.java
+package exception;
+
+public class ExercicioException extends RuntimeException {
+
+    public ExercicioException(String message) {
+        super(message);
+    }
+
+    public ExercicioException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/exception/LancamentoException.java
+++ b/src/main/java/exception/LancamentoException.java
@@ -1,0 +1,13 @@
+// path: src/main/java/exception/LancamentoException.java
+package exception;
+
+public class LancamentoException extends RuntimeException {
+
+    public LancamentoException(String message) {
+        super(message);
+    }
+
+    public LancamentoException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/infra/EntityManagerUtil.java
+++ b/src/main/java/infra/EntityManagerUtil.java
@@ -1,0 +1,17 @@
+// path: src/main/java/infra/EntityManagerUtil.java
+package infra;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.Persistence;
+
+public class EntityManagerUtil {
+    private static final EntityManagerFactory emf = Persistence.createEntityManagerFactory("rotinamaisPU");
+
+    private EntityManagerUtil() {
+    }
+
+    public static EntityManager getEntityManager() {
+        return emf.createEntityManager();
+    }
+}

--- a/src/main/java/infra/Logger.java
+++ b/src/main/java/infra/Logger.java
@@ -1,0 +1,15 @@
+// path: src/main/java/infra/Logger.java
+package infra;
+
+public class Logger {
+    public static void info(String msg) {
+        System.out.println("INFO: " + msg);
+    }
+
+    public static void error(String msg, Throwable t) {
+        System.err.println("ERROR: " + msg);
+        if (t != null) {
+            t.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/model/Documento.java
+++ b/src/main/java/model/Documento.java
@@ -1,0 +1,120 @@
+// path: src/main/java/model/Documento.java
+package model;
+
+import java.time.LocalDate;
+import java.util.Objects;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "Documento")
+public class Documento {
+
+    @Id
+    @Column(name = "id_documento")
+    private Integer idDocumento;
+
+    @Column(name = "nome")
+    private String nome;
+
+    @Lob
+    @Column(name = "arquivo")
+    private byte[] arquivo;
+
+    @Lob
+    @Column(name = "foto")
+    private byte[] foto;
+
+    @Lob
+    @Column(name = "video")
+    private byte[] video;
+
+    @Column(name = "data")
+    private LocalDate data;
+
+    @Column(name = "id_usuario")
+    private Integer idUsuario;
+
+    public Integer getIdDocumento() {
+        return idDocumento;
+    }
+
+    public void setIdDocumento(Integer idDocumento) {
+        this.idDocumento = idDocumento;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public byte[] getArquivo() {
+        return arquivo;
+    }
+
+    public void setArquivo(byte[] arquivo) {
+        this.arquivo = arquivo;
+    }
+
+    public byte[] getFoto() {
+        return foto;
+    }
+
+    public void setFoto(byte[] foto) {
+        this.foto = foto;
+    }
+
+    public byte[] getVideo() {
+        return video;
+    }
+
+    public void setVideo(byte[] video) {
+        this.video = video;
+    }
+
+    public LocalDate getData() {
+        return data;
+    }
+
+    public void setData(LocalDate data) {
+        this.data = data;
+    }
+
+    public Integer getIdUsuario() {
+        return idUsuario;
+    }
+
+    public void setIdUsuario(Integer idUsuario) {
+        this.idUsuario = idUsuario;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Documento)) return false;
+        Documento that = (Documento) o;
+        return Objects.equals(idDocumento, that.idDocumento);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idDocumento);
+    }
+
+    @Override
+    public String toString() {
+        return "Documento{" +
+                "idDocumento=" + idDocumento +
+                ", nome='" + nome + '\'' +
+                ", data=" + data +
+                ", idUsuario=" + idUsuario +
+                '}';
+    }
+}

--- a/src/main/java/model/Exercicio.java
+++ b/src/main/java/model/Exercicio.java
@@ -1,0 +1,94 @@
+// path: src/main/java/model/Exercicio.java
+package model;
+
+import java.util.Objects;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "Exercicio")
+public class Exercicio {
+
+    @Id
+    @Column(name = "id_exercicio")
+    private Integer idExercicio;
+
+    @Column(name = "nome")
+    private String nome;
+
+    @Column(name = "carga_leve")
+    private Integer cargaLeve;
+
+    @Column(name = "carga_media")
+    private Integer cargaMedia;
+
+    @Column(name = "carga_maxima")
+    private Integer cargaMaxima;
+
+    public Integer getIdExercicio() {
+        return idExercicio;
+    }
+
+    public void setIdExercicio(Integer idExercicio) {
+        this.idExercicio = idExercicio;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public Integer getCargaLeve() {
+        return cargaLeve;
+    }
+
+    public void setCargaLeve(Integer cargaLeve) {
+        this.cargaLeve = cargaLeve;
+    }
+
+    public Integer getCargaMedia() {
+        return cargaMedia;
+    }
+
+    public void setCargaMedia(Integer cargaMedia) {
+        this.cargaMedia = cargaMedia;
+    }
+
+    public Integer getCargaMaxima() {
+        return cargaMaxima;
+    }
+
+    public void setCargaMaxima(Integer cargaMaxima) {
+        this.cargaMaxima = cargaMaxima;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Exercicio)) return false;
+        Exercicio that = (Exercicio) o;
+        return Objects.equals(idExercicio, that.idExercicio);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idExercicio);
+    }
+
+    @Override
+    public String toString() {
+        return "Exercicio{" +
+                "idExercicio=" + idExercicio +
+                ", nome='" + nome + '\'' +
+                ", cargaLeve=" + cargaLeve +
+                ", cargaMedia=" + cargaMedia +
+                ", cargaMaxima=" + cargaMaxima +
+                '}';
+    }
+}

--- a/src/main/java/model/Lancamento.java
+++ b/src/main/java/model/Lancamento.java
@@ -1,0 +1,120 @@
+// path: src/main/java/model/Lancamento.java
+package model;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Objects;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "Lancamento")
+public class Lancamento {
+
+    @Id
+    @Column(name = "id_lancamento")
+    private Integer idLancamento;
+
+    @Column(name = "valor")
+    private BigDecimal valor;
+
+    @Column(name = "fixo")
+    private Boolean fixo;
+
+    @Column(name = "data_pagamento")
+    private LocalDate dataPagamento;
+
+    @Column(name = "status")
+    private Integer status;
+
+    @Column(name = "id_movimentacao")
+    private Integer idMovimentacao;
+
+    @Column(name = "id_evento")
+    private Integer idEvento;
+
+    public Integer getIdLancamento() {
+        return idLancamento;
+    }
+
+    public void setIdLancamento(Integer idLancamento) {
+        this.idLancamento = idLancamento;
+    }
+
+    public BigDecimal getValor() {
+        return valor;
+    }
+
+    public void setValor(BigDecimal valor) {
+        this.valor = valor;
+    }
+
+    public Boolean getFixo() {
+        return fixo;
+    }
+
+    public void setFixo(Boolean fixo) {
+        this.fixo = fixo;
+    }
+
+    public LocalDate getDataPagamento() {
+        return dataPagamento;
+    }
+
+    public void setDataPagamento(LocalDate dataPagamento) {
+        this.dataPagamento = dataPagamento;
+    }
+
+    public Integer getStatus() {
+        return status;
+    }
+
+    public void setStatus(Integer status) {
+        this.status = status;
+    }
+
+    public Integer getIdMovimentacao() {
+        return idMovimentacao;
+    }
+
+    public void setIdMovimentacao(Integer idMovimentacao) {
+        this.idMovimentacao = idMovimentacao;
+    }
+
+    public Integer getIdEvento() {
+        return idEvento;
+    }
+
+    public void setIdEvento(Integer idEvento) {
+        this.idEvento = idEvento;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Lancamento)) return false;
+        Lancamento that = (Lancamento) o;
+        return Objects.equals(idLancamento, that.idLancamento);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idLancamento);
+    }
+
+    @Override
+    public String toString() {
+        return "Lancamento{" +
+                "idLancamento=" + idLancamento +
+                ", valor=" + valor +
+                ", fixo=" + fixo +
+                ", dataPagamento=" + dataPagamento +
+                ", status=" + status +
+                ", idMovimentacao=" + idMovimentacao +
+                ", idEvento=" + idEvento +
+                '}';
+    }
+}

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,14 @@
+<!-- path: src/main/resources/META-INF/persistence.xml -->
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence" version="3.0">
+    <persistence-unit name="rotinamaisPU">
+        <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+        <properties>
+            <property name="jakarta.persistence.jdbc.driver" value="org.postgresql.Driver"/>
+            <property name="jakarta.persistence.jdbc.url" value="jdbc:postgresql://localhost:5432/rotinamais"/>
+            <property name="jakarta.persistence.jdbc.user" value="postgres"/>
+            <property name="jakarta.persistence.jdbc.password" value="postgres"/>
+            <property name="hibernate.dialect" value="org.hibernate.dialect.PostgreSQLDialect"/>
+            <property name="hibernate.hbm2ddl.auto" value="none"/>
+        </properties>
+    </persistence-unit>
+</persistence>


### PR DESCRIPTION
## Summary
- implement Lancamento entity, DAO, and controller using native SQL with Evento linkage
- add Exercicio structure with full CRUD and search support
- create Documento module with blob-aware queries and controllers
- drop unintended Evento module and pivot Lancamento to store only idEvento

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf64cd49288325890fe7732235f5da