### PR TITLE
feat: add movimentacao, rotina, fornecedor and ingrediente modules

### DIFF
--- a/src/main/java/controller/FornecedorController.java
+++ b/src/main/java/controller/FornecedorController.java
@@ -1,0 +1,143 @@
+// path: src/main/java/controller/FornecedorController.java
+package controller;
+
+import java.util.List;
+
+import dao.api.FornecedorDao;
+import exception.FornecedorException;
+import infra.Logger;
+import model.Fornecedor;
+
+public class FornecedorController {
+
+    private final FornecedorDao dao;
+
+    public FornecedorController(FornecedorDao dao) {
+        this.dao = dao;
+    }
+
+    public void criar(Fornecedor fornecedor) {
+        Logger.info("FornecedorController.criar - inicio");
+        if (fornecedor == null) {
+            throw new FornecedorException("Fornecedor não pode ser nulo");
+        }
+        if (fornecedor.getIdFornecedor() == null) {
+            throw new FornecedorException("Id do Fornecedor é obrigatório");
+        }
+        if (fornecedor.getNome() == null || fornecedor.getNome().isEmpty()) {
+            throw new FornecedorException("Nome do Fornecedor é obrigatório");
+        }
+        dao.create(fornecedor);
+        Logger.info("FornecedorController.criar - sucesso");
+    }
+
+    public Fornecedor atualizar(Fornecedor fornecedor) {
+        Logger.info("FornecedorController.atualizar - inicio");
+        if (fornecedor == null || fornecedor.getIdFornecedor() == null) {
+            throw new FornecedorException("Fornecedor ou Id não pode ser nulo");
+        }
+        if (fornecedor.getNome() == null || fornecedor.getNome().isEmpty()) {
+            throw new FornecedorException("Nome do Fornecedor é obrigatório");
+        }
+        Fornecedor updated = dao.update(fornecedor);
+        Logger.info("FornecedorController.atualizar - sucesso");
+        return updated;
+    }
+
+    public void remover(Integer id) {
+        Logger.info("FornecedorController.remover - inicio");
+        if (id == null) {
+            throw new FornecedorException("Id do Fornecedor é obrigatório");
+        }
+        dao.deleteById(id);
+        Logger.info("FornecedorController.remover - sucesso");
+    }
+
+    public Fornecedor buscarPorId(Integer id) {
+        Logger.info("FornecedorController.buscarPorId - inicio");
+        if (id == null) {
+            throw new FornecedorException("Id do Fornecedor é obrigatório");
+        }
+        Fornecedor f = dao.findById(id);
+        Logger.info("FornecedorController.buscarPorId - sucesso");
+        return f;
+    }
+
+    public Fornecedor buscarComFotoPorId(Integer id) {
+        Logger.info("FornecedorController.buscarComFotoPorId - inicio");
+        if (id == null) {
+            throw new FornecedorException("Id do Fornecedor é obrigatório");
+        }
+        Fornecedor f = dao.findWithFotoById(id);
+        Logger.info("FornecedorController.buscarComFotoPorId - sucesso");
+        return f;
+    }
+
+    public List<Fornecedor> listar() {
+        Logger.info("FornecedorController.listar - inicio");
+        List<Fornecedor> list = dao.findAll();
+        Logger.info("FornecedorController.listar - sucesso");
+        return list;
+    }
+
+    public List<Fornecedor> listar(int page, int size) {
+        Logger.info("FornecedorController.listar(page) - inicio");
+        List<Fornecedor> list = dao.findAll(page, size);
+        Logger.info("FornecedorController.listar(page) - sucesso");
+        return list;
+    }
+
+    public List<Fornecedor> buscarPorNome(String nome) {
+        Logger.info("FornecedorController.buscarPorNome - inicio");
+        if (nome == null || nome.isEmpty()) {
+            throw new FornecedorException("Nome não pode ser vazio");
+        }
+        List<Fornecedor> list = dao.findByNome(nome);
+        Logger.info("FornecedorController.buscarPorNome - sucesso");
+        return list;
+    }
+
+    public List<Fornecedor> buscarPorFoto(byte[] foto) {
+        Logger.info("FornecedorController.buscarPorFoto - inicio");
+        if (foto == null) {
+            throw new FornecedorException("Foto não pode ser nula");
+        }
+        List<Fornecedor> list = dao.findByFoto(foto);
+        Logger.info("FornecedorController.buscarPorFoto - sucesso");
+        return list;
+    }
+
+    public List<Fornecedor> buscarPorEndereco(String endereco) {
+        Logger.info("FornecedorController.buscarPorEndereco - inicio");
+        if (endereco == null || endereco.isEmpty()) {
+            throw new FornecedorException("Endereço não pode ser vazio");
+        }
+        List<Fornecedor> list = dao.findByEndereco(endereco);
+        Logger.info("FornecedorController.buscarPorEndereco - sucesso");
+        return list;
+    }
+
+    public List<Fornecedor> buscarPorOnline(Boolean online) {
+        Logger.info("FornecedorController.buscarPorOnline - inicio");
+        if (online == null) {
+            throw new FornecedorException("Online não pode ser nulo");
+        }
+        List<Fornecedor> list = dao.findByOnline(online);
+        Logger.info("FornecedorController.buscarPorOnline - sucesso");
+        return list;
+    }
+
+    public List<Fornecedor> pesquisar(Fornecedor filtro) {
+        Logger.info("FornecedorController.pesquisar - inicio");
+        List<Fornecedor> list = dao.search(filtro);
+        Logger.info("FornecedorController.pesquisar - sucesso");
+        return list;
+    }
+
+    public List<Fornecedor> pesquisar(Fornecedor filtro, int page, int size) {
+        Logger.info("FornecedorController.pesquisar(page) - inicio");
+        List<Fornecedor> list = dao.search(filtro, page, size);
+        Logger.info("FornecedorController.pesquisar(page) - sucesso");
+        return list;
+    }
+}

--- a/src/main/java/controller/IngredienteController.java
+++ b/src/main/java/controller/IngredienteController.java
@@ -1,0 +1,133 @@
+// path: src/main/java/controller/IngredienteController.java
+package controller;
+
+import java.util.List;
+
+import dao.api.IngredienteDao;
+import exception.IngredienteException;
+import infra.Logger;
+import model.Ingrediente;
+
+public class IngredienteController {
+
+    private final IngredienteDao dao;
+
+    public IngredienteController(IngredienteDao dao) {
+        this.dao = dao;
+    }
+
+    public void criar(Ingrediente ingrediente) {
+        Logger.info("IngredienteController.criar - inicio");
+        if (ingrediente == null) {
+            throw new IngredienteException("Ingrediente não pode ser nulo");
+        }
+        if (ingrediente.getIdIngrediente() == null) {
+            throw new IngredienteException("Id do Ingrediente é obrigatório");
+        }
+        if (ingrediente.getNome() == null || ingrediente.getNome().isEmpty()) {
+            throw new IngredienteException("Nome do Ingrediente é obrigatório");
+        }
+        dao.create(ingrediente);
+        Logger.info("IngredienteController.criar - sucesso");
+    }
+
+    public Ingrediente atualizar(Ingrediente ingrediente) {
+        Logger.info("IngredienteController.atualizar - inicio");
+        if (ingrediente == null || ingrediente.getIdIngrediente() == null) {
+            throw new IngredienteException("Ingrediente ou Id não pode ser nulo");
+        }
+        if (ingrediente.getNome() == null || ingrediente.getNome().isEmpty()) {
+            throw new IngredienteException("Nome do Ingrediente é obrigatório");
+        }
+        Ingrediente updated = dao.update(ingrediente);
+        Logger.info("IngredienteController.atualizar - sucesso");
+        return updated;
+    }
+
+    public void remover(Integer id) {
+        Logger.info("IngredienteController.remover - inicio");
+        if (id == null) {
+            throw new IngredienteException("Id do Ingrediente é obrigatório");
+        }
+        dao.deleteById(id);
+        Logger.info("IngredienteController.remover - sucesso");
+    }
+
+    public Ingrediente buscarPorId(Integer id) {
+        Logger.info("IngredienteController.buscarPorId - inicio");
+        if (id == null) {
+            throw new IngredienteException("Id do Ingrediente é obrigatório");
+        }
+        Ingrediente i = dao.findById(id);
+        Logger.info("IngredienteController.buscarPorId - sucesso");
+        return i;
+    }
+
+    public Ingrediente buscarComFotoPorId(Integer id) {
+        Logger.info("IngredienteController.buscarComFotoPorId - inicio");
+        if (id == null) {
+            throw new IngredienteException("Id do Ingrediente é obrigatório");
+        }
+        Ingrediente i = dao.findWithFotoById(id);
+        Logger.info("IngredienteController.buscarComFotoPorId - sucesso");
+        return i;
+    }
+
+    public List<Ingrediente> listar() {
+        Logger.info("IngredienteController.listar - inicio");
+        List<Ingrediente> list = dao.findAll();
+        Logger.info("IngredienteController.listar - sucesso");
+        return list;
+    }
+
+    public List<Ingrediente> listar(int page, int size) {
+        Logger.info("IngredienteController.listar(page) - inicio");
+        List<Ingrediente> list = dao.findAll(page, size);
+        Logger.info("IngredienteController.listar(page) - sucesso");
+        return list;
+    }
+
+    public List<Ingrediente> buscarPorFoto(byte[] foto) {
+        Logger.info("IngredienteController.buscarPorFoto - inicio");
+        if (foto == null) {
+            throw new IngredienteException("Foto não pode ser nula");
+        }
+        List<Ingrediente> list = dao.findByFoto(foto);
+        Logger.info("IngredienteController.buscarPorFoto - sucesso");
+        return list;
+    }
+
+    public List<Ingrediente> buscarPorNome(String nome) {
+        Logger.info("IngredienteController.buscarPorNome - inicio");
+        if (nome == null || nome.isEmpty()) {
+            throw new IngredienteException("Nome não pode ser vazio");
+        }
+        List<Ingrediente> list = dao.findByNome(nome);
+        Logger.info("IngredienteController.buscarPorNome - sucesso");
+        return list;
+    }
+
+    public List<Ingrediente> buscarPorDescricao(String descricao) {
+        Logger.info("IngredienteController.buscarPorDescricao - inicio");
+        if (descricao == null || descricao.isEmpty()) {
+            throw new IngredienteException("Descrição não pode ser vazia");
+        }
+        List<Ingrediente> list = dao.findByDescricao(descricao);
+        Logger.info("IngredienteController.buscarPorDescricao - sucesso");
+        return list;
+    }
+
+    public List<Ingrediente> pesquisar(Ingrediente filtro) {
+        Logger.info("IngredienteController.pesquisar - inicio");
+        List<Ingrediente> list = dao.search(filtro);
+        Logger.info("IngredienteController.pesquisar - sucesso");
+        return list;
+    }
+
+    public List<Ingrediente> pesquisar(Ingrediente filtro, int page, int size) {
+        Logger.info("IngredienteController.pesquisar(page) - inicio");
+        List<Ingrediente> list = dao.search(filtro, page, size);
+        Logger.info("IngredienteController.pesquisar(page) - sucesso");
+        return list;
+    }
+}

--- a/src/main/java/controller/MovimentacaoController.java
+++ b/src/main/java/controller/MovimentacaoController.java
@@ -1,0 +1,184 @@
+// path: src/main/java/controller/MovimentacaoController.java
+package controller;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import dao.api.MovimentacaoDao;
+import exception.MovimentacaoException;
+import infra.Logger;
+import model.Movimentacao;
+
+public class MovimentacaoController {
+
+    private final MovimentacaoDao dao;
+
+    public MovimentacaoController(MovimentacaoDao dao) {
+        this.dao = dao;
+    }
+
+    public void criar(Movimentacao movimentacao) {
+        Logger.info("MovimentacaoController.criar - inicio");
+        if (movimentacao == null) {
+            throw new MovimentacaoException("Movimentacao não pode ser nula");
+        }
+        if (movimentacao.getIdMovimentacao() == null) {
+            throw new MovimentacaoException("Id da Movimentacao é obrigatório");
+        }
+        if (movimentacao.getTipo() == null) {
+            throw new MovimentacaoException("Tipo da Movimentacao é obrigatório");
+        }
+        dao.create(movimentacao);
+        Logger.info("MovimentacaoController.criar - sucesso");
+    }
+
+    public Movimentacao atualizar(Movimentacao movimentacao) {
+        Logger.info("MovimentacaoController.atualizar - inicio");
+        if (movimentacao == null || movimentacao.getIdMovimentacao() == null) {
+            throw new MovimentacaoException("Movimentacao ou Id não pode ser nulo");
+        }
+        if (movimentacao.getTipo() == null) {
+            throw new MovimentacaoException("Tipo da Movimentacao é obrigatório");
+        }
+        Movimentacao updated = dao.update(movimentacao);
+        Logger.info("MovimentacaoController.atualizar - sucesso");
+        return updated;
+    }
+
+    public void remover(Integer id) {
+        Logger.info("MovimentacaoController.remover - inicio");
+        if (id == null) {
+            throw new MovimentacaoException("Id da Movimentacao é obrigatório");
+        }
+        dao.deleteById(id);
+        Logger.info("MovimentacaoController.remover - sucesso");
+    }
+
+    public Movimentacao buscarPorId(Integer id) {
+        Logger.info("MovimentacaoController.buscarPorId - inicio");
+        if (id == null) {
+            throw new MovimentacaoException("Id da Movimentacao é obrigatório");
+        }
+        Movimentacao m = dao.findById(id);
+        Logger.info("MovimentacaoController.buscarPorId - sucesso");
+        return m;
+    }
+
+    public List<Movimentacao> listar() {
+        Logger.info("MovimentacaoController.listar - inicio");
+        List<Movimentacao> list = dao.findAll();
+        Logger.info("MovimentacaoController.listar - sucesso");
+        return list;
+    }
+
+    public List<Movimentacao> listar(int page, int size) {
+        Logger.info("MovimentacaoController.listar(page) - inicio");
+        List<Movimentacao> list = dao.findAll(page, size);
+        Logger.info("MovimentacaoController.listar(page) - sucesso");
+        return list;
+    }
+
+    public List<Movimentacao> buscarPorDesconto(BigDecimal desconto) {
+        Logger.info("MovimentacaoController.buscarPorDesconto - inicio");
+        if (desconto == null) {
+            throw new MovimentacaoException("Desconto não pode ser nulo");
+        }
+        List<Movimentacao> list = dao.findByDesconto(desconto);
+        Logger.info("MovimentacaoController.buscarPorDesconto - sucesso");
+        return list;
+    }
+
+    public List<Movimentacao> buscarPorVantagem(BigDecimal vantagem) {
+        Logger.info("MovimentacaoController.buscarPorVantagem - inicio");
+        if (vantagem == null) {
+            throw new MovimentacaoException("Vantagem não pode ser nula");
+        }
+        List<Movimentacao> list = dao.findByVantagem(vantagem);
+        Logger.info("MovimentacaoController.buscarPorVantagem - sucesso");
+        return list;
+    }
+
+    public List<Movimentacao> buscarPorLiquido(BigDecimal liquido) {
+        Logger.info("MovimentacaoController.buscarPorLiquido - inicio");
+        if (liquido == null) {
+            throw new MovimentacaoException("Liquido não pode ser nulo");
+        }
+        List<Movimentacao> list = dao.findByLiquido(liquido);
+        Logger.info("MovimentacaoController.buscarPorLiquido - sucesso");
+        return list;
+    }
+
+    public List<Movimentacao> buscarPorTipo(Integer tipo) {
+        Logger.info("MovimentacaoController.buscarPorTipo - inicio");
+        if (tipo == null) {
+            throw new MovimentacaoException("Tipo não pode ser nulo");
+        }
+        List<Movimentacao> list = dao.findByTipo(tipo);
+        Logger.info("MovimentacaoController.buscarPorTipo - sucesso");
+        return list;
+    }
+
+    public List<Movimentacao> buscarPorStatus(Integer status) {
+        Logger.info("MovimentacaoController.buscarPorStatus - inicio");
+        if (status == null) {
+            throw new MovimentacaoException("Status não pode ser nulo");
+        }
+        List<Movimentacao> list = dao.findByStatus(status);
+        Logger.info("MovimentacaoController.buscarPorStatus - sucesso");
+        return list;
+    }
+
+    public List<Movimentacao> buscarPorPonto(Integer ponto) {
+        Logger.info("MovimentacaoController.buscarPorPonto - inicio");
+        if (ponto == null) {
+            throw new MovimentacaoException("Ponto não pode ser nulo");
+        }
+        List<Movimentacao> list = dao.findByPonto(ponto);
+        Logger.info("MovimentacaoController.buscarPorPonto - sucesso");
+        return list;
+    }
+
+    public List<Movimentacao> buscarPorIdUsuario(Integer idUsuario) {
+        Logger.info("MovimentacaoController.buscarPorIdUsuario - inicio");
+        if (idUsuario == null) {
+            throw new MovimentacaoException("Id do usuário não pode ser nulo");
+        }
+        List<Movimentacao> list = dao.findByIdUsuario(idUsuario);
+        Logger.info("MovimentacaoController.buscarPorIdUsuario - sucesso");
+        return list;
+    }
+
+    public List<Movimentacao> buscarPorIdCaixa(Integer idCaixa) {
+        Logger.info("MovimentacaoController.buscarPorIdCaixa - inicio");
+        if (idCaixa == null) {
+            throw new MovimentacaoException("Id do caixa não pode ser nulo");
+        }
+        List<Movimentacao> list = dao.findByIdCaixa(idCaixa);
+        Logger.info("MovimentacaoController.buscarPorIdCaixa - sucesso");
+        return list;
+    }
+
+    public List<Movimentacao> buscarPorIdPeriodo(Integer idPeriodo) {
+        Logger.info("MovimentacaoController.buscarPorIdPeriodo - inicio");
+        if (idPeriodo == null) {
+            throw new MovimentacaoException("Id do período não pode ser nulo");
+        }
+        List<Movimentacao> list = dao.findByIdPeriodo(idPeriodo);
+        Logger.info("MovimentacaoController.buscarPorIdPeriodo - sucesso");
+        return list;
+    }
+
+    public List<Movimentacao> pesquisar(Movimentacao filtro) {
+        Logger.info("MovimentacaoController.pesquisar - inicio");
+        List<Movimentacao> list = dao.search(filtro);
+        Logger.info("MovimentacaoController.pesquisar - sucesso");
+        return list;
+    }
+
+    public List<Movimentacao> pesquisar(Movimentacao filtro, int page, int size) {
+        Logger.info("MovimentacaoController.pesquisar(page) - inicio");
+        List<Movimentacao> list = dao.search(filtro, page, size);
+        Logger.info("MovimentacaoController.pesquisar(page) - sucesso");
+        return list;
+    }
+}

--- a/src/main/java/controller/RotinaController.java
+++ b/src/main/java/controller/RotinaController.java
@@ -1,0 +1,164 @@
+// path: src/main/java/controller/RotinaController.java
+package controller;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import dao.api.RotinaDao;
+import exception.RotinaException;
+import infra.Logger;
+import model.Rotina;
+
+public class RotinaController {
+
+    private final RotinaDao dao;
+
+    public RotinaController(RotinaDao dao) {
+        this.dao = dao;
+    }
+
+    public void criar(Rotina rotina) {
+        Logger.info("RotinaController.criar - inicio");
+        if (rotina == null) {
+            throw new RotinaException("Rotina não pode ser nula");
+        }
+        if (rotina.getIdRotina() == null) {
+            throw new RotinaException("Id da Rotina é obrigatório");
+        }
+        if (rotina.getNome() == null || rotina.getNome().isEmpty()) {
+            throw new RotinaException("Nome da Rotina é obrigatório");
+        }
+        dao.create(rotina);
+        Logger.info("RotinaController.criar - sucesso");
+    }
+
+    public Rotina atualizar(Rotina rotina) {
+        Logger.info("RotinaController.atualizar - inicio");
+        if (rotina == null || rotina.getIdRotina() == null) {
+            throw new RotinaException("Rotina ou Id não pode ser nulo");
+        }
+        if (rotina.getNome() == null || rotina.getNome().isEmpty()) {
+            throw new RotinaException("Nome da Rotina é obrigatório");
+        }
+        Rotina updated = dao.update(rotina);
+        Logger.info("RotinaController.atualizar - sucesso");
+        return updated;
+    }
+
+    public void remover(Integer id) {
+        Logger.info("RotinaController.remover - inicio");
+        if (id == null) {
+            throw new RotinaException("Id da Rotina é obrigatório");
+        }
+        dao.deleteById(id);
+        Logger.info("RotinaController.remover - sucesso");
+    }
+
+    public Rotina buscarPorId(Integer id) {
+        Logger.info("RotinaController.buscarPorId - inicio");
+        if (id == null) {
+            throw new RotinaException("Id da Rotina é obrigatório");
+        }
+        Rotina r = dao.findById(id);
+        Logger.info("RotinaController.buscarPorId - sucesso");
+        return r;
+    }
+
+    public List<Rotina> listar() {
+        Logger.info("RotinaController.listar - inicio");
+        List<Rotina> list = dao.findAll();
+        Logger.info("RotinaController.listar - sucesso");
+        return list;
+    }
+
+    public List<Rotina> listar(int page, int size) {
+        Logger.info("RotinaController.listar(page) - inicio");
+        List<Rotina> list = dao.findAll(page, size);
+        Logger.info("RotinaController.listar(page) - sucesso");
+        return list;
+    }
+
+    public List<Rotina> buscarPorNome(String nome) {
+        Logger.info("RotinaController.buscarPorNome - inicio");
+        if (nome == null || nome.isEmpty()) {
+            throw new RotinaException("Nome não pode ser vazio");
+        }
+        List<Rotina> list = dao.findByNome(nome);
+        Logger.info("RotinaController.buscarPorNome - sucesso");
+        return list;
+    }
+
+    public List<Rotina> buscarPorInicio(LocalDate inicio) {
+        Logger.info("RotinaController.buscarPorInicio - inicio");
+        if (inicio == null) {
+            throw new RotinaException("Inicio não pode ser nulo");
+        }
+        List<Rotina> list = dao.findByInicio(inicio);
+        Logger.info("RotinaController.buscarPorInicio - sucesso");
+        return list;
+    }
+
+    public List<Rotina> buscarPorFim(LocalDate fim) {
+        Logger.info("RotinaController.buscarPorFim - inicio");
+        if (fim == null) {
+            throw new RotinaException("Fim não pode ser nulo");
+        }
+        List<Rotina> list = dao.findByFim(fim);
+        Logger.info("RotinaController.buscarPorFim - sucesso");
+        return list;
+    }
+
+    public List<Rotina> buscarPorDescricao(String descricao) {
+        Logger.info("RotinaController.buscarPorDescricao - inicio");
+        if (descricao == null || descricao.isEmpty()) {
+            throw new RotinaException("Descrição não pode ser vazia");
+        }
+        List<Rotina> list = dao.findByDescricao(descricao);
+        Logger.info("RotinaController.buscarPorDescricao - sucesso");
+        return list;
+    }
+
+    public List<Rotina> buscarPorStatus(Integer status) {
+        Logger.info("RotinaController.buscarPorStatus - inicio");
+        if (status == null) {
+            throw new RotinaException("Status não pode ser nulo");
+        }
+        List<Rotina> list = dao.findByStatus(status);
+        Logger.info("RotinaController.buscarPorStatus - sucesso");
+        return list;
+    }
+
+    public List<Rotina> buscarPorPonto(Integer ponto) {
+        Logger.info("RotinaController.buscarPorPonto - inicio");
+        if (ponto == null) {
+            throw new RotinaException("Ponto não pode ser nulo");
+        }
+        List<Rotina> list = dao.findByPonto(ponto);
+        Logger.info("RotinaController.buscarPorPonto - sucesso");
+        return list;
+    }
+
+    public List<Rotina> buscarPorIdUsuario(Integer idUsuario) {
+        Logger.info("RotinaController.buscarPorIdUsuario - inicio");
+        if (idUsuario == null) {
+            throw new RotinaException("Id do usuário não pode ser nulo");
+        }
+        List<Rotina> list = dao.findByIdUsuario(idUsuario);
+        Logger.info("RotinaController.buscarPorIdUsuario - sucesso");
+        return list;
+    }
+
+    public List<Rotina> pesquisar(Rotina filtro) {
+        Logger.info("RotinaController.pesquisar - inicio");
+        List<Rotina> list = dao.search(filtro);
+        Logger.info("RotinaController.pesquisar - sucesso");
+        return list;
+    }
+
+    public List<Rotina> pesquisar(Rotina filtro, int page, int size) {
+        Logger.info("RotinaController.pesquisar(page) - inicio");
+        List<Rotina> list = dao.search(filtro, page, size);
+        Logger.info("RotinaController.pesquisar(page) - sucesso");
+        return list;
+    }
+}

--- a/src/main/java/dao/api/FornecedorDao.java
+++ b/src/main/java/dao/api/FornecedorDao.java
@@ -1,0 +1,36 @@
+// path: src/main/java/dao/api/FornecedorDao.java
+package dao.api;
+
+import java.util.List;
+
+import exception.FornecedorException;
+import model.Fornecedor;
+
+public interface FornecedorDao {
+
+    void create(Fornecedor fornecedor) throws FornecedorException;
+
+    Fornecedor update(Fornecedor fornecedor) throws FornecedorException;
+
+    void deleteById(Integer id) throws FornecedorException;
+
+    Fornecedor findById(Integer id) throws FornecedorException;
+
+    Fornecedor findWithFotoById(Integer id) throws FornecedorException;
+
+    List<Fornecedor> findAll();
+
+    List<Fornecedor> findAll(int page, int size);
+
+    List<Fornecedor> findByNome(String nome);
+
+    List<Fornecedor> findByFoto(byte[] foto);
+
+    List<Fornecedor> findByEndereco(String endereco);
+
+    List<Fornecedor> findByOnline(Boolean online);
+
+    List<Fornecedor> search(Fornecedor filtro);
+
+    List<Fornecedor> search(Fornecedor filtro, int page, int size);
+}

--- a/src/main/java/dao/api/IngredienteDao.java
+++ b/src/main/java/dao/api/IngredienteDao.java
@@ -1,0 +1,34 @@
+// path: src/main/java/dao/api/IngredienteDao.java
+package dao.api;
+
+import java.util.List;
+
+import exception.IngredienteException;
+import model.Ingrediente;
+
+public interface IngredienteDao {
+
+    void create(Ingrediente ingrediente) throws IngredienteException;
+
+    Ingrediente update(Ingrediente ingrediente) throws IngredienteException;
+
+    void deleteById(Integer id) throws IngredienteException;
+
+    Ingrediente findById(Integer id) throws IngredienteException;
+
+    Ingrediente findWithFotoById(Integer id) throws IngredienteException;
+
+    List<Ingrediente> findAll();
+
+    List<Ingrediente> findAll(int page, int size);
+
+    List<Ingrediente> findByFoto(byte[] foto);
+
+    List<Ingrediente> findByNome(String nome);
+
+    List<Ingrediente> findByDescricao(String descricao);
+
+    List<Ingrediente> search(Ingrediente filtro);
+
+    List<Ingrediente> search(Ingrediente filtro, int page, int size);
+}

--- a/src/main/java/dao/api/MovimentacaoDao.java
+++ b/src/main/java/dao/api/MovimentacaoDao.java
@@ -1,0 +1,45 @@
+// path: src/main/java/dao/api/MovimentacaoDao.java
+package dao.api;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import exception.MovimentacaoException;
+import model.Movimentacao;
+
+public interface MovimentacaoDao {
+
+    void create(Movimentacao movimentacao) throws MovimentacaoException;
+
+    Movimentacao update(Movimentacao movimentacao) throws MovimentacaoException;
+
+    void deleteById(Integer id) throws MovimentacaoException;
+
+    Movimentacao findById(Integer id) throws MovimentacaoException;
+
+    List<Movimentacao> findAll();
+
+    List<Movimentacao> findAll(int page, int size);
+
+    List<Movimentacao> findByDesconto(BigDecimal desconto);
+
+    List<Movimentacao> findByVantagem(BigDecimal vantagem);
+
+    List<Movimentacao> findByLiquido(BigDecimal liquido);
+
+    List<Movimentacao> findByTipo(Integer tipo);
+
+    List<Movimentacao> findByStatus(Integer status);
+
+    List<Movimentacao> findByPonto(Integer ponto);
+
+    List<Movimentacao> findByIdUsuario(Integer idUsuario);
+
+    List<Movimentacao> findByIdCaixa(Integer idCaixa);
+
+    List<Movimentacao> findByIdPeriodo(Integer idPeriodo);
+
+    List<Movimentacao> search(Movimentacao filtro);
+
+    List<Movimentacao> search(Movimentacao filtro, int page, int size);
+}

--- a/src/main/java/dao/api/RotinaDao.java
+++ b/src/main/java/dao/api/RotinaDao.java
@@ -1,0 +1,41 @@
+// path: src/main/java/dao/api/RotinaDao.java
+package dao.api;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import exception.RotinaException;
+import model.Rotina;
+
+public interface RotinaDao {
+
+    void create(Rotina rotina) throws RotinaException;
+
+    Rotina update(Rotina rotina) throws RotinaException;
+
+    void deleteById(Integer id) throws RotinaException;
+
+    Rotina findById(Integer id) throws RotinaException;
+
+    List<Rotina> findAll();
+
+    List<Rotina> findAll(int page, int size);
+
+    List<Rotina> findByNome(String nome);
+
+    List<Rotina> findByInicio(LocalDate inicio);
+
+    List<Rotina> findByFim(LocalDate fim);
+
+    List<Rotina> findByDescricao(String descricao);
+
+    List<Rotina> findByStatus(Integer status);
+
+    List<Rotina> findByPonto(Integer ponto);
+
+    List<Rotina> findByIdUsuario(Integer idUsuario);
+
+    List<Rotina> search(Rotina filtro);
+
+    List<Rotina> search(Rotina filtro, int page, int size);
+}

--- a/src/main/java/dao/impl/FornecedorDaoNativeImpl.java
+++ b/src/main/java/dao/impl/FornecedorDaoNativeImpl.java
@@ -1,0 +1,285 @@
+// path: src/main/java/dao/impl/FornecedorDaoNativeImpl.java
+package dao.impl;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import dao.api.FornecedorDao;
+import exception.FornecedorException;
+import infra.EntityManagerUtil;
+import infra.Logger;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import model.Fornecedor;
+
+public class FornecedorDaoNativeImpl implements FornecedorDao {
+
+    @Override
+    public void create(Fornecedor fornecedor) throws FornecedorException {
+        Logger.info("FornecedorDaoNativeImpl.create - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "INSERT INTO Fornecedor (id_fornecedor, nome, foto, endereco, online) " +
+                    "VALUES (:id, :nome, :foto, :endereco, :online)";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("id", fornecedor.getIdFornecedor());
+            query.setParameter("nome", fornecedor.getNome());
+            query.setParameter("foto", fornecedor.getFoto());
+            query.setParameter("endereco", fornecedor.getEndereco());
+            query.setParameter("online", fornecedor.getOnline());
+            query.executeUpdate();
+            em.getTransaction().commit();
+            Logger.info("FornecedorDaoNativeImpl.create - sucesso");
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("FornecedorDaoNativeImpl.create - erro", e);
+            throw new FornecedorException("Erro ao criar Fornecedor", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Fornecedor update(Fornecedor fornecedor) throws FornecedorException {
+        Logger.info("FornecedorDaoNativeImpl.update - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "UPDATE Fornecedor SET nome=:nome, foto=:foto, endereco=:endereco, online=:online WHERE id_fornecedor=:id";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("nome", fornecedor.getNome());
+            query.setParameter("foto", fornecedor.getFoto());
+            query.setParameter("endereco", fornecedor.getEndereco());
+            query.setParameter("online", fornecedor.getOnline());
+            query.setParameter("id", fornecedor.getIdFornecedor());
+            int updated = query.executeUpdate();
+            if (updated == 0) {
+                throw new FornecedorException("Fornecedor não encontrado: id=" + fornecedor.getIdFornecedor());
+            }
+            em.getTransaction().commit();
+            Logger.info("FornecedorDaoNativeImpl.update - sucesso");
+            return findById(fornecedor.getIdFornecedor());
+        } catch (FornecedorException e) {
+            em.getTransaction().rollback();
+            Logger.error("FornecedorDaoNativeImpl.update - erro", e);
+            throw e;
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("FornecedorDaoNativeImpl.update - erro", e);
+            throw new FornecedorException("Erro ao atualizar Fornecedor", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public void deleteById(Integer id) throws FornecedorException {
+        Logger.info("FornecedorDaoNativeImpl.deleteById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "DELETE FROM Fornecedor WHERE id_fornecedor=:id";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("id", id);
+            int deleted = query.executeUpdate();
+            if (deleted == 0) {
+                throw new FornecedorException("Fornecedor não encontrado: id=" + id);
+            }
+            em.getTransaction().commit();
+            Logger.info("FornecedorDaoNativeImpl.deleteById - sucesso");
+        } catch (FornecedorException e) {
+            em.getTransaction().rollback();
+            Logger.error("FornecedorDaoNativeImpl.deleteById - erro", e);
+            throw e;
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("FornecedorDaoNativeImpl.deleteById - erro", e);
+            throw new FornecedorException("Erro ao deletar Fornecedor", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Fornecedor findById(Integer id) throws FornecedorException {
+        Logger.info("FornecedorDaoNativeImpl.findById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_fornecedor, nome, endereco, online FROM Fornecedor WHERE id_fornecedor=:id";
+            Query query = em.createNativeQuery(sql, Fornecedor.class);
+            query.setParameter("id", id);
+            Fornecedor f = (Fornecedor) query.getSingleResult();
+            Logger.info("FornecedorDaoNativeImpl.findById - sucesso");
+            return f;
+        } catch (Exception e) {
+            Logger.error("FornecedorDaoNativeImpl.findById - erro", e);
+            throw new FornecedorException("Fornecedor não encontrado: id=" + id, e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Fornecedor findWithFotoById(Integer id) throws FornecedorException {
+        Logger.info("FornecedorDaoNativeImpl.findWithFotoById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_fornecedor, nome, foto, endereco, online FROM Fornecedor WHERE id_fornecedor=:id";
+            Query query = em.createNativeQuery(sql, Fornecedor.class);
+            query.setParameter("id", id);
+            Fornecedor f = (Fornecedor) query.getSingleResult();
+            Logger.info("FornecedorDaoNativeImpl.findWithFotoById - sucesso");
+            return f;
+        } catch (Exception e) {
+            Logger.error("FornecedorDaoNativeImpl.findWithFotoById - erro", e);
+            throw new FornecedorException("Fornecedor não encontrado: id=" + id, e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Fornecedor> findAll() {
+        Logger.info("FornecedorDaoNativeImpl.findAll - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_fornecedor, nome, endereco, online FROM Fornecedor";
+            Query query = em.createNativeQuery(sql, Fornecedor.class);
+            List<Fornecedor> list = query.getResultList();
+            Logger.info("FornecedorDaoNativeImpl.findAll - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Fornecedor> findAll(int page, int size) {
+        Logger.info("FornecedorDaoNativeImpl.findAll(page) - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_fornecedor, nome, endereco, online FROM Fornecedor LIMIT :limit OFFSET :offset";
+            Query query = em.createNativeQuery(sql, Fornecedor.class);
+            query.setParameter("limit", size);
+            query.setParameter("offset", page * size);
+            List<Fornecedor> list = query.getResultList();
+            Logger.info("FornecedorDaoNativeImpl.findAll(page) - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Fornecedor> findByNome(String nome) {
+        Logger.info("FornecedorDaoNativeImpl.findByNome - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_fornecedor, nome, endereco, online FROM Fornecedor WHERE nome=:nome";
+            Query query = em.createNativeQuery(sql, Fornecedor.class);
+            query.setParameter("nome", nome);
+            List<Fornecedor> list = query.getResultList();
+            Logger.info("FornecedorDaoNativeImpl.findByNome - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Fornecedor> findByFoto(byte[] foto) {
+        Logger.info("FornecedorDaoNativeImpl.findByFoto - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_fornecedor, nome, foto, endereco, online FROM Fornecedor WHERE foto=:foto";
+            Query query = em.createNativeQuery(sql, Fornecedor.class);
+            query.setParameter("foto", foto);
+            List<Fornecedor> list = query.getResultList();
+            Logger.info("FornecedorDaoNativeImpl.findByFoto - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Fornecedor> findByEndereco(String endereco) {
+        Logger.info("FornecedorDaoNativeImpl.findByEndereco - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_fornecedor, nome, endereco, online FROM Fornecedor WHERE endereco=:endereco";
+            Query query = em.createNativeQuery(sql, Fornecedor.class);
+            query.setParameter("endereco", endereco);
+            List<Fornecedor> list = query.getResultList();
+            Logger.info("FornecedorDaoNativeImpl.findByEndereco - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Fornecedor> findByOnline(Boolean online) {
+        Logger.info("FornecedorDaoNativeImpl.findByOnline - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_fornecedor, nome, endereco, online FROM Fornecedor WHERE online=:online";
+            Query query = em.createNativeQuery(sql, Fornecedor.class);
+            query.setParameter("online", online);
+            List<Fornecedor> list = query.getResultList();
+            Logger.info("FornecedorDaoNativeImpl.findByOnline - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Fornecedor> search(Fornecedor filtro) {
+        return search(filtro, -1, -1);
+    }
+
+    @Override
+    public List<Fornecedor> search(Fornecedor filtro, int page, int size) {
+        Logger.info("FornecedorDaoNativeImpl.search - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            StringBuilder sb = new StringBuilder("SELECT id_fornecedor, nome, endereco, online FROM Fornecedor WHERE 1=1");
+            Map<String, Object> params = new HashMap<>();
+            if (filtro.getNome() != null && !filtro.getNome().isEmpty()) {
+                sb.append(" AND nome=:nome");
+                params.put("nome", filtro.getNome());
+            }
+            if (filtro.getFoto() != null) {
+                sb.append(" AND foto=:foto");
+                params.put("foto", filtro.getFoto());
+            }
+            if (filtro.getEndereco() != null && !filtro.getEndereco().isEmpty()) {
+                sb.append(" AND endereco=:endereco");
+                params.put("endereco", filtro.getEndereco());
+            }
+            if (filtro.getOnline() != null) {
+                sb.append(" AND online=:online");
+                params.put("online", filtro.getOnline());
+            }
+            if (page >= 0 && size > 0) {
+                sb.append(" LIMIT :limit OFFSET :offset");
+            }
+            Query query = em.createNativeQuery(sb.toString(), Fornecedor.class);
+            for (Map.Entry<String, Object> e : params.entrySet()) {
+                query.setParameter(e.getKey(), e.getValue());
+            }
+            if (page >= 0 && size > 0) {
+                query.setParameter("limit", size);
+                query.setParameter("offset", page * size);
+            }
+            List<Fornecedor> list = query.getResultList();
+            Logger.info("FornecedorDaoNativeImpl.search - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+}

--- a/src/main/java/dao/impl/IngredienteDaoNativeImpl.java
+++ b/src/main/java/dao/impl/IngredienteDaoNativeImpl.java
@@ -1,0 +1,263 @@
+// path: src/main/java/dao/impl/IngredienteDaoNativeImpl.java
+package dao.impl;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import dao.api.IngredienteDao;
+import exception.IngredienteException;
+import infra.EntityManagerUtil;
+import infra.Logger;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import model.Ingrediente;
+
+public class IngredienteDaoNativeImpl implements IngredienteDao {
+
+    @Override
+    public void create(Ingrediente ingrediente) throws IngredienteException {
+        Logger.info("IngredienteDaoNativeImpl.create - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "INSERT INTO Ingrediente (id_ingrediente, nome, descricao, foto) " +
+                    "VALUES (:id, :nome, :descricao, :foto)";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("id", ingrediente.getIdIngrediente());
+            query.setParameter("nome", ingrediente.getNome());
+            query.setParameter("descricao", ingrediente.getDescricao());
+            query.setParameter("foto", ingrediente.getFoto());
+            query.executeUpdate();
+            em.getTransaction().commit();
+            Logger.info("IngredienteDaoNativeImpl.create - sucesso");
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("IngredienteDaoNativeImpl.create - erro", e);
+            throw new IngredienteException("Erro ao criar Ingrediente", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Ingrediente update(Ingrediente ingrediente) throws IngredienteException {
+        Logger.info("IngredienteDaoNativeImpl.update - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "UPDATE Ingrediente SET nome=:nome, descricao=:descricao, foto=:foto WHERE id_ingrediente=:id";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("nome", ingrediente.getNome());
+            query.setParameter("descricao", ingrediente.getDescricao());
+            query.setParameter("foto", ingrediente.getFoto());
+            query.setParameter("id", ingrediente.getIdIngrediente());
+            int updated = query.executeUpdate();
+            if (updated == 0) {
+                throw new IngredienteException("Ingrediente não encontrado: id=" + ingrediente.getIdIngrediente());
+            }
+            em.getTransaction().commit();
+            Logger.info("IngredienteDaoNativeImpl.update - sucesso");
+            return findById(ingrediente.getIdIngrediente());
+        } catch (IngredienteException e) {
+            em.getTransaction().rollback();
+            Logger.error("IngredienteDaoNativeImpl.update - erro", e);
+            throw e;
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("IngredienteDaoNativeImpl.update - erro", e);
+            throw new IngredienteException("Erro ao atualizar Ingrediente", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public void deleteById(Integer id) throws IngredienteException {
+        Logger.info("IngredienteDaoNativeImpl.deleteById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "DELETE FROM Ingrediente WHERE id_ingrediente=:id";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("id", id);
+            int deleted = query.executeUpdate();
+            if (deleted == 0) {
+                throw new IngredienteException("Ingrediente não encontrado: id=" + id);
+            }
+            em.getTransaction().commit();
+            Logger.info("IngredienteDaoNativeImpl.deleteById - sucesso");
+        } catch (IngredienteException e) {
+            em.getTransaction().rollback();
+            Logger.error("IngredienteDaoNativeImpl.deleteById - erro", e);
+            throw e;
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("IngredienteDaoNativeImpl.deleteById - erro", e);
+            throw new IngredienteException("Erro ao deletar Ingrediente", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Ingrediente findById(Integer id) throws IngredienteException {
+        Logger.info("IngredienteDaoNativeImpl.findById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_ingrediente, nome, descricao FROM Ingrediente WHERE id_ingrediente=:id";
+            Query query = em.createNativeQuery(sql, Ingrediente.class);
+            query.setParameter("id", id);
+            Ingrediente i = (Ingrediente) query.getSingleResult();
+            Logger.info("IngredienteDaoNativeImpl.findById - sucesso");
+            return i;
+        } catch (Exception e) {
+            Logger.error("IngredienteDaoNativeImpl.findById - erro", e);
+            throw new IngredienteException("Ingrediente não encontrado: id=" + id, e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Ingrediente findWithFotoById(Integer id) throws IngredienteException {
+        Logger.info("IngredienteDaoNativeImpl.findWithFotoById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_ingrediente, nome, descricao, foto FROM Ingrediente WHERE id_ingrediente=:id";
+            Query query = em.createNativeQuery(sql, Ingrediente.class);
+            query.setParameter("id", id);
+            Ingrediente i = (Ingrediente) query.getSingleResult();
+            Logger.info("IngredienteDaoNativeImpl.findWithFotoById - sucesso");
+            return i;
+        } catch (Exception e) {
+            Logger.error("IngredienteDaoNativeImpl.findWithFotoById - erro", e);
+            throw new IngredienteException("Ingrediente não encontrado: id=" + id, e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Ingrediente> findAll() {
+        Logger.info("IngredienteDaoNativeImpl.findAll - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_ingrediente, nome, descricao FROM Ingrediente";
+            Query query = em.createNativeQuery(sql, Ingrediente.class);
+            List<Ingrediente> list = query.getResultList();
+            Logger.info("IngredienteDaoNativeImpl.findAll - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Ingrediente> findAll(int page, int size) {
+        Logger.info("IngredienteDaoNativeImpl.findAll(page) - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_ingrediente, nome, descricao FROM Ingrediente LIMIT :limit OFFSET :offset";
+            Query query = em.createNativeQuery(sql, Ingrediente.class);
+            query.setParameter("limit", size);
+            query.setParameter("offset", page * size);
+            List<Ingrediente> list = query.getResultList();
+            Logger.info("IngredienteDaoNativeImpl.findAll(page) - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Ingrediente> findByFoto(byte[] foto) {
+        Logger.info("IngredienteDaoNativeImpl.findByFoto - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_ingrediente, nome, descricao, foto FROM Ingrediente WHERE foto=:foto";
+            Query query = em.createNativeQuery(sql, Ingrediente.class);
+            query.setParameter("foto", foto);
+            List<Ingrediente> list = query.getResultList();
+            Logger.info("IngredienteDaoNativeImpl.findByFoto - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Ingrediente> findByNome(String nome) {
+        Logger.info("IngredienteDaoNativeImpl.findByNome - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_ingrediente, nome, descricao FROM Ingrediente WHERE nome=:nome";
+            Query query = em.createNativeQuery(sql, Ingrediente.class);
+            query.setParameter("nome", nome);
+            List<Ingrediente> list = query.getResultList();
+            Logger.info("IngredienteDaoNativeImpl.findByNome - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Ingrediente> findByDescricao(String descricao) {
+        Logger.info("IngredienteDaoNativeImpl.findByDescricao - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_ingrediente, nome, descricao FROM Ingrediente WHERE descricao=:descricao";
+            Query query = em.createNativeQuery(sql, Ingrediente.class);
+            query.setParameter("descricao", descricao);
+            List<Ingrediente> list = query.getResultList();
+            Logger.info("IngredienteDaoNativeImpl.findByDescricao - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Ingrediente> search(Ingrediente filtro) {
+        return search(filtro, -1, -1);
+    }
+
+    @Override
+    public List<Ingrediente> search(Ingrediente filtro, int page, int size) {
+        Logger.info("IngredienteDaoNativeImpl.search - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            StringBuilder sb = new StringBuilder("SELECT id_ingrediente, nome, descricao FROM Ingrediente WHERE 1=1");
+            Map<String, Object> params = new HashMap<>();
+            if (filtro.getFoto() != null) {
+                sb.append(" AND foto=:foto");
+                params.put("foto", filtro.getFoto());
+            }
+            if (filtro.getNome() != null && !filtro.getNome().isEmpty()) {
+                sb.append(" AND nome=:nome");
+                params.put("nome", filtro.getNome());
+            }
+            if (filtro.getDescricao() != null && !filtro.getDescricao().isEmpty()) {
+                sb.append(" AND descricao=:descricao");
+                params.put("descricao", filtro.getDescricao());
+            }
+            if (page >= 0 && size > 0) {
+                sb.append(" LIMIT :limit OFFSET :offset");
+            }
+            Query query = em.createNativeQuery(sb.toString(), Ingrediente.class);
+            for (Map.Entry<String, Object> e : params.entrySet()) {
+                query.setParameter(e.getKey(), e.getValue());
+            }
+            if (page >= 0 && size > 0) {
+                query.setParameter("limit", size);
+                query.setParameter("offset", page * size);
+            }
+            List<Ingrediente> list = query.getResultList();
+            Logger.info("IngredienteDaoNativeImpl.search - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+}

--- a/src/main/java/dao/impl/MovimentacaoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/MovimentacaoDaoNativeImpl.java
@@ -1,0 +1,377 @@
+// path: src/main/java/dao/impl/MovimentacaoDaoNativeImpl.java
+package dao.impl;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import dao.api.MovimentacaoDao;
+import exception.MovimentacaoException;
+import infra.EntityManagerUtil;
+import infra.Logger;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import model.Movimentacao;
+
+public class MovimentacaoDaoNativeImpl implements MovimentacaoDao {
+
+    @Override
+    public void create(Movimentacao movimentacao) throws MovimentacaoException {
+        Logger.info("MovimentacaoDaoNativeImpl.create - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "INSERT INTO Movimentacao (id_movimentacao, desconto, vantagem, liquido, tipo, status, ponto, id_usuario, id_caixa, id_periodo) " +
+                    "VALUES (:id, :desconto, :vantagem, :liquido, :tipo, :status, :ponto, :idUsuario, :idCaixa, :idPeriodo)";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("id", movimentacao.getIdMovimentacao());
+            query.setParameter("desconto", movimentacao.getDesconto());
+            query.setParameter("vantagem", movimentacao.getVantagem());
+            query.setParameter("liquido", movimentacao.getLiquido());
+            query.setParameter("tipo", movimentacao.getTipo());
+            query.setParameter("status", movimentacao.getStatus());
+            query.setParameter("ponto", movimentacao.getPonto());
+            query.setParameter("idUsuario", movimentacao.getIdUsuario());
+            query.setParameter("idCaixa", movimentacao.getIdCaixa());
+            query.setParameter("idPeriodo", movimentacao.getIdPeriodo());
+            query.executeUpdate();
+            em.getTransaction().commit();
+            Logger.info("MovimentacaoDaoNativeImpl.create - sucesso");
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("MovimentacaoDaoNativeImpl.create - erro", e);
+            throw new MovimentacaoException("Erro ao criar Movimentacao", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Movimentacao update(Movimentacao movimentacao) throws MovimentacaoException {
+        Logger.info("MovimentacaoDaoNativeImpl.update - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "UPDATE Movimentacao SET desconto=:desconto, vantagem=:vantagem, liquido=:liquido, tipo=:tipo, status=:status, ponto=:ponto, id_usuario=:idUsuario, id_caixa=:idCaixa, id_periodo=:idPeriodo WHERE id_movimentacao=:id";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("desconto", movimentacao.getDesconto());
+            query.setParameter("vantagem", movimentacao.getVantagem());
+            query.setParameter("liquido", movimentacao.getLiquido());
+            query.setParameter("tipo", movimentacao.getTipo());
+            query.setParameter("status", movimentacao.getStatus());
+            query.setParameter("ponto", movimentacao.getPonto());
+            query.setParameter("idUsuario", movimentacao.getIdUsuario());
+            query.setParameter("idCaixa", movimentacao.getIdCaixa());
+            query.setParameter("idPeriodo", movimentacao.getIdPeriodo());
+            query.setParameter("id", movimentacao.getIdMovimentacao());
+            int updated = query.executeUpdate();
+            if (updated == 0) {
+                throw new MovimentacaoException("Movimentacao não encontrada: id=" + movimentacao.getIdMovimentacao());
+            }
+            em.getTransaction().commit();
+            Logger.info("MovimentacaoDaoNativeImpl.update - sucesso");
+            return findById(movimentacao.getIdMovimentacao());
+        } catch (MovimentacaoException e) {
+            em.getTransaction().rollback();
+            Logger.error("MovimentacaoDaoNativeImpl.update - erro", e);
+            throw e;
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("MovimentacaoDaoNativeImpl.update - erro", e);
+            throw new MovimentacaoException("Erro ao atualizar Movimentacao", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public void deleteById(Integer id) throws MovimentacaoException {
+        Logger.info("MovimentacaoDaoNativeImpl.deleteById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "DELETE FROM Movimentacao WHERE id_movimentacao=:id";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("id", id);
+            int deleted = query.executeUpdate();
+            if (deleted == 0) {
+                throw new MovimentacaoException("Movimentacao não encontrada: id=" + id);
+            }
+            em.getTransaction().commit();
+            Logger.info("MovimentacaoDaoNativeImpl.deleteById - sucesso");
+        } catch (MovimentacaoException e) {
+            em.getTransaction().rollback();
+            Logger.error("MovimentacaoDaoNativeImpl.deleteById - erro", e);
+            throw e;
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("MovimentacaoDaoNativeImpl.deleteById - erro", e);
+            throw new MovimentacaoException("Erro ao deletar Movimentacao", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Movimentacao findById(Integer id) throws MovimentacaoException {
+        Logger.info("MovimentacaoDaoNativeImpl.findById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_movimentacao, desconto, vantagem, liquido, tipo, status, ponto, id_usuario, id_caixa, id_periodo FROM Movimentacao WHERE id_movimentacao=:id";
+            Query query = em.createNativeQuery(sql, Movimentacao.class);
+            query.setParameter("id", id);
+            Movimentacao m = (Movimentacao) query.getSingleResult();
+            Logger.info("MovimentacaoDaoNativeImpl.findById - sucesso");
+            return m;
+        } catch (Exception e) {
+            Logger.error("MovimentacaoDaoNativeImpl.findById - erro", e);
+            throw new MovimentacaoException("Movimentacao não encontrada: id=" + id, e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Movimentacao> findAll() {
+        Logger.info("MovimentacaoDaoNativeImpl.findAll - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_movimentacao, desconto, vantagem, liquido, tipo, status, ponto, id_usuario, id_caixa, id_periodo FROM Movimentacao";
+            Query query = em.createNativeQuery(sql, Movimentacao.class);
+            List<Movimentacao> list = query.getResultList();
+            Logger.info("MovimentacaoDaoNativeImpl.findAll - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Movimentacao> findAll(int page, int size) {
+        Logger.info("MovimentacaoDaoNativeImpl.findAll(page) - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_movimentacao, desconto, vantagem, liquido, tipo, status, ponto, id_usuario, id_caixa, id_periodo FROM Movimentacao LIMIT :limit OFFSET :offset";
+            Query query = em.createNativeQuery(sql, Movimentacao.class);
+            query.setParameter("limit", size);
+            query.setParameter("offset", page * size);
+            List<Movimentacao> list = query.getResultList();
+            Logger.info("MovimentacaoDaoNativeImpl.findAll(page) - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Movimentacao> findByDesconto(BigDecimal desconto) {
+        Logger.info("MovimentacaoDaoNativeImpl.findByDesconto - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_movimentacao, desconto, vantagem, liquido, tipo, status, ponto, id_usuario, id_caixa, id_periodo FROM Movimentacao WHERE desconto=:desconto";
+            Query query = em.createNativeQuery(sql, Movimentacao.class);
+            query.setParameter("desconto", desconto);
+            List<Movimentacao> list = query.getResultList();
+            Logger.info("MovimentacaoDaoNativeImpl.findByDesconto - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Movimentacao> findByVantagem(BigDecimal vantagem) {
+        Logger.info("MovimentacaoDaoNativeImpl.findByVantagem - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_movimentacao, desconto, vantagem, liquido, tipo, status, ponto, id_usuario, id_caixa, id_periodo FROM Movimentacao WHERE vantagem=:vantagem";
+            Query query = em.createNativeQuery(sql, Movimentacao.class);
+            query.setParameter("vantagem", vantagem);
+            List<Movimentacao> list = query.getResultList();
+            Logger.info("MovimentacaoDaoNativeImpl.findByVantagem - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Movimentacao> findByLiquido(BigDecimal liquido) {
+        Logger.info("MovimentacaoDaoNativeImpl.findByLiquido - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_movimentacao, desconto, vantagem, liquido, tipo, status, ponto, id_usuario, id_caixa, id_periodo FROM Movimentacao WHERE liquido=:liquido";
+            Query query = em.createNativeQuery(sql, Movimentacao.class);
+            query.setParameter("liquido", liquido);
+            List<Movimentacao> list = query.getResultList();
+            Logger.info("MovimentacaoDaoNativeImpl.findByLiquido - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Movimentacao> findByTipo(Integer tipo) {
+        Logger.info("MovimentacaoDaoNativeImpl.findByTipo - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_movimentacao, desconto, vantagem, liquido, tipo, status, ponto, id_usuario, id_caixa, id_periodo FROM Movimentacao WHERE tipo=:tipo";
+            Query query = em.createNativeQuery(sql, Movimentacao.class);
+            query.setParameter("tipo", tipo);
+            List<Movimentacao> list = query.getResultList();
+            Logger.info("MovimentacaoDaoNativeImpl.findByTipo - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Movimentacao> findByStatus(Integer status) {
+        Logger.info("MovimentacaoDaoNativeImpl.findByStatus - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_movimentacao, desconto, vantagem, liquido, tipo, status, ponto, id_usuario, id_caixa, id_periodo FROM Movimentacao WHERE status=:status";
+            Query query = em.createNativeQuery(sql, Movimentacao.class);
+            query.setParameter("status", status);
+            List<Movimentacao> list = query.getResultList();
+            Logger.info("MovimentacaoDaoNativeImpl.findByStatus - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Movimentacao> findByPonto(Integer ponto) {
+        Logger.info("MovimentacaoDaoNativeImpl.findByPonto - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_movimentacao, desconto, vantagem, liquido, tipo, status, ponto, id_usuario, id_caixa, id_periodo FROM Movimentacao WHERE ponto=:ponto";
+            Query query = em.createNativeQuery(sql, Movimentacao.class);
+            query.setParameter("ponto", ponto);
+            List<Movimentacao> list = query.getResultList();
+            Logger.info("MovimentacaoDaoNativeImpl.findByPonto - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Movimentacao> findByIdUsuario(Integer idUsuario) {
+        Logger.info("MovimentacaoDaoNativeImpl.findByIdUsuario - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_movimentacao, desconto, vantagem, liquido, tipo, status, ponto, id_usuario, id_caixa, id_periodo FROM Movimentacao WHERE id_usuario=:idUsuario";
+            Query query = em.createNativeQuery(sql, Movimentacao.class);
+            query.setParameter("idUsuario", idUsuario);
+            List<Movimentacao> list = query.getResultList();
+            Logger.info("MovimentacaoDaoNativeImpl.findByIdUsuario - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Movimentacao> findByIdCaixa(Integer idCaixa) {
+        Logger.info("MovimentacaoDaoNativeImpl.findByIdCaixa - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_movimentacao, desconto, vantagem, liquido, tipo, status, ponto, id_usuario, id_caixa, id_periodo FROM Movimentacao WHERE id_caixa=:idCaixa";
+            Query query = em.createNativeQuery(sql, Movimentacao.class);
+            query.setParameter("idCaixa", idCaixa);
+            List<Movimentacao> list = query.getResultList();
+            Logger.info("MovimentacaoDaoNativeImpl.findByIdCaixa - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Movimentacao> findByIdPeriodo(Integer idPeriodo) {
+        Logger.info("MovimentacaoDaoNativeImpl.findByIdPeriodo - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_movimentacao, desconto, vantagem, liquido, tipo, status, ponto, id_usuario, id_caixa, id_periodo FROM Movimentacao WHERE id_periodo=:idPeriodo";
+            Query query = em.createNativeQuery(sql, Movimentacao.class);
+            query.setParameter("idPeriodo", idPeriodo);
+            List<Movimentacao> list = query.getResultList();
+            Logger.info("MovimentacaoDaoNativeImpl.findByIdPeriodo - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Movimentacao> search(Movimentacao filtro) {
+        return search(filtro, -1, -1);
+    }
+
+    @Override
+    public List<Movimentacao> search(Movimentacao filtro, int page, int size) {
+        Logger.info("MovimentacaoDaoNativeImpl.search - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            StringBuilder sb = new StringBuilder("SELECT id_movimentacao, desconto, vantagem, liquido, tipo, status, ponto, id_usuario, id_caixa, id_periodo FROM Movimentacao WHERE 1=1");
+            Map<String, Object> params = new HashMap<>();
+            if (filtro.getDesconto() != null) {
+                sb.append(" AND desconto=:desconto");
+                params.put("desconto", filtro.getDesconto());
+            }
+            if (filtro.getVantagem() != null) {
+                sb.append(" AND vantagem=:vantagem");
+                params.put("vantagem", filtro.getVantagem());
+            }
+            if (filtro.getLiquido() != null) {
+                sb.append(" AND liquido=:liquido");
+                params.put("liquido", filtro.getLiquido());
+            }
+            if (filtro.getTipo() != null) {
+                sb.append(" AND tipo=:tipo");
+                params.put("tipo", filtro.getTipo());
+            }
+            if (filtro.getStatus() != null) {
+                sb.append(" AND status=:status");
+                params.put("status", filtro.getStatus());
+            }
+            if (filtro.getPonto() != null) {
+                sb.append(" AND ponto=:ponto");
+                params.put("ponto", filtro.getPonto());
+            }
+            if (filtro.getIdUsuario() != null) {
+                sb.append(" AND id_usuario=:idUsuario");
+                params.put("idUsuario", filtro.getIdUsuario());
+            }
+            if (filtro.getIdCaixa() != null) {
+                sb.append(" AND id_caixa=:idCaixa");
+                params.put("idCaixa", filtro.getIdCaixa());
+            }
+            if (filtro.getIdPeriodo() != null) {
+                sb.append(" AND id_periodo=:idPeriodo");
+                params.put("idPeriodo", filtro.getIdPeriodo());
+            }
+            if (page >= 0 && size > 0) {
+                sb.append(" LIMIT :limit OFFSET :offset");
+            }
+            Query query = em.createNativeQuery(sb.toString(), Movimentacao.class);
+            for (Map.Entry<String, Object> e : params.entrySet()) {
+                query.setParameter(e.getKey(), e.getValue());
+            }
+            if (page >= 0 && size > 0) {
+                query.setParameter("limit", size);
+                query.setParameter("offset", page * size);
+            }
+            List<Movimentacao> list = query.getResultList();
+            Logger.info("MovimentacaoDaoNativeImpl.search - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+}

--- a/src/main/java/dao/impl/RotinaDaoNativeImpl.java
+++ b/src/main/java/dao/impl/RotinaDaoNativeImpl.java
@@ -1,0 +1,333 @@
+// path: src/main/java/dao/impl/RotinaDaoNativeImpl.java
+package dao.impl;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import dao.api.RotinaDao;
+import exception.RotinaException;
+import infra.EntityManagerUtil;
+import infra.Logger;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import model.Rotina;
+
+public class RotinaDaoNativeImpl implements RotinaDao {
+
+    @Override
+    public void create(Rotina rotina) throws RotinaException {
+        Logger.info("RotinaDaoNativeImpl.create - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "INSERT INTO Rotina (id_rotina, nome, inicio, fim, descricao, status, ponto, id_usuario) " +
+                    "VALUES (:id, :nome, :inicio, :fim, :descricao, :status, :ponto, :idUsuario)";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("id", rotina.getIdRotina());
+            query.setParameter("nome", rotina.getNome());
+            query.setParameter("inicio", rotina.getInicio());
+            query.setParameter("fim", rotina.getFim());
+            query.setParameter("descricao", rotina.getDescricao());
+            query.setParameter("status", rotina.getStatus());
+            query.setParameter("ponto", rotina.getPonto());
+            query.setParameter("idUsuario", rotina.getIdUsuario());
+            query.executeUpdate();
+            em.getTransaction().commit();
+            Logger.info("RotinaDaoNativeImpl.create - sucesso");
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("RotinaDaoNativeImpl.create - erro", e);
+            throw new RotinaException("Erro ao criar Rotina", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Rotina update(Rotina rotina) throws RotinaException {
+        Logger.info("RotinaDaoNativeImpl.update - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "UPDATE Rotina SET nome=:nome, inicio=:inicio, fim=:fim, descricao=:descricao, status=:status, ponto=:ponto, id_usuario=:idUsuario WHERE id_rotina=:id";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("nome", rotina.getNome());
+            query.setParameter("inicio", rotina.getInicio());
+            query.setParameter("fim", rotina.getFim());
+            query.setParameter("descricao", rotina.getDescricao());
+            query.setParameter("status", rotina.getStatus());
+            query.setParameter("ponto", rotina.getPonto());
+            query.setParameter("idUsuario", rotina.getIdUsuario());
+            query.setParameter("id", rotina.getIdRotina());
+            int updated = query.executeUpdate();
+            if (updated == 0) {
+                throw new RotinaException("Rotina não encontrada: id=" + rotina.getIdRotina());
+            }
+            em.getTransaction().commit();
+            Logger.info("RotinaDaoNativeImpl.update - sucesso");
+            return findById(rotina.getIdRotina());
+        } catch (RotinaException e) {
+            em.getTransaction().rollback();
+            Logger.error("RotinaDaoNativeImpl.update - erro", e);
+            throw e;
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("RotinaDaoNativeImpl.update - erro", e);
+            throw new RotinaException("Erro ao atualizar Rotina", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public void deleteById(Integer id) throws RotinaException {
+        Logger.info("RotinaDaoNativeImpl.deleteById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "DELETE FROM Rotina WHERE id_rotina=:id";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("id", id);
+            int deleted = query.executeUpdate();
+            if (deleted == 0) {
+                throw new RotinaException("Rotina não encontrada: id=" + id);
+            }
+            em.getTransaction().commit();
+            Logger.info("RotinaDaoNativeImpl.deleteById - sucesso");
+        } catch (RotinaException e) {
+            em.getTransaction().rollback();
+            Logger.error("RotinaDaoNativeImpl.deleteById - erro", e);
+            throw e;
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("RotinaDaoNativeImpl.deleteById - erro", e);
+            throw new RotinaException("Erro ao deletar Rotina", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Rotina findById(Integer id) throws RotinaException {
+        Logger.info("RotinaDaoNativeImpl.findById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_rotina, nome, inicio, fim, descricao, status, ponto, id_usuario FROM Rotina WHERE id_rotina=:id";
+            Query query = em.createNativeQuery(sql, Rotina.class);
+            query.setParameter("id", id);
+            Rotina r = (Rotina) query.getSingleResult();
+            Logger.info("RotinaDaoNativeImpl.findById - sucesso");
+            return r;
+        } catch (Exception e) {
+            Logger.error("RotinaDaoNativeImpl.findById - erro", e);
+            throw new RotinaException("Rotina não encontrada: id=" + id, e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Rotina> findAll() {
+        Logger.info("RotinaDaoNativeImpl.findAll - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_rotina, nome, inicio, fim, descricao, status, ponto, id_usuario FROM Rotina";
+            Query query = em.createNativeQuery(sql, Rotina.class);
+            List<Rotina> list = query.getResultList();
+            Logger.info("RotinaDaoNativeImpl.findAll - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Rotina> findAll(int page, int size) {
+        Logger.info("RotinaDaoNativeImpl.findAll(page) - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_rotina, nome, inicio, fim, descricao, status, ponto, id_usuario FROM Rotina LIMIT :limit OFFSET :offset";
+            Query query = em.createNativeQuery(sql, Rotina.class);
+            query.setParameter("limit", size);
+            query.setParameter("offset", page * size);
+            List<Rotina> list = query.getResultList();
+            Logger.info("RotinaDaoNativeImpl.findAll(page) - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Rotina> findByNome(String nome) {
+        Logger.info("RotinaDaoNativeImpl.findByNome - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_rotina, nome, inicio, fim, descricao, status, ponto, id_usuario FROM Rotina WHERE nome=:nome";
+            Query query = em.createNativeQuery(sql, Rotina.class);
+            query.setParameter("nome", nome);
+            List<Rotina> list = query.getResultList();
+            Logger.info("RotinaDaoNativeImpl.findByNome - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Rotina> findByInicio(LocalDate inicio) {
+        Logger.info("RotinaDaoNativeImpl.findByInicio - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_rotina, nome, inicio, fim, descricao, status, ponto, id_usuario FROM Rotina WHERE inicio=:inicio";
+            Query query = em.createNativeQuery(sql, Rotina.class);
+            query.setParameter("inicio", inicio);
+            List<Rotina> list = query.getResultList();
+            Logger.info("RotinaDaoNativeImpl.findByInicio - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Rotina> findByFim(LocalDate fim) {
+        Logger.info("RotinaDaoNativeImpl.findByFim - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_rotina, nome, inicio, fim, descricao, status, ponto, id_usuario FROM Rotina WHERE fim=:fim";
+            Query query = em.createNativeQuery(sql, Rotina.class);
+            query.setParameter("fim", fim);
+            List<Rotina> list = query.getResultList();
+            Logger.info("RotinaDaoNativeImpl.findByFim - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Rotina> findByDescricao(String descricao) {
+        Logger.info("RotinaDaoNativeImpl.findByDescricao - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_rotina, nome, inicio, fim, descricao, status, ponto, id_usuario FROM Rotina WHERE descricao=:descricao";
+            Query query = em.createNativeQuery(sql, Rotina.class);
+            query.setParameter("descricao", descricao);
+            List<Rotina> list = query.getResultList();
+            Logger.info("RotinaDaoNativeImpl.findByDescricao - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Rotina> findByStatus(Integer status) {
+        Logger.info("RotinaDaoNativeImpl.findByStatus - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_rotina, nome, inicio, fim, descricao, status, ponto, id_usuario FROM Rotina WHERE status=:status";
+            Query query = em.createNativeQuery(sql, Rotina.class);
+            query.setParameter("status", status);
+            List<Rotina> list = query.getResultList();
+            Logger.info("RotinaDaoNativeImpl.findByStatus - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Rotina> findByPonto(Integer ponto) {
+        Logger.info("RotinaDaoNativeImpl.findByPonto - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_rotina, nome, inicio, fim, descricao, status, ponto, id_usuario FROM Rotina WHERE ponto=:ponto";
+            Query query = em.createNativeQuery(sql, Rotina.class);
+            query.setParameter("ponto", ponto);
+            List<Rotina> list = query.getResultList();
+            Logger.info("RotinaDaoNativeImpl.findByPonto - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Rotina> findByIdUsuario(Integer idUsuario) {
+        Logger.info("RotinaDaoNativeImpl.findByIdUsuario - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_rotina, nome, inicio, fim, descricao, status, ponto, id_usuario FROM Rotina WHERE id_usuario=:idUsuario";
+            Query query = em.createNativeQuery(sql, Rotina.class);
+            query.setParameter("idUsuario", idUsuario);
+            List<Rotina> list = query.getResultList();
+            Logger.info("RotinaDaoNativeImpl.findByIdUsuario - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Rotina> search(Rotina filtro) {
+        return search(filtro, -1, -1);
+    }
+
+    @Override
+    public List<Rotina> search(Rotina filtro, int page, int size) {
+        Logger.info("RotinaDaoNativeImpl.search - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            StringBuilder sb = new StringBuilder("SELECT id_rotina, nome, inicio, fim, descricao, status, ponto, id_usuario FROM Rotina WHERE 1=1");
+            Map<String, Object> params = new HashMap<>();
+            if (filtro.getNome() != null && !filtro.getNome().isEmpty()) {
+                sb.append(" AND nome=:nome");
+                params.put("nome", filtro.getNome());
+            }
+            if (filtro.getInicio() != null) {
+                sb.append(" AND inicio=:inicio");
+                params.put("inicio", filtro.getInicio());
+            }
+            if (filtro.getFim() != null) {
+                sb.append(" AND fim=:fim");
+                params.put("fim", filtro.getFim());
+            }
+            if (filtro.getDescricao() != null && !filtro.getDescricao().isEmpty()) {
+                sb.append(" AND descricao=:descricao");
+                params.put("descricao", filtro.getDescricao());
+            }
+            if (filtro.getStatus() != null) {
+                sb.append(" AND status=:status");
+                params.put("status", filtro.getStatus());
+            }
+            if (filtro.getPonto() != null) {
+                sb.append(" AND ponto=:ponto");
+                params.put("ponto", filtro.getPonto());
+            }
+            if (filtro.getIdUsuario() != null) {
+                sb.append(" AND id_usuario=:idUsuario");
+                params.put("idUsuario", filtro.getIdUsuario());
+            }
+            if (page >= 0 && size > 0) {
+                sb.append(" LIMIT :limit OFFSET :offset");
+            }
+            Query query = em.createNativeQuery(sb.toString(), Rotina.class);
+            for (Map.Entry<String, Object> e : params.entrySet()) {
+                query.setParameter(e.getKey(), e.getValue());
+            }
+            if (page >= 0 && size > 0) {
+                query.setParameter("limit", size);
+                query.setParameter("offset", page * size);
+            }
+            List<Rotina> list = query.getResultList();
+            Logger.info("RotinaDaoNativeImpl.search - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+}

--- a/src/main/java/exception/FornecedorException.java
+++ b/src/main/java/exception/FornecedorException.java
@@ -1,0 +1,12 @@
+// path: src/main/java/exception/FornecedorException.java
+package exception;
+
+public class FornecedorException extends RuntimeException {
+    public FornecedorException(String message) {
+        super(message);
+    }
+
+    public FornecedorException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/exception/IngredienteException.java
+++ b/src/main/java/exception/IngredienteException.java
@@ -1,0 +1,12 @@
+// path: src/main/java/exception/IngredienteException.java
+package exception;
+
+public class IngredienteException extends RuntimeException {
+    public IngredienteException(String message) {
+        super(message);
+    }
+
+    public IngredienteException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/exception/MovimentacaoException.java
+++ b/src/main/java/exception/MovimentacaoException.java
@@ -1,0 +1,12 @@
+// path: src/main/java/exception/MovimentacaoException.java
+package exception;
+
+public class MovimentacaoException extends RuntimeException {
+    public MovimentacaoException(String message) {
+        super(message);
+    }
+
+    public MovimentacaoException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/exception/RotinaException.java
+++ b/src/main/java/exception/RotinaException.java
@@ -1,0 +1,12 @@
+// path: src/main/java/exception/RotinaException.java
+package exception;
+
+public class RotinaException extends RuntimeException {
+    public RotinaException(String message) {
+        super(message);
+    }
+
+    public RotinaException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/infra/EntityManagerUtil.java
+++ b/src/main/java/infra/EntityManagerUtil.java
@@ -1,0 +1,17 @@
+// path: src/main/java/infra/EntityManagerUtil.java
+package infra;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.Persistence;
+
+public class EntityManagerUtil {
+    private static final EntityManagerFactory emf = Persistence.createEntityManagerFactory("rotinamaisPU");
+
+    private EntityManagerUtil() {
+    }
+
+    public static EntityManager getEntityManager() {
+        return emf.createEntityManager();
+    }
+}

--- a/src/main/java/infra/Logger.java
+++ b/src/main/java/infra/Logger.java
@@ -1,0 +1,15 @@
+// path: src/main/java/infra/Logger.java
+package infra;
+
+public class Logger {
+    public static void info(String msg) {
+        System.out.println("INFO: " + msg);
+    }
+
+    public static void error(String msg, Throwable t) {
+        System.err.println("ERROR: " + msg);
+        if (t != null) {
+            t.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/model/Fornecedor.java
+++ b/src/main/java/model/Fornecedor.java
@@ -1,0 +1,95 @@
+// path: src/main/java/model/Fornecedor.java
+package model;
+
+import java.util.Objects;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "Fornecedor")
+public class Fornecedor {
+
+    @Id
+    @Column(name = "id_fornecedor")
+    private Integer idFornecedor;
+
+    @Column(name = "nome")
+    private String nome;
+
+    @Lob
+    @Column(name = "foto")
+    private byte[] foto;
+
+    @Column(name = "endereco")
+    private String endereco;
+
+    @Column(name = "online")
+    private Boolean online;
+
+    public Integer getIdFornecedor() {
+        return idFornecedor;
+    }
+
+    public void setIdFornecedor(Integer idFornecedor) {
+        this.idFornecedor = idFornecedor;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public byte[] getFoto() {
+        return foto;
+    }
+
+    public void setFoto(byte[] foto) {
+        this.foto = foto;
+    }
+
+    public String getEndereco() {
+        return endereco;
+    }
+
+    public void setEndereco(String endereco) {
+        this.endereco = endereco;
+    }
+
+    public Boolean getOnline() {
+        return online;
+    }
+
+    public void setOnline(Boolean online) {
+        this.online = online;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Fornecedor)) return false;
+        Fornecedor that = (Fornecedor) o;
+        return Objects.equals(idFornecedor, that.idFornecedor);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idFornecedor);
+    }
+
+    @Override
+    public String toString() {
+        return "Fornecedor{" +
+                "idFornecedor=" + idFornecedor +
+                ", nome='" + nome + '\'' +
+                ", endereco='" + endereco + '\'' +
+                ", online=" + online +
+                '}';
+    }
+}

--- a/src/main/java/model/Ingrediente.java
+++ b/src/main/java/model/Ingrediente.java
@@ -1,0 +1,83 @@
+// path: src/main/java/model/Ingrediente.java
+package model;
+
+import java.util.Objects;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "Ingrediente")
+public class Ingrediente {
+
+    @Lob
+    @Column(name = "foto")
+    private byte[] foto;
+
+    @Id
+    @Column(name = "id_ingrediente")
+    private Integer idIngrediente;
+
+    @Column(name = "nome")
+    private String nome;
+
+    @Column(name = "descricao")
+    private String descricao;
+
+    public byte[] getFoto() {
+        return foto;
+    }
+
+    public void setFoto(byte[] foto) {
+        this.foto = foto;
+    }
+
+    public Integer getIdIngrediente() {
+        return idIngrediente;
+    }
+
+    public void setIdIngrediente(Integer idIngrediente) {
+        this.idIngrediente = idIngrediente;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public String getDescricao() {
+        return descricao;
+    }
+
+    public void setDescricao(String descricao) {
+        this.descricao = descricao;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Ingrediente)) return false;
+        Ingrediente that = (Ingrediente) o;
+        return Objects.equals(idIngrediente, that.idIngrediente);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idIngrediente);
+    }
+
+    @Override
+    public String toString() {
+        return "Ingrediente{" +
+                "idIngrediente=" + idIngrediente +
+                ", nome='" + nome + '\'' +
+                ", descricao='" + descricao + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/model/Movimentacao.java
+++ b/src/main/java/model/Movimentacao.java
@@ -1,0 +1,155 @@
+// path: src/main/java/model/Movimentacao.java
+package model;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "Movimentacao")
+public class Movimentacao {
+
+    @Id
+    @Column(name = "id_movimentacao")
+    private Integer idMovimentacao;
+
+    @Column(name = "desconto")
+    private BigDecimal desconto;
+
+    @Column(name = "vantagem")
+    private BigDecimal vantagem;
+
+    @Column(name = "liquido")
+    private BigDecimal liquido;
+
+    @Column(name = "tipo")
+    private Integer tipo;
+
+    @Column(name = "status")
+    private Integer status;
+
+    @Column(name = "ponto")
+    private Integer ponto;
+
+    @Column(name = "id_usuario")
+    private Integer idUsuario;
+
+    @Column(name = "id_caixa")
+    private Integer idCaixa;
+
+    @Column(name = "id_periodo")
+    private Integer idPeriodo;
+
+    public Integer getIdMovimentacao() {
+        return idMovimentacao;
+    }
+
+    public void setIdMovimentacao(Integer idMovimentacao) {
+        this.idMovimentacao = idMovimentacao;
+    }
+
+    public BigDecimal getDesconto() {
+        return desconto;
+    }
+
+    public void setDesconto(BigDecimal desconto) {
+        this.desconto = desconto;
+    }
+
+    public BigDecimal getVantagem() {
+        return vantagem;
+    }
+
+    public void setVantagem(BigDecimal vantagem) {
+        this.vantagem = vantagem;
+    }
+
+    public BigDecimal getLiquido() {
+        return liquido;
+    }
+
+    public void setLiquido(BigDecimal liquido) {
+        this.liquido = liquido;
+    }
+
+    public Integer getTipo() {
+        return tipo;
+    }
+
+    public void setTipo(Integer tipo) {
+        this.tipo = tipo;
+    }
+
+    public Integer getStatus() {
+        return status;
+    }
+
+    public void setStatus(Integer status) {
+        this.status = status;
+    }
+
+    public Integer getPonto() {
+        return ponto;
+    }
+
+    public void setPonto(Integer ponto) {
+        this.ponto = ponto;
+    }
+
+    public Integer getIdUsuario() {
+        return idUsuario;
+    }
+
+    public void setIdUsuario(Integer idUsuario) {
+        this.idUsuario = idUsuario;
+    }
+
+    public Integer getIdCaixa() {
+        return idCaixa;
+    }
+
+    public void setIdCaixa(Integer idCaixa) {
+        this.idCaixa = idCaixa;
+    }
+
+    public Integer getIdPeriodo() {
+        return idPeriodo;
+    }
+
+    public void setIdPeriodo(Integer idPeriodo) {
+        this.idPeriodo = idPeriodo;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Movimentacao)) return false;
+        Movimentacao that = (Movimentacao) o;
+        return Objects.equals(idMovimentacao, that.idMovimentacao);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idMovimentacao);
+    }
+
+    @Override
+    public String toString() {
+        return "Movimentacao{" +
+                "idMovimentacao=" + idMovimentacao +
+                ", desconto=" + desconto +
+                ", vantagem=" + vantagem +
+                ", liquido=" + liquido +
+                ", tipo=" + tipo +
+                ", status=" + status +
+                ", ponto=" + ponto +
+                ", idUsuario=" + idUsuario +
+                ", idCaixa=" + idCaixa +
+                ", idPeriodo=" + idPeriodo +
+                '}';
+    }
+}

--- a/src/main/java/model/Rotina.java
+++ b/src/main/java/model/Rotina.java
@@ -1,0 +1,131 @@
+// path: src/main/java/model/Rotina.java
+package model;
+
+import java.time.LocalDate;
+import java.util.Objects;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "Rotina")
+public class Rotina {
+
+    @Id
+    @Column(name = "id_rotina")
+    private Integer idRotina;
+
+    @Column(name = "nome")
+    private String nome;
+
+    @Column(name = "inicio")
+    private LocalDate inicio;
+
+    @Column(name = "fim")
+    private LocalDate fim;
+
+    @Column(name = "descricao")
+    private String descricao;
+
+    @Column(name = "status")
+    private Integer status;
+
+    @Column(name = "ponto")
+    private Integer ponto;
+
+    @Column(name = "id_usuario")
+    private Integer idUsuario;
+
+    public Integer getIdRotina() {
+        return idRotina;
+    }
+
+    public void setIdRotina(Integer idRotina) {
+        this.idRotina = idRotina;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public LocalDate getInicio() {
+        return inicio;
+    }
+
+    public void setInicio(LocalDate inicio) {
+        this.inicio = inicio;
+    }
+
+    public LocalDate getFim() {
+        return fim;
+    }
+
+    public void setFim(LocalDate fim) {
+        this.fim = fim;
+    }
+
+    public String getDescricao() {
+        return descricao;
+    }
+
+    public void setDescricao(String descricao) {
+        this.descricao = descricao;
+    }
+
+    public Integer getStatus() {
+        return status;
+    }
+
+    public void setStatus(Integer status) {
+        this.status = status;
+    }
+
+    public Integer getPonto() {
+        return ponto;
+    }
+
+    public void setPonto(Integer ponto) {
+        this.ponto = ponto;
+    }
+
+    public Integer getIdUsuario() {
+        return idUsuario;
+    }
+
+    public void setIdUsuario(Integer idUsuario) {
+        this.idUsuario = idUsuario;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Rotina)) return false;
+        Rotina rotina = (Rotina) o;
+        return Objects.equals(idRotina, rotina.idRotina);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idRotina);
+    }
+
+    @Override
+    public String toString() {
+        return "Rotina{" +
+                "idRotina=" + idRotina +
+                ", nome='" + nome + '\'' +
+                ", inicio=" + inicio +
+                ", fim=" + fim +
+                ", descricao='" + descricao + '\'' +
+                ", status=" + status +
+                ", ponto=" + ponto +
+                ", idUsuario=" + idUsuario +
+                '}';
+    }
+}

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,14 @@
+<!-- path: src/main/resources/META-INF/persistence.xml -->
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence" version="3.0">
+    <persistence-unit name="rotinamaisPU">
+        <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+        <properties>
+            <property name="jakarta.persistence.jdbc.driver" value="org.postgresql.Driver"/>
+            <property name="jakarta.persistence.jdbc.url" value="jdbc:postgresql://localhost:5432/rotinamais"/>
+            <property name="jakarta.persistence.jdbc.user" value="postgres"/>
+            <property name="jakarta.persistence.jdbc.password" value="postgres"/>
+            <property name="hibernate.dialect" value="org.hibernate.dialect.PostgreSQLDialect"/>
+            <property name="hibernate.hbm2ddl.auto" value="none"/>
+        </properties>
+    </persistence-unit>
+</persistence>


### PR DESCRIPTION
## Summary
- add Movimentacao, Rotina, Fornecedor and Ingrediente JPA models with native DAO layers
- implement controllers with validations and logging, including blob-aware retrieval for Fornecedor and Ingrediente
- remove Lancamento, Documento and Exercicio modules to align scope

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf64cd49288325890fe7732235f5da