### PR TITLE
feat: add monitoring, feeding, training and support entities

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,3 +4,4 @@ RotinaMaisDesktop (estrutura completa)
 - Utilitário de ícones: swing.icon.Icones (PNG/JPG em /resources/icon + fallback Material Icons).
 - Coloque seus PNGs/JPGs de ícones em: src/main/resources/icon/
 - Coloque TimingFramework-0.55.jar em: libs/TimingFramework-0.55.jar (ou ajuste o pom.xml).
+- Exemplos de entidades JPA e DAOs nativos adicionados para Monitoramento, Alimentacao, Treino, Objeto, Site, Caixa e Periodo.

--- a/src/main/java/controller/AlimentacaoController.java
+++ b/src/main/java/controller/AlimentacaoController.java
@@ -1,0 +1,163 @@
+// path: src/main/java/controller/AlimentacaoController.java
+package controller;
+
+import java.util.List;
+
+import dao.api.AlimentacaoDao;
+import exception.AlimentacaoException;
+import infra.Logger;
+import model.Alimentacao;
+
+public class AlimentacaoController {
+
+    private final AlimentacaoDao dao;
+
+    public AlimentacaoController(AlimentacaoDao dao) {
+        this.dao = dao;
+    }
+
+    public void criar(Alimentacao alimentacao) {
+        Logger.info("AlimentacaoController.criar - inicio");
+        if (alimentacao == null) {
+            throw new AlimentacaoException("Alimentacao não pode ser nula");
+        }
+        if (alimentacao.getIdAlimentacao() == null) {
+            throw new AlimentacaoException("Id da Alimentacao é obrigatório");
+        }
+        if (alimentacao.getNome() == null || alimentacao.getNome().isEmpty()) {
+            throw new AlimentacaoException("Nome da Alimentacao é obrigatório");
+        }
+        dao.create(alimentacao);
+        Logger.info("AlimentacaoController.criar - sucesso");
+    }
+
+    public Alimentacao atualizar(Alimentacao alimentacao) {
+        Logger.info("AlimentacaoController.atualizar - inicio");
+        if (alimentacao == null || alimentacao.getIdAlimentacao() == null) {
+            throw new AlimentacaoException("Alimentacao ou Id não pode ser nulo");
+        }
+        if (alimentacao.getNome() == null || alimentacao.getNome().isEmpty()) {
+            throw new AlimentacaoException("Nome da Alimentacao é obrigatório");
+        }
+        Alimentacao updated = dao.update(alimentacao);
+        Logger.info("AlimentacaoController.atualizar - sucesso");
+        return updated;
+    }
+
+    public void remover(Integer id) {
+        Logger.info("AlimentacaoController.remover - inicio");
+        if (id == null) {
+            throw new AlimentacaoException("Id da Alimentacao é obrigatório");
+        }
+        dao.deleteById(id);
+        Logger.info("AlimentacaoController.remover - sucesso");
+    }
+
+    public Alimentacao buscarPorId(Integer id) {
+        Logger.info("AlimentacaoController.buscarPorId - inicio");
+        if (id == null) {
+            throw new AlimentacaoException("Id da Alimentacao é obrigatório");
+        }
+        Alimentacao a = dao.findById(id);
+        Logger.info("AlimentacaoController.buscarPorId - sucesso");
+        return a;
+    }
+
+    public Alimentacao buscarComVideoPorId(Integer id) {
+        Logger.info("AlimentacaoController.buscarComVideoPorId - inicio");
+        if (id == null) {
+            throw new AlimentacaoException("Id da Alimentacao é obrigatório");
+        }
+        Alimentacao a = dao.findWithVideoById(id);
+        Logger.info("AlimentacaoController.buscarComVideoPorId - sucesso");
+        return a;
+    }
+
+    public List<Alimentacao> listar() {
+        Logger.info("AlimentacaoController.listar - inicio");
+        List<Alimentacao> list = dao.findAll();
+        Logger.info("AlimentacaoController.listar - sucesso");
+        return list;
+    }
+
+    public List<Alimentacao> listar(int page, int size) {
+        Logger.info("AlimentacaoController.listar(page) - inicio");
+        List<Alimentacao> list = dao.findAll(page, size);
+        Logger.info("AlimentacaoController.listar(page) - sucesso");
+        return list;
+    }
+
+    public List<Alimentacao> buscarPorStatus(Integer status) {
+        Logger.info("AlimentacaoController.buscarPorStatus - inicio");
+        if (status == null) {
+            throw new AlimentacaoException("Status não pode ser nulo");
+        }
+        List<Alimentacao> list = dao.findByStatus(status);
+        Logger.info("AlimentacaoController.buscarPorStatus - sucesso");
+        return list;
+    }
+
+    public List<Alimentacao> buscarPorNome(String nome) {
+        Logger.info("AlimentacaoController.buscarPorNome - inicio");
+        if (nome == null || nome.isEmpty()) {
+            throw new AlimentacaoException("Nome não pode ser vazio");
+        }
+        List<Alimentacao> list = dao.findByNome(nome);
+        Logger.info("AlimentacaoController.buscarPorNome - sucesso");
+        return list;
+    }
+
+    public List<Alimentacao> buscarPorLink(String link) {
+        Logger.info("AlimentacaoController.buscarPorLink - inicio");
+        if (link == null || link.isEmpty()) {
+            throw new AlimentacaoException("Link não pode ser vazio");
+        }
+        List<Alimentacao> list = dao.findByLink(link);
+        Logger.info("AlimentacaoController.buscarPorLink - sucesso");
+        return list;
+    }
+
+    public List<Alimentacao> buscarPorVideo(byte[] video) {
+        Logger.info("AlimentacaoController.buscarPorVideo - inicio");
+        if (video == null) {
+            throw new AlimentacaoException("Video não pode ser nulo");
+        }
+        List<Alimentacao> list = dao.findByVideo(video);
+        Logger.info("AlimentacaoController.buscarPorVideo - sucesso");
+        return list;
+    }
+
+    public List<Alimentacao> buscarPorPreparo(String preparo) {
+        Logger.info("AlimentacaoController.buscarPorPreparo - inicio");
+        if (preparo == null || preparo.isEmpty()) {
+            throw new AlimentacaoException("Preparo não pode ser vazio");
+        }
+        List<Alimentacao> list = dao.findByPreparo(preparo);
+        Logger.info("AlimentacaoController.buscarPorPreparo - sucesso");
+        return list;
+    }
+
+    public List<Alimentacao> buscarPorIdRotina(Integer idRotina) {
+        Logger.info("AlimentacaoController.buscarPorIdRotina - inicio");
+        if (idRotina == null) {
+            throw new AlimentacaoException("Id da rotina não pode ser nulo");
+        }
+        List<Alimentacao> list = dao.findByIdRotina(idRotina);
+        Logger.info("AlimentacaoController.buscarPorIdRotina - sucesso");
+        return list;
+    }
+
+    public List<Alimentacao> pesquisar(Alimentacao filtro) {
+        Logger.info("AlimentacaoController.pesquisar - inicio");
+        List<Alimentacao> list = dao.search(filtro);
+        Logger.info("AlimentacaoController.pesquisar - sucesso");
+        return list;
+    }
+
+    public List<Alimentacao> pesquisar(Alimentacao filtro, int page, int size) {
+        Logger.info("AlimentacaoController.pesquisar(page) - inicio");
+        List<Alimentacao> list = dao.search(filtro, page, size);
+        Logger.info("AlimentacaoController.pesquisar(page) - sucesso");
+        return list;
+    }
+}

--- a/src/main/java/controller/CaixaController.java
+++ b/src/main/java/controller/CaixaController.java
@@ -1,0 +1,144 @@
+// path: src/main/java/controller/CaixaController.java
+package controller;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import dao.api.CaixaDao;
+import exception.CaixaException;
+import infra.Logger;
+import model.Caixa;
+
+public class CaixaController {
+
+    private final CaixaDao dao;
+
+    public CaixaController(CaixaDao dao) {
+        this.dao = dao;
+    }
+
+    public void criar(Caixa caixa) {
+        Logger.info("CaixaController.criar - inicio");
+        if (caixa == null) {
+            throw new CaixaException("Caixa não pode ser nula");
+        }
+        if (caixa.getIdCaixa() == null) {
+            throw new CaixaException("Id da Caixa é obrigatório");
+        }
+        if (caixa.getNome() == null || caixa.getNome().isEmpty()) {
+            throw new CaixaException("Nome da Caixa é obrigatório");
+        }
+        dao.create(caixa);
+        Logger.info("CaixaController.criar - sucesso");
+    }
+
+    public Caixa atualizar(Caixa caixa) {
+        Logger.info("CaixaController.atualizar - inicio");
+        if (caixa == null || caixa.getIdCaixa() == null) {
+            throw new CaixaException("Caixa ou Id não pode ser nulo");
+        }
+        if (caixa.getNome() == null || caixa.getNome().isEmpty()) {
+            throw new CaixaException("Nome da Caixa é obrigatório");
+        }
+        Caixa updated = dao.update(caixa);
+        Logger.info("CaixaController.atualizar - sucesso");
+        return updated;
+    }
+
+    public void remover(Integer id) {
+        Logger.info("CaixaController.remover - inicio");
+        if (id == null) {
+            throw new CaixaException("Id da Caixa é obrigatório");
+        }
+        dao.deleteById(id);
+        Logger.info("CaixaController.remover - sucesso");
+    }
+
+    public Caixa buscarPorId(Integer id) {
+        Logger.info("CaixaController.buscarPorId - inicio");
+        if (id == null) {
+            throw new CaixaException("Id da Caixa é obrigatório");
+        }
+        Caixa c = dao.findById(id);
+        Logger.info("CaixaController.buscarPorId - sucesso");
+        return c;
+    }
+
+    public List<Caixa> listar() {
+        Logger.info("CaixaController.listar - inicio");
+        List<Caixa> list = dao.findAll();
+        Logger.info("CaixaController.listar - sucesso");
+        return list;
+    }
+
+    public List<Caixa> listar(int page, int size) {
+        Logger.info("CaixaController.listar(page) - inicio");
+        List<Caixa> list = dao.findAll(page, size);
+        Logger.info("CaixaController.listar(page) - sucesso");
+        return list;
+    }
+
+    public List<Caixa> buscarPorNome(String nome) {
+        Logger.info("CaixaController.buscarPorNome - inicio");
+        if (nome == null || nome.isEmpty()) {
+            throw new CaixaException("Nome não pode ser vazio");
+        }
+        List<Caixa> list = dao.findByNome(nome);
+        Logger.info("CaixaController.buscarPorNome - sucesso");
+        return list;
+    }
+
+    public List<Caixa> buscarPorReservaEmergencia(BigDecimal reserva) {
+        Logger.info("CaixaController.buscarPorReservaEmergencia - inicio");
+        if (reserva == null) {
+            throw new CaixaException("Reserva não pode ser nula");
+        }
+        List<Caixa> list = dao.findByReservaEmergencia(reserva);
+        Logger.info("CaixaController.buscarPorReservaEmergencia - sucesso");
+        return list;
+    }
+
+    public List<Caixa> buscarPorSalarioMedio(BigDecimal salario) {
+        Logger.info("CaixaController.buscarPorSalarioMedio - inicio");
+        if (salario == null) {
+            throw new CaixaException("Salário não pode ser nulo");
+        }
+        List<Caixa> list = dao.findBySalarioMedio(salario);
+        Logger.info("CaixaController.buscarPorSalarioMedio - sucesso");
+        return list;
+    }
+
+    public List<Caixa> buscarPorValorTotal(BigDecimal valor) {
+        Logger.info("CaixaController.buscarPorValorTotal - inicio");
+        if (valor == null) {
+            throw new CaixaException("Valor não pode ser nulo");
+        }
+        List<Caixa> list = dao.findByValorTotal(valor);
+        Logger.info("CaixaController.buscarPorValorTotal - sucesso");
+        return list;
+    }
+
+    public List<Caixa> buscarPorIdUsuario(Integer idUsuario) {
+        Logger.info("CaixaController.buscarPorIdUsuario - inicio");
+        if (idUsuario == null) {
+            throw new CaixaException("Id do usuário não pode ser nulo");
+        }
+        List<Caixa> list = dao.findByIdUsuario(idUsuario);
+        Logger.info("CaixaController.buscarPorIdUsuario - sucesso");
+        return list;
+    }
+
+    public List<Caixa> pesquisar(Caixa filtro) {
+        Logger.info("CaixaController.pesquisar - inicio");
+        List<Caixa> list = dao.search(filtro);
+        Logger.info("CaixaController.pesquisar - sucesso");
+        return list;
+    }
+
+    public List<Caixa> pesquisar(Caixa filtro, int page, int size) {
+        Logger.info("CaixaController.pesquisar(page) - inicio");
+        List<Caixa> list = dao.search(filtro, page, size);
+        Logger.info("CaixaController.pesquisar(page) - sucesso");
+        return list;
+    }
+}

--- a/src/main/java/controller/MonitoramentoController.java
+++ b/src/main/java/controller/MonitoramentoController.java
@@ -1,0 +1,153 @@
+// path: src/main/java/controller/MonitoramentoController.java
+package controller;
+
+import java.util.List;
+
+import dao.api.MonitoramentoDao;
+import exception.MonitoramentoException;
+import infra.Logger;
+import model.Monitoramento;
+
+public class MonitoramentoController {
+
+    private final MonitoramentoDao dao;
+
+    public MonitoramentoController(MonitoramentoDao dao) {
+        this.dao = dao;
+    }
+
+    public void criar(Monitoramento monitoramento) {
+        Logger.info("MonitoramentoController.criar - inicio");
+        if (monitoramento == null) {
+            throw new MonitoramentoException("Monitoramento não pode ser nulo");
+        }
+        if (monitoramento.getIdMonitoramento() == null) {
+            throw new MonitoramentoException("Id do Monitoramento é obrigatório");
+        }
+        if (monitoramento.getNome() == null || monitoramento.getNome().isEmpty()) {
+            throw new MonitoramentoException("Nome do Monitoramento é obrigatório");
+        }
+        dao.create(monitoramento);
+        Logger.info("MonitoramentoController.criar - sucesso");
+    }
+
+    public Monitoramento atualizar(Monitoramento monitoramento) {
+        Logger.info("MonitoramentoController.atualizar - inicio");
+        if (monitoramento == null || monitoramento.getIdMonitoramento() == null) {
+            throw new MonitoramentoException("Monitoramento ou Id não pode ser nulo");
+        }
+        if (monitoramento.getNome() == null || monitoramento.getNome().isEmpty()) {
+            throw new MonitoramentoException("Nome do Monitoramento é obrigatório");
+        }
+        Monitoramento updated = dao.update(monitoramento);
+        Logger.info("MonitoramentoController.atualizar - sucesso");
+        return updated;
+    }
+
+    public void remover(Integer id) {
+        Logger.info("MonitoramentoController.remover - inicio");
+        if (id == null) {
+            throw new MonitoramentoException("Id do Monitoramento é obrigatório");
+        }
+        dao.deleteById(id);
+        Logger.info("MonitoramentoController.remover - sucesso");
+    }
+
+    public Monitoramento buscarPorId(Integer id) {
+        Logger.info("MonitoramentoController.buscarPorId - inicio");
+        if (id == null) {
+            throw new MonitoramentoException("Id do Monitoramento é obrigatório");
+        }
+        Monitoramento m = dao.findById(id);
+        Logger.info("MonitoramentoController.buscarPorId - sucesso");
+        return m;
+    }
+
+    public Monitoramento buscarComFotoPorId(Integer id) {
+        Logger.info("MonitoramentoController.buscarComFotoPorId - inicio");
+        if (id == null) {
+            throw new MonitoramentoException("Id do Monitoramento é obrigatório");
+        }
+        Monitoramento m = dao.findWithFotoById(id);
+        Logger.info("MonitoramentoController.buscarComFotoPorId - sucesso");
+        return m;
+    }
+
+    public List<Monitoramento> listar() {
+        Logger.info("MonitoramentoController.listar - inicio");
+        List<Monitoramento> list = dao.findAll();
+        Logger.info("MonitoramentoController.listar - sucesso");
+        return list;
+    }
+
+    public List<Monitoramento> listar(int page, int size) {
+        Logger.info("MonitoramentoController.listar(page) - inicio");
+        List<Monitoramento> list = dao.findAll(page, size);
+        Logger.info("MonitoramentoController.listar(page) - sucesso");
+        return list;
+    }
+
+    public List<Monitoramento> buscarPorStatus(Integer status) {
+        Logger.info("MonitoramentoController.buscarPorStatus - inicio");
+        if (status == null) {
+            throw new MonitoramentoException("Status não pode ser nulo");
+        }
+        List<Monitoramento> list = dao.findByStatus(status);
+        Logger.info("MonitoramentoController.buscarPorStatus - sucesso");
+        return list;
+    }
+
+    public List<Monitoramento> buscarPorNome(String nome) {
+        Logger.info("MonitoramentoController.buscarPorNome - inicio");
+        if (nome == null || nome.isEmpty()) {
+            throw new MonitoramentoException("Nome não pode ser vazio");
+        }
+        List<Monitoramento> list = dao.findByNome(nome);
+        Logger.info("MonitoramentoController.buscarPorNome - sucesso");
+        return list;
+    }
+
+    public List<Monitoramento> buscarPorDescricao(String descricao) {
+        Logger.info("MonitoramentoController.buscarPorDescricao - inicio");
+        if (descricao == null || descricao.isEmpty()) {
+            throw new MonitoramentoException("Descrição não pode ser vazia");
+        }
+        List<Monitoramento> list = dao.findByDescricao(descricao);
+        Logger.info("MonitoramentoController.buscarPorDescricao - sucesso");
+        return list;
+    }
+
+    public List<Monitoramento> buscarPorFoto(byte[] foto) {
+        Logger.info("MonitoramentoController.buscarPorFoto - inicio");
+        if (foto == null) {
+            throw new MonitoramentoException("Foto não pode ser nula");
+        }
+        List<Monitoramento> list = dao.findByFoto(foto);
+        Logger.info("MonitoramentoController.buscarPorFoto - sucesso");
+        return list;
+    }
+
+    public List<Monitoramento> buscarPorIdPeriodo(Integer idPeriodo) {
+        Logger.info("MonitoramentoController.buscarPorIdPeriodo - inicio");
+        if (idPeriodo == null) {
+            throw new MonitoramentoException("Id do período não pode ser nulo");
+        }
+        List<Monitoramento> list = dao.findByIdPeriodo(idPeriodo);
+        Logger.info("MonitoramentoController.buscarPorIdPeriodo - sucesso");
+        return list;
+    }
+
+    public List<Monitoramento> pesquisar(Monitoramento filtro) {
+        Logger.info("MonitoramentoController.pesquisar - inicio");
+        List<Monitoramento> list = dao.search(filtro);
+        Logger.info("MonitoramentoController.pesquisar - sucesso");
+        return list;
+    }
+
+    public List<Monitoramento> pesquisar(Monitoramento filtro, int page, int size) {
+        Logger.info("MonitoramentoController.pesquisar(page) - inicio");
+        List<Monitoramento> list = dao.search(filtro, page, size);
+        Logger.info("MonitoramentoController.pesquisar(page) - sucesso");
+        return list;
+    }
+}

--- a/src/main/java/controller/ObjetoController.java
+++ b/src/main/java/controller/ObjetoController.java
@@ -1,0 +1,154 @@
+// path: src/main/java/controller/ObjetoController.java
+package controller;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import dao.api.ObjetoDao;
+import exception.ObjetoException;
+import infra.Logger;
+import model.Objeto;
+
+public class ObjetoController {
+
+    private final ObjetoDao dao;
+
+    public ObjetoController(ObjetoDao dao) {
+        this.dao = dao;
+    }
+
+    public void criar(Objeto objeto) {
+        Logger.info("ObjetoController.criar - inicio");
+        if (objeto == null) {
+            throw new ObjetoException("Objeto não pode ser nulo");
+        }
+        if (objeto.getIdObjeto() == null) {
+            throw new ObjetoException("Id do Objeto é obrigatório");
+        }
+        if (objeto.getNome() == null || objeto.getNome().isEmpty()) {
+            throw new ObjetoException("Nome do Objeto é obrigatório");
+        }
+        dao.create(objeto);
+        Logger.info("ObjetoController.criar - sucesso");
+    }
+
+    public Objeto atualizar(Objeto objeto) {
+        Logger.info("ObjetoController.atualizar - inicio");
+        if (objeto == null || objeto.getIdObjeto() == null) {
+            throw new ObjetoException("Objeto ou Id não pode ser nulo");
+        }
+        if (objeto.getNome() == null || objeto.getNome().isEmpty()) {
+            throw new ObjetoException("Nome do Objeto é obrigatório");
+        }
+        Objeto updated = dao.update(objeto);
+        Logger.info("ObjetoController.atualizar - sucesso");
+        return updated;
+    }
+
+    public void remover(Integer id) {
+        Logger.info("ObjetoController.remover - inicio");
+        if (id == null) {
+            throw new ObjetoException("Id do Objeto é obrigatório");
+        }
+        dao.deleteById(id);
+        Logger.info("ObjetoController.remover - sucesso");
+    }
+
+    public Objeto buscarPorId(Integer id) {
+        Logger.info("ObjetoController.buscarPorId - inicio");
+        if (id == null) {
+            throw new ObjetoException("Id do Objeto é obrigatório");
+        }
+        Objeto o = dao.findById(id);
+        Logger.info("ObjetoController.buscarPorId - sucesso");
+        return o;
+    }
+
+    public Objeto buscarComFotoPorId(Integer id) {
+        Logger.info("ObjetoController.buscarComFotoPorId - inicio");
+        if (id == null) {
+            throw new ObjetoException("Id do Objeto é obrigatório");
+        }
+        Objeto o = dao.findWithFotoById(id);
+        Logger.info("ObjetoController.buscarComFotoPorId - sucesso");
+        return o;
+    }
+
+    public List<Objeto> listar() {
+        Logger.info("ObjetoController.listar - inicio");
+        List<Objeto> list = dao.findAll();
+        Logger.info("ObjetoController.listar - sucesso");
+        return list;
+    }
+
+    public List<Objeto> listar(int page, int size) {
+        Logger.info("ObjetoController.listar(page) - inicio");
+        List<Objeto> list = dao.findAll(page, size);
+        Logger.info("ObjetoController.listar(page) - sucesso");
+        return list;
+    }
+
+    public List<Objeto> buscarPorNome(String nome) {
+        Logger.info("ObjetoController.buscarPorNome - inicio");
+        if (nome == null || nome.isEmpty()) {
+            throw new ObjetoException("Nome não pode ser vazio");
+        }
+        List<Objeto> list = dao.findByNome(nome);
+        Logger.info("ObjetoController.buscarPorNome - sucesso");
+        return list;
+    }
+
+    public List<Objeto> buscarPorTipo(Integer tipo) {
+        Logger.info("ObjetoController.buscarPorTipo - inicio");
+        if (tipo == null) {
+            throw new ObjetoException("Tipo não pode ser nulo");
+        }
+        List<Objeto> list = dao.findByTipo(tipo);
+        Logger.info("ObjetoController.buscarPorTipo - sucesso");
+        return list;
+    }
+
+    public List<Objeto> buscarPorValor(BigDecimal valor) {
+        Logger.info("ObjetoController.buscarPorValor - inicio");
+        if (valor == null) {
+            throw new ObjetoException("Valor não pode ser nulo");
+        }
+        List<Objeto> list = dao.findByValor(valor);
+        Logger.info("ObjetoController.buscarPorValor - sucesso");
+        return list;
+    }
+
+    public List<Objeto> buscarPorDescricao(String descricao) {
+        Logger.info("ObjetoController.buscarPorDescricao - inicio");
+        if (descricao == null || descricao.isEmpty()) {
+            throw new ObjetoException("Descrição não pode ser vazia");
+        }
+        List<Objeto> list = dao.findByDescricao(descricao);
+        Logger.info("ObjetoController.buscarPorDescricao - sucesso");
+        return list;
+    }
+
+    public List<Objeto> buscarPorFoto(byte[] foto) {
+        Logger.info("ObjetoController.buscarPorFoto - inicio");
+        if (foto == null) {
+            throw new ObjetoException("Foto não pode ser nula");
+        }
+        List<Objeto> list = dao.findByFoto(foto);
+        Logger.info("ObjetoController.buscarPorFoto - sucesso");
+        return list;
+    }
+
+    public List<Objeto> pesquisar(Objeto filtro) {
+        Logger.info("ObjetoController.pesquisar - inicio");
+        List<Objeto> list = dao.search(filtro);
+        Logger.info("ObjetoController.pesquisar - sucesso");
+        return list;
+    }
+
+    public List<Objeto> pesquisar(Objeto filtro, int page, int size) {
+        Logger.info("ObjetoController.pesquisar(page) - inicio");
+        List<Objeto> list = dao.search(filtro, page, size);
+        Logger.info("ObjetoController.pesquisar(page) - sucesso");
+        return list;
+    }
+}

--- a/src/main/java/controller/PeriodoController.java
+++ b/src/main/java/controller/PeriodoController.java
@@ -1,0 +1,119 @@
+// path: src/main/java/controller/PeriodoController.java
+package controller;
+
+import java.util.List;
+
+import dao.api.PeriodoDao;
+import exception.PeriodoException;
+import infra.Logger;
+import model.Periodo;
+
+public class PeriodoController {
+
+    private final PeriodoDao dao;
+
+    public PeriodoController(PeriodoDao dao) {
+        this.dao = dao;
+    }
+
+    public void criar(Periodo periodo) {
+        Logger.info("PeriodoController.criar - inicio");
+        if (periodo == null) {
+            throw new PeriodoException("Periodo não pode ser nulo");
+        }
+        if (periodo.getIdPeriodo() == null) {
+            throw new PeriodoException("Id do Periodo é obrigatório");
+        }
+        if (periodo.getAno() == null) {
+            throw new PeriodoException("Ano do Periodo é obrigatório");
+        }
+        if (periodo.getMes() == null) {
+            throw new PeriodoException("Mês do Periodo é obrigatório");
+        }
+        dao.create(periodo);
+        Logger.info("PeriodoController.criar - sucesso");
+    }
+
+    public Periodo atualizar(Periodo periodo) {
+        Logger.info("PeriodoController.atualizar - inicio");
+        if (periodo == null || periodo.getIdPeriodo() == null) {
+            throw new PeriodoException("Periodo ou Id não pode ser nulo");
+        }
+        if (periodo.getAno() == null) {
+            throw new PeriodoException("Ano do Periodo é obrigatório");
+        }
+        if (periodo.getMes() == null) {
+            throw new PeriodoException("Mês do Periodo é obrigatório");
+        }
+        Periodo updated = dao.update(periodo);
+        Logger.info("PeriodoController.atualizar - sucesso");
+        return updated;
+    }
+
+    public void remover(Integer id) {
+        Logger.info("PeriodoController.remover - inicio");
+        if (id == null) {
+            throw new PeriodoException("Id do Periodo é obrigatório");
+        }
+        dao.deleteById(id);
+        Logger.info("PeriodoController.remover - sucesso");
+    }
+
+    public Periodo buscarPorId(Integer id) {
+        Logger.info("PeriodoController.buscarPorId - inicio");
+        if (id == null) {
+            throw new PeriodoException("Id do Periodo é obrigatório");
+        }
+        Periodo p = dao.findById(id);
+        Logger.info("PeriodoController.buscarPorId - sucesso");
+        return p;
+    }
+
+    public List<Periodo> listar() {
+        Logger.info("PeriodoController.listar - inicio");
+        List<Periodo> list = dao.findAll();
+        Logger.info("PeriodoController.listar - sucesso");
+        return list;
+    }
+
+    public List<Periodo> listar(int page, int size) {
+        Logger.info("PeriodoController.listar(page) - inicio");
+        List<Periodo> list = dao.findAll(page, size);
+        Logger.info("PeriodoController.listar(page) - sucesso");
+        return list;
+    }
+
+    public List<Periodo> buscarPorAno(Integer ano) {
+        Logger.info("PeriodoController.buscarPorAno - inicio");
+        if (ano == null) {
+            throw new PeriodoException("Ano não pode ser nulo");
+        }
+        List<Periodo> list = dao.findByAno(ano);
+        Logger.info("PeriodoController.buscarPorAno - sucesso");
+        return list;
+    }
+
+    public List<Periodo> buscarPorMes(Integer mes) {
+        Logger.info("PeriodoController.buscarPorMes - inicio");
+        if (mes == null) {
+            throw new PeriodoException("Mês não pode ser nulo");
+        }
+        List<Periodo> list = dao.findByMes(mes);
+        Logger.info("PeriodoController.buscarPorMes - sucesso");
+        return list;
+    }
+
+    public List<Periodo> pesquisar(Periodo filtro) {
+        Logger.info("PeriodoController.pesquisar - inicio");
+        List<Periodo> list = dao.search(filtro);
+        Logger.info("PeriodoController.pesquisar - sucesso");
+        return list;
+    }
+
+    public List<Periodo> pesquisar(Periodo filtro, int page, int size) {
+        Logger.info("PeriodoController.pesquisar(page) - inicio");
+        List<Periodo> list = dao.search(filtro, page, size);
+        Logger.info("PeriodoController.pesquisar(page) - sucesso");
+        return list;
+    }
+}

--- a/src/main/java/controller/SiteController.java
+++ b/src/main/java/controller/SiteController.java
@@ -1,0 +1,133 @@
+// path: src/main/java/controller/SiteController.java
+package controller;
+
+import java.util.List;
+
+import dao.api.SiteDao;
+import exception.SiteException;
+import infra.Logger;
+import model.Site;
+
+public class SiteController {
+
+    private final SiteDao dao;
+
+    public SiteController(SiteDao dao) {
+        this.dao = dao;
+    }
+
+    public void criar(Site site) {
+        Logger.info("SiteController.criar - inicio");
+        if (site == null) {
+            throw new SiteException("Site não pode ser nulo");
+        }
+        if (site.getIdSite() == null) {
+            throw new SiteException("Id do Site é obrigatório");
+        }
+        if (site.getUrl() == null || site.getUrl().isEmpty()) {
+            throw new SiteException("URL do Site é obrigatória");
+        }
+        dao.create(site);
+        Logger.info("SiteController.criar - sucesso");
+    }
+
+    public Site atualizar(Site site) {
+        Logger.info("SiteController.atualizar - inicio");
+        if (site == null || site.getIdSite() == null) {
+            throw new SiteException("Site ou Id não pode ser nulo");
+        }
+        if (site.getUrl() == null || site.getUrl().isEmpty()) {
+            throw new SiteException("URL do Site é obrigatória");
+        }
+        Site updated = dao.update(site);
+        Logger.info("SiteController.atualizar - sucesso");
+        return updated;
+    }
+
+    public void remover(Integer id) {
+        Logger.info("SiteController.remover - inicio");
+        if (id == null) {
+            throw new SiteException("Id do Site é obrigatório");
+        }
+        dao.deleteById(id);
+        Logger.info("SiteController.remover - sucesso");
+    }
+
+    public Site buscarPorId(Integer id) {
+        Logger.info("SiteController.buscarPorId - inicio");
+        if (id == null) {
+            throw new SiteException("Id do Site é obrigatório");
+        }
+        Site s = dao.findById(id);
+        Logger.info("SiteController.buscarPorId - sucesso");
+        return s;
+    }
+
+    public Site buscarComLogoPorId(Integer id) {
+        Logger.info("SiteController.buscarComLogoPorId - inicio");
+        if (id == null) {
+            throw new SiteException("Id do Site é obrigatório");
+        }
+        Site s = dao.findWithLogoById(id);
+        Logger.info("SiteController.buscarComLogoPorId - sucesso");
+        return s;
+    }
+
+    public List<Site> listar() {
+        Logger.info("SiteController.listar - inicio");
+        List<Site> list = dao.findAll();
+        Logger.info("SiteController.listar - sucesso");
+        return list;
+    }
+
+    public List<Site> listar(int page, int size) {
+        Logger.info("SiteController.listar(page) - inicio");
+        List<Site> list = dao.findAll(page, size);
+        Logger.info("SiteController.listar(page) - sucesso");
+        return list;
+    }
+
+    public List<Site> buscarPorUrl(String url) {
+        Logger.info("SiteController.buscarPorUrl - inicio");
+        if (url == null || url.isEmpty()) {
+            throw new SiteException("URL não pode ser vazia");
+        }
+        List<Site> list = dao.findByUrl(url);
+        Logger.info("SiteController.buscarPorUrl - sucesso");
+        return list;
+    }
+
+    public List<Site> buscarPorAtivo(Boolean ativo) {
+        Logger.info("SiteController.buscarPorAtivo - inicio");
+        if (ativo == null) {
+            throw new SiteException("Ativo não pode ser nulo");
+        }
+        List<Site> list = dao.findByAtivo(ativo);
+        Logger.info("SiteController.buscarPorAtivo - sucesso");
+        return list;
+    }
+
+    public List<Site> buscarPorLogo(byte[] logo) {
+        Logger.info("SiteController.buscarPorLogo - inicio");
+        if (logo == null) {
+            throw new SiteException("Logo não pode ser nulo");
+        }
+        List<Site> list = dao.findByLogo(logo);
+        Logger.info("SiteController.buscarPorLogo - sucesso");
+        return list;
+    }
+
+    public List<Site> pesquisar(Site filtro) {
+        Logger.info("SiteController.pesquisar - inicio");
+        List<Site> list = dao.search(filtro);
+        Logger.info("SiteController.pesquisar - sucesso");
+        return list;
+    }
+
+    public List<Site> pesquisar(Site filtro, int page, int size) {
+        Logger.info("SiteController.pesquisar(page) - inicio");
+        List<Site> list = dao.search(filtro, page, size);
+        Logger.info("SiteController.pesquisar(page) - sucesso");
+        return list;
+    }
+}

--- a/src/main/java/controller/TreinoController.java
+++ b/src/main/java/controller/TreinoController.java
@@ -1,0 +1,123 @@
+// path: src/main/java/controller/TreinoController.java
+package controller;
+
+import java.util.List;
+
+import dao.api.TreinoDao;
+import exception.TreinoException;
+import infra.Logger;
+import model.Treino;
+
+public class TreinoController {
+
+    private final TreinoDao dao;
+
+    public TreinoController(TreinoDao dao) {
+        this.dao = dao;
+    }
+
+    public void criar(Treino treino) {
+        Logger.info("TreinoController.criar - inicio");
+        if (treino == null) {
+            throw new TreinoException("Treino não pode ser nulo");
+        }
+        if (treino.getIdTreino() == null) {
+            throw new TreinoException("Id do Treino é obrigatório");
+        }
+        if (treino.getNome() == null || treino.getNome().isEmpty()) {
+            throw new TreinoException("Nome do Treino é obrigatório");
+        }
+        dao.create(treino);
+        Logger.info("TreinoController.criar - sucesso");
+    }
+
+    public Treino atualizar(Treino treino) {
+        Logger.info("TreinoController.atualizar - inicio");
+        if (treino == null || treino.getIdTreino() == null) {
+            throw new TreinoException("Treino ou Id não pode ser nulo");
+        }
+        if (treino.getNome() == null || treino.getNome().isEmpty()) {
+            throw new TreinoException("Nome do Treino é obrigatório");
+        }
+        Treino updated = dao.update(treino);
+        Logger.info("TreinoController.atualizar - sucesso");
+        return updated;
+    }
+
+    public void remover(Integer id) {
+        Logger.info("TreinoController.remover - inicio");
+        if (id == null) {
+            throw new TreinoException("Id do Treino é obrigatório");
+        }
+        dao.deleteById(id);
+        Logger.info("TreinoController.remover - sucesso");
+    }
+
+    public Treino buscarPorId(Integer id) {
+        Logger.info("TreinoController.buscarPorId - inicio");
+        if (id == null) {
+            throw new TreinoException("Id do Treino é obrigatório");
+        }
+        Treino t = dao.findById(id);
+        Logger.info("TreinoController.buscarPorId - sucesso");
+        return t;
+    }
+
+    public List<Treino> listar() {
+        Logger.info("TreinoController.listar - inicio");
+        List<Treino> list = dao.findAll();
+        Logger.info("TreinoController.listar - sucesso");
+        return list;
+    }
+
+    public List<Treino> listar(int page, int size) {
+        Logger.info("TreinoController.listar(page) - inicio");
+        List<Treino> list = dao.findAll(page, size);
+        Logger.info("TreinoController.listar(page) - sucesso");
+        return list;
+    }
+
+    public List<Treino> buscarPorNome(String nome) {
+        Logger.info("TreinoController.buscarPorNome - inicio");
+        if (nome == null || nome.isEmpty()) {
+            throw new TreinoException("Nome não pode ser vazio");
+        }
+        List<Treino> list = dao.findByNome(nome);
+        Logger.info("TreinoController.buscarPorNome - sucesso");
+        return list;
+    }
+
+    public List<Treino> buscarPorClasse(String classe) {
+        Logger.info("TreinoController.buscarPorClasse - inicio");
+        if (classe == null || classe.isEmpty()) {
+            throw new TreinoException("Classe não pode ser vazia");
+        }
+        List<Treino> list = dao.findByClasse(classe);
+        Logger.info("TreinoController.buscarPorClasse - sucesso");
+        return list;
+    }
+
+    public List<Treino> buscarPorIdRotina(Integer idRotina) {
+        Logger.info("TreinoController.buscarPorIdRotina - inicio");
+        if (idRotina == null) {
+            throw new TreinoException("Id da rotina não pode ser nulo");
+        }
+        List<Treino> list = dao.findByIdRotina(idRotina);
+        Logger.info("TreinoController.buscarPorIdRotina - sucesso");
+        return list;
+    }
+
+    public List<Treino> pesquisar(Treino filtro) {
+        Logger.info("TreinoController.pesquisar - inicio");
+        List<Treino> list = dao.search(filtro);
+        Logger.info("TreinoController.pesquisar - sucesso");
+        return list;
+    }
+
+    public List<Treino> pesquisar(Treino filtro, int page, int size) {
+        Logger.info("TreinoController.pesquisar(page) - inicio");
+        List<Treino> list = dao.search(filtro, page, size);
+        Logger.info("TreinoController.pesquisar(page) - sucesso");
+        return list;
+    }
+}

--- a/src/main/java/dao/api/AlimentacaoDao.java
+++ b/src/main/java/dao/api/AlimentacaoDao.java
@@ -1,0 +1,40 @@
+// path: src/main/java/dao/api/AlimentacaoDao.java
+package dao.api;
+
+import java.util.List;
+
+import exception.AlimentacaoException;
+import model.Alimentacao;
+
+public interface AlimentacaoDao {
+
+    void create(Alimentacao alimentacao) throws AlimentacaoException;
+
+    Alimentacao update(Alimentacao alimentacao) throws AlimentacaoException;
+
+    void deleteById(Integer id) throws AlimentacaoException;
+
+    Alimentacao findById(Integer id) throws AlimentacaoException;
+
+    Alimentacao findWithVideoById(Integer id) throws AlimentacaoException;
+
+    List<Alimentacao> findAll();
+
+    List<Alimentacao> findAll(int page, int size);
+
+    List<Alimentacao> findByStatus(Integer status);
+
+    List<Alimentacao> findByNome(String nome);
+
+    List<Alimentacao> findByLink(String link);
+
+    List<Alimentacao> findByVideo(byte[] video);
+
+    List<Alimentacao> findByPreparo(String preparo);
+
+    List<Alimentacao> findByIdRotina(Integer idRotina);
+
+    List<Alimentacao> search(Alimentacao filtro);
+
+    List<Alimentacao> search(Alimentacao filtro, int page, int size);
+}

--- a/src/main/java/dao/api/CaixaDao.java
+++ b/src/main/java/dao/api/CaixaDao.java
@@ -1,0 +1,37 @@
+// path: src/main/java/dao/api/CaixaDao.java
+package dao.api;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import exception.CaixaException;
+import model.Caixa;
+
+public interface CaixaDao {
+
+    void create(Caixa caixa) throws CaixaException;
+
+    Caixa update(Caixa caixa) throws CaixaException;
+
+    void deleteById(Integer id) throws CaixaException;
+
+    Caixa findById(Integer id) throws CaixaException;
+
+    List<Caixa> findAll();
+
+    List<Caixa> findAll(int page, int size);
+
+    List<Caixa> findByNome(String nome);
+
+    List<Caixa> findByReservaEmergencia(BigDecimal reservaEmergencia);
+
+    List<Caixa> findBySalarioMedio(BigDecimal salarioMedio);
+
+    List<Caixa> findByValorTotal(BigDecimal valorTotal);
+
+    List<Caixa> findByIdUsuario(Integer idUsuario);
+
+    List<Caixa> search(Caixa filtro);
+
+    List<Caixa> search(Caixa filtro, int page, int size);
+}

--- a/src/main/java/dao/api/MonitoramentoDao.java
+++ b/src/main/java/dao/api/MonitoramentoDao.java
@@ -1,0 +1,38 @@
+// path: src/main/java/dao/api/MonitoramentoDao.java
+package dao.api;
+
+import java.util.List;
+
+import exception.MonitoramentoException;
+import model.Monitoramento;
+
+public interface MonitoramentoDao {
+
+    void create(Monitoramento monitoramento) throws MonitoramentoException;
+
+    Monitoramento update(Monitoramento monitoramento) throws MonitoramentoException;
+
+    void deleteById(Integer id) throws MonitoramentoException;
+
+    Monitoramento findById(Integer id) throws MonitoramentoException;
+
+    Monitoramento findWithFotoById(Integer id) throws MonitoramentoException;
+
+    List<Monitoramento> findAll();
+
+    List<Monitoramento> findAll(int page, int size);
+
+    List<Monitoramento> findByStatus(Integer status);
+
+    List<Monitoramento> findByNome(String nome);
+
+    List<Monitoramento> findByDescricao(String descricao);
+
+    List<Monitoramento> findByFoto(byte[] foto);
+
+    List<Monitoramento> findByIdPeriodo(Integer idPeriodo);
+
+    List<Monitoramento> search(Monitoramento filtro);
+
+    List<Monitoramento> search(Monitoramento filtro, int page, int size);
+}

--- a/src/main/java/dao/api/ObjetoDao.java
+++ b/src/main/java/dao/api/ObjetoDao.java
@@ -1,0 +1,39 @@
+// path: src/main/java/dao/api/ObjetoDao.java
+package dao.api;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import exception.ObjetoException;
+import model.Objeto;
+
+public interface ObjetoDao {
+
+    void create(Objeto objeto) throws ObjetoException;
+
+    Objeto update(Objeto objeto) throws ObjetoException;
+
+    void deleteById(Integer id) throws ObjetoException;
+
+    Objeto findById(Integer id) throws ObjetoException;
+
+    Objeto findWithFotoById(Integer id) throws ObjetoException;
+
+    List<Objeto> findAll();
+
+    List<Objeto> findAll(int page, int size);
+
+    List<Objeto> findByNome(String nome);
+
+    List<Objeto> findByTipo(Integer tipo);
+
+    List<Objeto> findByValor(BigDecimal valor);
+
+    List<Objeto> findByDescricao(String descricao);
+
+    List<Objeto> findByFoto(byte[] foto);
+
+    List<Objeto> search(Objeto filtro);
+
+    List<Objeto> search(Objeto filtro, int page, int size);
+}

--- a/src/main/java/dao/api/PeriodoDao.java
+++ b/src/main/java/dao/api/PeriodoDao.java
@@ -1,0 +1,30 @@
+// path: src/main/java/dao/api/PeriodoDao.java
+package dao.api;
+
+import java.util.List;
+
+import exception.PeriodoException;
+import model.Periodo;
+
+public interface PeriodoDao {
+
+    void create(Periodo periodo) throws PeriodoException;
+
+    Periodo update(Periodo periodo) throws PeriodoException;
+
+    void deleteById(Integer id) throws PeriodoException;
+
+    Periodo findById(Integer id) throws PeriodoException;
+
+    List<Periodo> findAll();
+
+    List<Periodo> findAll(int page, int size);
+
+    List<Periodo> findByAno(Integer ano);
+
+    List<Periodo> findByMes(Integer mes);
+
+    List<Periodo> search(Periodo filtro);
+
+    List<Periodo> search(Periodo filtro, int page, int size);
+}

--- a/src/main/java/dao/api/SiteDao.java
+++ b/src/main/java/dao/api/SiteDao.java
@@ -1,0 +1,34 @@
+// path: src/main/java/dao/api/SiteDao.java
+package dao.api;
+
+import java.util.List;
+
+import exception.SiteException;
+import model.Site;
+
+public interface SiteDao {
+
+    void create(Site site) throws SiteException;
+
+    Site update(Site site) throws SiteException;
+
+    void deleteById(Integer id) throws SiteException;
+
+    Site findById(Integer id) throws SiteException;
+
+    Site findWithLogoById(Integer id) throws SiteException;
+
+    List<Site> findAll();
+
+    List<Site> findAll(int page, int size);
+
+    List<Site> findByUrl(String url);
+
+    List<Site> findByAtivo(Boolean ativo);
+
+    List<Site> findByLogo(byte[] logo);
+
+    List<Site> search(Site filtro);
+
+    List<Site> search(Site filtro, int page, int size);
+}

--- a/src/main/java/dao/api/TreinoDao.java
+++ b/src/main/java/dao/api/TreinoDao.java
@@ -1,0 +1,32 @@
+// path: src/main/java/dao/api/TreinoDao.java
+package dao.api;
+
+import java.util.List;
+
+import exception.TreinoException;
+import model.Treino;
+
+public interface TreinoDao {
+
+    void create(Treino treino) throws TreinoException;
+
+    Treino update(Treino treino) throws TreinoException;
+
+    void deleteById(Integer id) throws TreinoException;
+
+    Treino findById(Integer id) throws TreinoException;
+
+    List<Treino> findAll();
+
+    List<Treino> findAll(int page, int size);
+
+    List<Treino> findByNome(String nome);
+
+    List<Treino> findByClasse(String classe);
+
+    List<Treino> findByIdRotina(Integer idRotina);
+
+    List<Treino> search(Treino filtro);
+
+    List<Treino> search(Treino filtro, int page, int size);
+}

--- a/src/main/java/dao/impl/AlimentacaoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/AlimentacaoDaoNativeImpl.java
@@ -1,0 +1,329 @@
+// path: src/main/java/dao/impl/AlimentacaoDaoNativeImpl.java
+package dao.impl;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import dao.api.AlimentacaoDao;
+import exception.AlimentacaoException;
+import infra.EntityManagerUtil;
+import infra.Logger;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import model.Alimentacao;
+
+public class AlimentacaoDaoNativeImpl implements AlimentacaoDao {
+
+    @Override
+    public void create(Alimentacao alimentacao) throws AlimentacaoException {
+        Logger.info("AlimentacaoDaoNativeImpl.create - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "INSERT INTO Alimentacao (id_alimentacao, status, nome, link, video, preparo, id_rotina) " +
+                    "VALUES (:id, :status, :nome, :link, :video, :preparo, :idRotina)";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("id", alimentacao.getIdAlimentacao());
+            query.setParameter("status", alimentacao.getStatus());
+            query.setParameter("nome", alimentacao.getNome());
+            query.setParameter("link", alimentacao.getLink());
+            query.setParameter("video", alimentacao.getVideo());
+            query.setParameter("preparo", alimentacao.getPreparo());
+            query.setParameter("idRotina", alimentacao.getIdRotina());
+            query.executeUpdate();
+            em.getTransaction().commit();
+            Logger.info("AlimentacaoDaoNativeImpl.create - sucesso");
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("AlimentacaoDaoNativeImpl.create - erro", e);
+            throw new AlimentacaoException("Erro ao criar Alimentacao", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Alimentacao update(Alimentacao alimentacao) throws AlimentacaoException {
+        Logger.info("AlimentacaoDaoNativeImpl.update - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "UPDATE Alimentacao SET status=:status, nome=:nome, link=:link, video=:video, preparo=:preparo, id_rotina=:idRotina WHERE id_alimentacao=:id";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("status", alimentacao.getStatus());
+            query.setParameter("nome", alimentacao.getNome());
+            query.setParameter("link", alimentacao.getLink());
+            query.setParameter("video", alimentacao.getVideo());
+            query.setParameter("preparo", alimentacao.getPreparo());
+            query.setParameter("idRotina", alimentacao.getIdRotina());
+            query.setParameter("id", alimentacao.getIdAlimentacao());
+            int updated = query.executeUpdate();
+            if (updated == 0) {
+                throw new AlimentacaoException("Alimentacao não encontrada: id=" + alimentacao.getIdAlimentacao());
+            }
+            em.getTransaction().commit();
+            Logger.info("AlimentacaoDaoNativeImpl.update - sucesso");
+            return findById(alimentacao.getIdAlimentacao());
+        } catch (AlimentacaoException e) {
+            em.getTransaction().rollback();
+            Logger.error("AlimentacaoDaoNativeImpl.update - erro", e);
+            throw e;
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("AlimentacaoDaoNativeImpl.update - erro", e);
+            throw new AlimentacaoException("Erro ao atualizar Alimentacao", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public void deleteById(Integer id) throws AlimentacaoException {
+        Logger.info("AlimentacaoDaoNativeImpl.deleteById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "DELETE FROM Alimentacao WHERE id_alimentacao=:id";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("id", id);
+            int deleted = query.executeUpdate();
+            if (deleted == 0) {
+                throw new AlimentacaoException("Alimentacao não encontrada: id=" + id);
+            }
+            em.getTransaction().commit();
+            Logger.info("AlimentacaoDaoNativeImpl.deleteById - sucesso");
+        } catch (AlimentacaoException e) {
+            em.getTransaction().rollback();
+            Logger.error("AlimentacaoDaoNativeImpl.deleteById - erro", e);
+            throw e;
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("AlimentacaoDaoNativeImpl.deleteById - erro", e);
+            throw new AlimentacaoException("Erro ao deletar Alimentacao", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Alimentacao findById(Integer id) throws AlimentacaoException {
+        Logger.info("AlimentacaoDaoNativeImpl.findById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_alimentacao, status, nome, link, preparo, id_rotina FROM Alimentacao WHERE id_alimentacao=:id";
+            Query query = em.createNativeQuery(sql, Alimentacao.class);
+            query.setParameter("id", id);
+            Alimentacao a = (Alimentacao) query.getSingleResult();
+            Logger.info("AlimentacaoDaoNativeImpl.findById - sucesso");
+            return a;
+        } catch (Exception e) {
+            Logger.error("AlimentacaoDaoNativeImpl.findById - erro", e);
+            throw new AlimentacaoException("Alimentacao não encontrada: id=" + id, e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Alimentacao findWithVideoById(Integer id) throws AlimentacaoException {
+        Logger.info("AlimentacaoDaoNativeImpl.findWithVideoById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_alimentacao, status, nome, link, video, preparo, id_rotina FROM Alimentacao WHERE id_alimentacao=:id";
+            Query query = em.createNativeQuery(sql, Alimentacao.class);
+            query.setParameter("id", id);
+            Alimentacao a = (Alimentacao) query.getSingleResult();
+            Logger.info("AlimentacaoDaoNativeImpl.findWithVideoById - sucesso");
+            return a;
+        } catch (Exception e) {
+            Logger.error("AlimentacaoDaoNativeImpl.findWithVideoById - erro", e);
+            throw new AlimentacaoException("Alimentacao não encontrada: id=" + id, e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Alimentacao> findAll() {
+        Logger.info("AlimentacaoDaoNativeImpl.findAll - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_alimentacao, status, nome, link, preparo, id_rotina FROM Alimentacao";
+            Query query = em.createNativeQuery(sql, Alimentacao.class);
+            List<Alimentacao> list = query.getResultList();
+            Logger.info("AlimentacaoDaoNativeImpl.findAll - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Alimentacao> findAll(int page, int size) {
+        Logger.info("AlimentacaoDaoNativeImpl.findAll(page) - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_alimentacao, status, nome, link, preparo, id_rotina FROM Alimentacao LIMIT :limit OFFSET :offset";
+            Query query = em.createNativeQuery(sql, Alimentacao.class);
+            query.setParameter("limit", size);
+            query.setParameter("offset", page * size);
+            List<Alimentacao> list = query.getResultList();
+            Logger.info("AlimentacaoDaoNativeImpl.findAll(page) - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Alimentacao> findByStatus(Integer status) {
+        Logger.info("AlimentacaoDaoNativeImpl.findByStatus - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_alimentacao, status, nome, link, preparo, id_rotina FROM Alimentacao WHERE status=:status";
+            Query query = em.createNativeQuery(sql, Alimentacao.class);
+            query.setParameter("status", status);
+            List<Alimentacao> list = query.getResultList();
+            Logger.info("AlimentacaoDaoNativeImpl.findByStatus - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Alimentacao> findByNome(String nome) {
+        Logger.info("AlimentacaoDaoNativeImpl.findByNome - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_alimentacao, status, nome, link, preparo, id_rotina FROM Alimentacao WHERE nome=:nome";
+            Query query = em.createNativeQuery(sql, Alimentacao.class);
+            query.setParameter("nome", nome);
+            List<Alimentacao> list = query.getResultList();
+            Logger.info("AlimentacaoDaoNativeImpl.findByNome - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Alimentacao> findByLink(String link) {
+        Logger.info("AlimentacaoDaoNativeImpl.findByLink - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_alimentacao, status, nome, link, preparo, id_rotina FROM Alimentacao WHERE link=:link";
+            Query query = em.createNativeQuery(sql, Alimentacao.class);
+            query.setParameter("link", link);
+            List<Alimentacao> list = query.getResultList();
+            Logger.info("AlimentacaoDaoNativeImpl.findByLink - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Alimentacao> findByVideo(byte[] video) {
+        Logger.info("AlimentacaoDaoNativeImpl.findByVideo - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_alimentacao, status, nome, link, video, preparo, id_rotina FROM Alimentacao WHERE video=:video";
+            Query query = em.createNativeQuery(sql, Alimentacao.class);
+            query.setParameter("video", video);
+            List<Alimentacao> list = query.getResultList();
+            Logger.info("AlimentacaoDaoNativeImpl.findByVideo - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Alimentacao> findByPreparo(String preparo) {
+        Logger.info("AlimentacaoDaoNativeImpl.findByPreparo - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_alimentacao, status, nome, link, preparo, id_rotina FROM Alimentacao WHERE preparo=:preparo";
+            Query query = em.createNativeQuery(sql, Alimentacao.class);
+            query.setParameter("preparo", preparo);
+            List<Alimentacao> list = query.getResultList();
+            Logger.info("AlimentacaoDaoNativeImpl.findByPreparo - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Alimentacao> findByIdRotina(Integer idRotina) {
+        Logger.info("AlimentacaoDaoNativeImpl.findByIdRotina - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_alimentacao, status, nome, link, preparo, id_rotina FROM Alimentacao WHERE id_rotina=:idRotina";
+            Query query = em.createNativeQuery(sql, Alimentacao.class);
+            query.setParameter("idRotina", idRotina);
+            List<Alimentacao> list = query.getResultList();
+            Logger.info("AlimentacaoDaoNativeImpl.findByIdRotina - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Alimentacao> search(Alimentacao filtro) {
+        return search(filtro, -1, -1);
+    }
+
+    @Override
+    public List<Alimentacao> search(Alimentacao filtro, int page, int size) {
+        Logger.info("AlimentacaoDaoNativeImpl.search - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            StringBuilder sb = new StringBuilder("SELECT id_alimentacao, status, nome, link, preparo, id_rotina FROM Alimentacao WHERE 1=1");
+            Map<String, Object> params = new HashMap<>();
+            if (filtro.getStatus() != null) {
+                sb.append(" AND status=:status");
+                params.put("status", filtro.getStatus());
+            }
+            if (filtro.getNome() != null && !filtro.getNome().isEmpty()) {
+                sb.append(" AND nome=:nome");
+                params.put("nome", filtro.getNome());
+            }
+            if (filtro.getLink() != null && !filtro.getLink().isEmpty()) {
+                sb.append(" AND link=:link");
+                params.put("link", filtro.getLink());
+            }
+            if (filtro.getVideo() != null) {
+                sb.append(" AND video=:video");
+                params.put("video", filtro.getVideo());
+            }
+            if (filtro.getPreparo() != null && !filtro.getPreparo().isEmpty()) {
+                sb.append(" AND preparo=:preparo");
+                params.put("preparo", filtro.getPreparo());
+            }
+            if (filtro.getIdRotina() != null) {
+                sb.append(" AND id_rotina=:idRotina");
+                params.put("idRotina", filtro.getIdRotina());
+            }
+            if (page >= 0 && size > 0) {
+                sb.append(" LIMIT :limit OFFSET :offset");
+            }
+            Query query = em.createNativeQuery(sb.toString(), Alimentacao.class);
+            for (Map.Entry<String, Object> e : params.entrySet()) {
+                query.setParameter(e.getKey(), e.getValue());
+            }
+            if (page >= 0 && size > 0) {
+                query.setParameter("limit", size);
+                query.setParameter("offset", page * size);
+            }
+            List<Alimentacao> list = query.getResultList();
+            Logger.info("AlimentacaoDaoNativeImpl.search - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+}

--- a/src/main/java/dao/impl/CaixaDaoNativeImpl.java
+++ b/src/main/java/dao/impl/CaixaDaoNativeImpl.java
@@ -1,0 +1,288 @@
+// path: src/main/java/dao/impl/CaixaDaoNativeImpl.java
+package dao.impl;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import dao.api.CaixaDao;
+import exception.CaixaException;
+import infra.EntityManagerUtil;
+import infra.Logger;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import model.Caixa;
+
+public class CaixaDaoNativeImpl implements CaixaDao {
+
+    @Override
+    public void create(Caixa caixa) throws CaixaException {
+        Logger.info("CaixaDaoNativeImpl.create - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "INSERT INTO Caixa (id_caixa, nome, reserva_emergencia, salario_medio, valor_total, id_usuario) VALUES (:id, :nome, :reserva, :salario, :valor, :idUsuario)";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("id", caixa.getIdCaixa());
+            query.setParameter("nome", caixa.getNome());
+            query.setParameter("reserva", caixa.getReservaEmergencia());
+            query.setParameter("salario", caixa.getSalarioMedio());
+            query.setParameter("valor", caixa.getValorTotal());
+            query.setParameter("idUsuario", caixa.getIdUsuario());
+            query.executeUpdate();
+            em.getTransaction().commit();
+            Logger.info("CaixaDaoNativeImpl.create - sucesso");
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("CaixaDaoNativeImpl.create - erro", e);
+            throw new CaixaException("Erro ao criar Caixa", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Caixa update(Caixa caixa) throws CaixaException {
+        Logger.info("CaixaDaoNativeImpl.update - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "UPDATE Caixa SET nome=:nome, reserva_emergencia=:reserva, salario_medio=:salario, valor_total=:valor, id_usuario=:idUsuario WHERE id_caixa=:id";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("nome", caixa.getNome());
+            query.setParameter("reserva", caixa.getReservaEmergencia());
+            query.setParameter("salario", caixa.getSalarioMedio());
+            query.setParameter("valor", caixa.getValorTotal());
+            query.setParameter("idUsuario", caixa.getIdUsuario());
+            query.setParameter("id", caixa.getIdCaixa());
+            int updated = query.executeUpdate();
+            if (updated == 0) {
+                throw new CaixaException("Caixa não encontrada: id=" + caixa.getIdCaixa());
+            }
+            em.getTransaction().commit();
+            Logger.info("CaixaDaoNativeImpl.update - sucesso");
+            return findById(caixa.getIdCaixa());
+        } catch (CaixaException e) {
+            em.getTransaction().rollback();
+            Logger.error("CaixaDaoNativeImpl.update - erro", e);
+            throw e;
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("CaixaDaoNativeImpl.update - erro", e);
+            throw new CaixaException("Erro ao atualizar Caixa", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public void deleteById(Integer id) throws CaixaException {
+        Logger.info("CaixaDaoNativeImpl.deleteById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "DELETE FROM Caixa WHERE id_caixa=:id";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("id", id);
+            int deleted = query.executeUpdate();
+            if (deleted == 0) {
+                throw new CaixaException("Caixa não encontrada: id=" + id);
+            }
+            em.getTransaction().commit();
+            Logger.info("CaixaDaoNativeImpl.deleteById - sucesso");
+        } catch (CaixaException e) {
+            em.getTransaction().rollback();
+            Logger.error("CaixaDaoNativeImpl.deleteById - erro", e);
+            throw e;
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("CaixaDaoNativeImpl.deleteById - erro", e);
+            throw new CaixaException("Erro ao deletar Caixa", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Caixa findById(Integer id) throws CaixaException {
+        Logger.info("CaixaDaoNativeImpl.findById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_caixa, nome, reserva_emergencia, salario_medio, valor_total, id_usuario FROM Caixa WHERE id_caixa=:id";
+            Query query = em.createNativeQuery(sql, Caixa.class);
+            query.setParameter("id", id);
+            Caixa c = (Caixa) query.getSingleResult();
+            Logger.info("CaixaDaoNativeImpl.findById - sucesso");
+            return c;
+        } catch (Exception e) {
+            Logger.error("CaixaDaoNativeImpl.findById - erro", e);
+            throw new CaixaException("Caixa não encontrada: id=" + id, e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Caixa> findAll() {
+        Logger.info("CaixaDaoNativeImpl.findAll - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_caixa, nome, reserva_emergencia, salario_medio, valor_total, id_usuario FROM Caixa";
+            Query query = em.createNativeQuery(sql, Caixa.class);
+            List<Caixa> list = query.getResultList();
+            Logger.info("CaixaDaoNativeImpl.findAll - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Caixa> findAll(int page, int size) {
+        Logger.info("CaixaDaoNativeImpl.findAll(page) - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_caixa, nome, reserva_emergencia, salario_medio, valor_total, id_usuario FROM Caixa LIMIT :limit OFFSET :offset";
+            Query query = em.createNativeQuery(sql, Caixa.class);
+            query.setParameter("limit", size);
+            query.setParameter("offset", page * size);
+            List<Caixa> list = query.getResultList();
+            Logger.info("CaixaDaoNativeImpl.findAll(page) - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Caixa> findByNome(String nome) {
+        Logger.info("CaixaDaoNativeImpl.findByNome - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_caixa, nome, reserva_emergencia, salario_medio, valor_total, id_usuario FROM Caixa WHERE nome=:nome";
+            Query query = em.createNativeQuery(sql, Caixa.class);
+            query.setParameter("nome", nome);
+            List<Caixa> list = query.getResultList();
+            Logger.info("CaixaDaoNativeImpl.findByNome - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Caixa> findByReservaEmergencia(BigDecimal reservaEmergencia) {
+        Logger.info("CaixaDaoNativeImpl.findByReservaEmergencia - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_caixa, nome, reserva_emergencia, salario_medio, valor_total, id_usuario FROM Caixa WHERE reserva_emergencia=:reserva";
+            Query query = em.createNativeQuery(sql, Caixa.class);
+            query.setParameter("reserva", reservaEmergencia);
+            List<Caixa> list = query.getResultList();
+            Logger.info("CaixaDaoNativeImpl.findByReservaEmergencia - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Caixa> findBySalarioMedio(BigDecimal salarioMedio) {
+        Logger.info("CaixaDaoNativeImpl.findBySalarioMedio - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_caixa, nome, reserva_emergencia, salario_medio, valor_total, id_usuario FROM Caixa WHERE salario_medio=:salario";
+            Query query = em.createNativeQuery(sql, Caixa.class);
+            query.setParameter("salario", salarioMedio);
+            List<Caixa> list = query.getResultList();
+            Logger.info("CaixaDaoNativeImpl.findBySalarioMedio - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Caixa> findByValorTotal(BigDecimal valorTotal) {
+        Logger.info("CaixaDaoNativeImpl.findByValorTotal - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_caixa, nome, reserva_emergencia, salario_medio, valor_total, id_usuario FROM Caixa WHERE valor_total=:valor";
+            Query query = em.createNativeQuery(sql, Caixa.class);
+            query.setParameter("valor", valorTotal);
+            List<Caixa> list = query.getResultList();
+            Logger.info("CaixaDaoNativeImpl.findByValorTotal - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Caixa> findByIdUsuario(Integer idUsuario) {
+        Logger.info("CaixaDaoNativeImpl.findByIdUsuario - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_caixa, nome, reserva_emergencia, salario_medio, valor_total, id_usuario FROM Caixa WHERE id_usuario=:idUsuario";
+            Query query = em.createNativeQuery(sql, Caixa.class);
+            query.setParameter("idUsuario", idUsuario);
+            List<Caixa> list = query.getResultList();
+            Logger.info("CaixaDaoNativeImpl.findByIdUsuario - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Caixa> search(Caixa filtro) {
+        return search(filtro, -1, -1);
+    }
+
+    @Override
+    public List<Caixa> search(Caixa filtro, int page, int size) {
+        Logger.info("CaixaDaoNativeImpl.search - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            StringBuilder sb = new StringBuilder("SELECT id_caixa, nome, reserva_emergencia, salario_medio, valor_total, id_usuario FROM Caixa WHERE 1=1");
+            Map<String, Object> params = new HashMap<>();
+            if (filtro.getNome() != null && !filtro.getNome().isEmpty()) {
+                sb.append(" AND nome=:nome");
+                params.put("nome", filtro.getNome());
+            }
+            if (filtro.getReservaEmergencia() != null) {
+                sb.append(" AND reserva_emergencia=:reserva");
+                params.put("reserva", filtro.getReservaEmergencia());
+            }
+            if (filtro.getSalarioMedio() != null) {
+                sb.append(" AND salario_medio=:salario");
+                params.put("salario", filtro.getSalarioMedio());
+            }
+            if (filtro.getValorTotal() != null) {
+                sb.append(" AND valor_total=:valor");
+                params.put("valor", filtro.getValorTotal());
+            }
+            if (filtro.getIdUsuario() != null) {
+                sb.append(" AND id_usuario=:idUsuario");
+                params.put("idUsuario", filtro.getIdUsuario());
+            }
+            if (page >= 0 && size > 0) {
+                sb.append(" LIMIT :limit OFFSET :offset");
+            }
+            Query query = em.createNativeQuery(sb.toString(), Caixa.class);
+            for (Map.Entry<String, Object> e : params.entrySet()) {
+                query.setParameter(e.getKey(), e.getValue());
+            }
+            if (page >= 0 && size > 0) {
+                query.setParameter("limit", size);
+                query.setParameter("offset", page * size);
+            }
+            List<Caixa> list = query.getResultList();
+            Logger.info("CaixaDaoNativeImpl.search - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+}

--- a/src/main/java/dao/impl/MonitoramentoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/MonitoramentoDaoNativeImpl.java
@@ -1,0 +1,307 @@
+// path: src/main/java/dao/impl/MonitoramentoDaoNativeImpl.java
+package dao.impl;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import dao.api.MonitoramentoDao;
+import exception.MonitoramentoException;
+import infra.EntityManagerUtil;
+import infra.Logger;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import model.Monitoramento;
+
+public class MonitoramentoDaoNativeImpl implements MonitoramentoDao {
+
+    @Override
+    public void create(Monitoramento monitoramento) throws MonitoramentoException {
+        Logger.info("MonitoramentoDaoNativeImpl.create - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "INSERT INTO Monitoramento (id_monitoramento, status, nome, descricao, foto, id_periodo) " +
+                    "VALUES (:id, :status, :nome, :descricao, :foto, :idPeriodo)";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("id", monitoramento.getIdMonitoramento());
+            query.setParameter("status", monitoramento.getStatus());
+            query.setParameter("nome", monitoramento.getNome());
+            query.setParameter("descricao", monitoramento.getDescricao());
+            query.setParameter("foto", monitoramento.getFoto());
+            query.setParameter("idPeriodo", monitoramento.getIdPeriodo());
+            query.executeUpdate();
+            em.getTransaction().commit();
+            Logger.info("MonitoramentoDaoNativeImpl.create - sucesso");
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("MonitoramentoDaoNativeImpl.create - erro", e);
+            throw new MonitoramentoException("Erro ao criar Monitoramento", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Monitoramento update(Monitoramento monitoramento) throws MonitoramentoException {
+        Logger.info("MonitoramentoDaoNativeImpl.update - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "UPDATE Monitoramento SET status=:status, nome=:nome, descricao=:descricao, foto=:foto, id_periodo=:idPeriodo WHERE id_monitoramento=:id";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("status", monitoramento.getStatus());
+            query.setParameter("nome", monitoramento.getNome());
+            query.setParameter("descricao", monitoramento.getDescricao());
+            query.setParameter("foto", monitoramento.getFoto());
+            query.setParameter("idPeriodo", monitoramento.getIdPeriodo());
+            query.setParameter("id", monitoramento.getIdMonitoramento());
+            int updated = query.executeUpdate();
+            if (updated == 0) {
+                throw new MonitoramentoException("Monitoramento não encontrado: id=" + monitoramento.getIdMonitoramento());
+            }
+            em.getTransaction().commit();
+            Logger.info("MonitoramentoDaoNativeImpl.update - sucesso");
+            return findById(monitoramento.getIdMonitoramento());
+        } catch (MonitoramentoException e) {
+            em.getTransaction().rollback();
+            Logger.error("MonitoramentoDaoNativeImpl.update - erro", e);
+            throw e;
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("MonitoramentoDaoNativeImpl.update - erro", e);
+            throw new MonitoramentoException("Erro ao atualizar Monitoramento", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public void deleteById(Integer id) throws MonitoramentoException {
+        Logger.info("MonitoramentoDaoNativeImpl.deleteById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "DELETE FROM Monitoramento WHERE id_monitoramento=:id";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("id", id);
+            int deleted = query.executeUpdate();
+            if (deleted == 0) {
+                throw new MonitoramentoException("Monitoramento não encontrado: id=" + id);
+            }
+            em.getTransaction().commit();
+            Logger.info("MonitoramentoDaoNativeImpl.deleteById - sucesso");
+        } catch (MonitoramentoException e) {
+            em.getTransaction().rollback();
+            Logger.error("MonitoramentoDaoNativeImpl.deleteById - erro", e);
+            throw e;
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("MonitoramentoDaoNativeImpl.deleteById - erro", e);
+            throw new MonitoramentoException("Erro ao deletar Monitoramento", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Monitoramento findById(Integer id) throws MonitoramentoException {
+        Logger.info("MonitoramentoDaoNativeImpl.findById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_monitoramento, status, nome, descricao, id_periodo FROM Monitoramento WHERE id_monitoramento=:id";
+            Query query = em.createNativeQuery(sql, Monitoramento.class);
+            query.setParameter("id", id);
+            Monitoramento m = (Monitoramento) query.getSingleResult();
+            Logger.info("MonitoramentoDaoNativeImpl.findById - sucesso");
+            return m;
+        } catch (Exception e) {
+            Logger.error("MonitoramentoDaoNativeImpl.findById - erro", e);
+            throw new MonitoramentoException("Monitoramento não encontrado: id=" + id, e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Monitoramento findWithFotoById(Integer id) throws MonitoramentoException {
+        Logger.info("MonitoramentoDaoNativeImpl.findWithFotoById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_monitoramento, status, nome, descricao, foto, id_periodo FROM Monitoramento WHERE id_monitoramento=:id";
+            Query query = em.createNativeQuery(sql, Monitoramento.class);
+            query.setParameter("id", id);
+            Monitoramento m = (Monitoramento) query.getSingleResult();
+            Logger.info("MonitoramentoDaoNativeImpl.findWithFotoById - sucesso");
+            return m;
+        } catch (Exception e) {
+            Logger.error("MonitoramentoDaoNativeImpl.findWithFotoById - erro", e);
+            throw new MonitoramentoException("Monitoramento não encontrado: id=" + id, e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Monitoramento> findAll() {
+        Logger.info("MonitoramentoDaoNativeImpl.findAll - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_monitoramento, status, nome, descricao, id_periodo FROM Monitoramento";
+            Query query = em.createNativeQuery(sql, Monitoramento.class);
+            List<Monitoramento> list = query.getResultList();
+            Logger.info("MonitoramentoDaoNativeImpl.findAll - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Monitoramento> findAll(int page, int size) {
+        Logger.info("MonitoramentoDaoNativeImpl.findAll(page) - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_monitoramento, status, nome, descricao, id_periodo FROM Monitoramento LIMIT :limit OFFSET :offset";
+            Query query = em.createNativeQuery(sql, Monitoramento.class);
+            query.setParameter("limit", size);
+            query.setParameter("offset", page * size);
+            List<Monitoramento> list = query.getResultList();
+            Logger.info("MonitoramentoDaoNativeImpl.findAll(page) - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Monitoramento> findByStatus(Integer status) {
+        Logger.info("MonitoramentoDaoNativeImpl.findByStatus - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_monitoramento, status, nome, descricao, id_periodo FROM Monitoramento WHERE status=:status";
+            Query query = em.createNativeQuery(sql, Monitoramento.class);
+            query.setParameter("status", status);
+            List<Monitoramento> list = query.getResultList();
+            Logger.info("MonitoramentoDaoNativeImpl.findByStatus - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Monitoramento> findByNome(String nome) {
+        Logger.info("MonitoramentoDaoNativeImpl.findByNome - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_monitoramento, status, nome, descricao, id_periodo FROM Monitoramento WHERE nome=:nome";
+            Query query = em.createNativeQuery(sql, Monitoramento.class);
+            query.setParameter("nome", nome);
+            List<Monitoramento> list = query.getResultList();
+            Logger.info("MonitoramentoDaoNativeImpl.findByNome - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Monitoramento> findByDescricao(String descricao) {
+        Logger.info("MonitoramentoDaoNativeImpl.findByDescricao - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_monitoramento, status, nome, descricao, id_periodo FROM Monitoramento WHERE descricao=:descricao";
+            Query query = em.createNativeQuery(sql, Monitoramento.class);
+            query.setParameter("descricao", descricao);
+            List<Monitoramento> list = query.getResultList();
+            Logger.info("MonitoramentoDaoNativeImpl.findByDescricao - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Monitoramento> findByFoto(byte[] foto) {
+        Logger.info("MonitoramentoDaoNativeImpl.findByFoto - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_monitoramento, status, nome, descricao, foto, id_periodo FROM Monitoramento WHERE foto=:foto";
+            Query query = em.createNativeQuery(sql, Monitoramento.class);
+            query.setParameter("foto", foto);
+            List<Monitoramento> list = query.getResultList();
+            Logger.info("MonitoramentoDaoNativeImpl.findByFoto - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Monitoramento> findByIdPeriodo(Integer idPeriodo) {
+        Logger.info("MonitoramentoDaoNativeImpl.findByIdPeriodo - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_monitoramento, status, nome, descricao, id_periodo FROM Monitoramento WHERE id_periodo=:idPeriodo";
+            Query query = em.createNativeQuery(sql, Monitoramento.class);
+            query.setParameter("idPeriodo", idPeriodo);
+            List<Monitoramento> list = query.getResultList();
+            Logger.info("MonitoramentoDaoNativeImpl.findByIdPeriodo - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Monitoramento> search(Monitoramento filtro) {
+        return search(filtro, -1, -1);
+    }
+
+    @Override
+    public List<Monitoramento> search(Monitoramento filtro, int page, int size) {
+        Logger.info("MonitoramentoDaoNativeImpl.search - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            StringBuilder sb = new StringBuilder("SELECT id_monitoramento, status, nome, descricao, id_periodo FROM Monitoramento WHERE 1=1");
+            Map<String, Object> params = new HashMap<>();
+            if (filtro.getStatus() != null) {
+                sb.append(" AND status=:status");
+                params.put("status", filtro.getStatus());
+            }
+            if (filtro.getNome() != null && !filtro.getNome().isEmpty()) {
+                sb.append(" AND nome=:nome");
+                params.put("nome", filtro.getNome());
+            }
+            if (filtro.getDescricao() != null && !filtro.getDescricao().isEmpty()) {
+                sb.append(" AND descricao=:descricao");
+                params.put("descricao", filtro.getDescricao());
+            }
+            if (filtro.getFoto() != null) {
+                sb.append(" AND foto=:foto");
+                params.put("foto", filtro.getFoto());
+            }
+            if (filtro.getIdPeriodo() != null) {
+                sb.append(" AND id_periodo=:idPeriodo");
+                params.put("idPeriodo", filtro.getIdPeriodo());
+            }
+            if (page >= 0 && size > 0) {
+                sb.append(" LIMIT :limit OFFSET :offset");
+            }
+            Query query = em.createNativeQuery(sb.toString(), Monitoramento.class);
+            for (Map.Entry<String, Object> e : params.entrySet()) {
+                query.setParameter(e.getKey(), e.getValue());
+            }
+            if (page >= 0 && size > 0) {
+                query.setParameter("limit", size);
+                query.setParameter("offset", page * size);
+            }
+            List<Monitoramento> list = query.getResultList();
+            Logger.info("MonitoramentoDaoNativeImpl.search - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+}

--- a/src/main/java/dao/impl/ObjetoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/ObjetoDaoNativeImpl.java
@@ -1,0 +1,307 @@
+// path: src/main/java/dao/impl/ObjetoDaoNativeImpl.java
+package dao.impl;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import dao.api.ObjetoDao;
+import exception.ObjetoException;
+import infra.EntityManagerUtil;
+import infra.Logger;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import model.Objeto;
+
+public class ObjetoDaoNativeImpl implements ObjetoDao {
+
+    @Override
+    public void create(Objeto objeto) throws ObjetoException {
+        Logger.info("ObjetoDaoNativeImpl.create - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "INSERT INTO Objeto (id_objeto, nome, tipo, valor, descricao, foto) VALUES (:id, :nome, :tipo, :valor, :descricao, :foto)";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("id", objeto.getIdObjeto());
+            query.setParameter("nome", objeto.getNome());
+            query.setParameter("tipo", objeto.getTipo());
+            query.setParameter("valor", objeto.getValor());
+            query.setParameter("descricao", objeto.getDescricao());
+            query.setParameter("foto", objeto.getFoto());
+            query.executeUpdate();
+            em.getTransaction().commit();
+            Logger.info("ObjetoDaoNativeImpl.create - sucesso");
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("ObjetoDaoNativeImpl.create - erro", e);
+            throw new ObjetoException("Erro ao criar Objeto", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Objeto update(Objeto objeto) throws ObjetoException {
+        Logger.info("ObjetoDaoNativeImpl.update - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "UPDATE Objeto SET nome=:nome, tipo=:tipo, valor=:valor, descricao=:descricao, foto=:foto WHERE id_objeto=:id";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("nome", objeto.getNome());
+            query.setParameter("tipo", objeto.getTipo());
+            query.setParameter("valor", objeto.getValor());
+            query.setParameter("descricao", objeto.getDescricao());
+            query.setParameter("foto", objeto.getFoto());
+            query.setParameter("id", objeto.getIdObjeto());
+            int updated = query.executeUpdate();
+            if (updated == 0) {
+                throw new ObjetoException("Objeto não encontrado: id=" + objeto.getIdObjeto());
+            }
+            em.getTransaction().commit();
+            Logger.info("ObjetoDaoNativeImpl.update - sucesso");
+            return findById(objeto.getIdObjeto());
+        } catch (ObjetoException e) {
+            em.getTransaction().rollback();
+            Logger.error("ObjetoDaoNativeImpl.update - erro", e);
+            throw e;
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("ObjetoDaoNativeImpl.update - erro", e);
+            throw new ObjetoException("Erro ao atualizar Objeto", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public void deleteById(Integer id) throws ObjetoException {
+        Logger.info("ObjetoDaoNativeImpl.deleteById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "DELETE FROM Objeto WHERE id_objeto=:id";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("id", id);
+            int deleted = query.executeUpdate();
+            if (deleted == 0) {
+                throw new ObjetoException("Objeto não encontrado: id=" + id);
+            }
+            em.getTransaction().commit();
+            Logger.info("ObjetoDaoNativeImpl.deleteById - sucesso");
+        } catch (ObjetoException e) {
+            em.getTransaction().rollback();
+            Logger.error("ObjetoDaoNativeImpl.deleteById - erro", e);
+            throw e;
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("ObjetoDaoNativeImpl.deleteById - erro", e);
+            throw new ObjetoException("Erro ao deletar Objeto", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Objeto findById(Integer id) throws ObjetoException {
+        Logger.info("ObjetoDaoNativeImpl.findById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_objeto, nome, tipo, valor, descricao FROM Objeto WHERE id_objeto=:id";
+            Query query = em.createNativeQuery(sql, Objeto.class);
+            query.setParameter("id", id);
+            Objeto o = (Objeto) query.getSingleResult();
+            Logger.info("ObjetoDaoNativeImpl.findById - sucesso");
+            return o;
+        } catch (Exception e) {
+            Logger.error("ObjetoDaoNativeImpl.findById - erro", e);
+            throw new ObjetoException("Objeto não encontrado: id=" + id, e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Objeto findWithFotoById(Integer id) throws ObjetoException {
+        Logger.info("ObjetoDaoNativeImpl.findWithFotoById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_objeto, nome, tipo, valor, descricao, foto FROM Objeto WHERE id_objeto=:id";
+            Query query = em.createNativeQuery(sql, Objeto.class);
+            query.setParameter("id", id);
+            Objeto o = (Objeto) query.getSingleResult();
+            Logger.info("ObjetoDaoNativeImpl.findWithFotoById - sucesso");
+            return o;
+        } catch (Exception e) {
+            Logger.error("ObjetoDaoNativeImpl.findWithFotoById - erro", e);
+            throw new ObjetoException("Objeto não encontrado: id=" + id, e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Objeto> findAll() {
+        Logger.info("ObjetoDaoNativeImpl.findAll - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_objeto, nome, tipo, valor, descricao FROM Objeto";
+            Query query = em.createNativeQuery(sql, Objeto.class);
+            List<Objeto> list = query.getResultList();
+            Logger.info("ObjetoDaoNativeImpl.findAll - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Objeto> findAll(int page, int size) {
+        Logger.info("ObjetoDaoNativeImpl.findAll(page) - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_objeto, nome, tipo, valor, descricao FROM Objeto LIMIT :limit OFFSET :offset";
+            Query query = em.createNativeQuery(sql, Objeto.class);
+            query.setParameter("limit", size);
+            query.setParameter("offset", page * size);
+            List<Objeto> list = query.getResultList();
+            Logger.info("ObjetoDaoNativeImpl.findAll(page) - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Objeto> findByNome(String nome) {
+        Logger.info("ObjetoDaoNativeImpl.findByNome - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_objeto, nome, tipo, valor, descricao FROM Objeto WHERE nome=:nome";
+            Query query = em.createNativeQuery(sql, Objeto.class);
+            query.setParameter("nome", nome);
+            List<Objeto> list = query.getResultList();
+            Logger.info("ObjetoDaoNativeImpl.findByNome - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Objeto> findByTipo(Integer tipo) {
+        Logger.info("ObjetoDaoNativeImpl.findByTipo - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_objeto, nome, tipo, valor, descricao FROM Objeto WHERE tipo=:tipo";
+            Query query = em.createNativeQuery(sql, Objeto.class);
+            query.setParameter("tipo", tipo);
+            List<Objeto> list = query.getResultList();
+            Logger.info("ObjetoDaoNativeImpl.findByTipo - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Objeto> findByValor(BigDecimal valor) {
+        Logger.info("ObjetoDaoNativeImpl.findByValor - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_objeto, nome, tipo, valor, descricao FROM Objeto WHERE valor=:valor";
+            Query query = em.createNativeQuery(sql, Objeto.class);
+            query.setParameter("valor", valor);
+            List<Objeto> list = query.getResultList();
+            Logger.info("ObjetoDaoNativeImpl.findByValor - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Objeto> findByDescricao(String descricao) {
+        Logger.info("ObjetoDaoNativeImpl.findByDescricao - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_objeto, nome, tipo, valor, descricao FROM Objeto WHERE descricao=:descricao";
+            Query query = em.createNativeQuery(sql, Objeto.class);
+            query.setParameter("descricao", descricao);
+            List<Objeto> list = query.getResultList();
+            Logger.info("ObjetoDaoNativeImpl.findByDescricao - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Objeto> findByFoto(byte[] foto) {
+        Logger.info("ObjetoDaoNativeImpl.findByFoto - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_objeto, nome, tipo, valor, descricao, foto FROM Objeto WHERE foto=:foto";
+            Query query = em.createNativeQuery(sql, Objeto.class);
+            query.setParameter("foto", foto);
+            List<Objeto> list = query.getResultList();
+            Logger.info("ObjetoDaoNativeImpl.findByFoto - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Objeto> search(Objeto filtro) {
+        return search(filtro, -1, -1);
+    }
+
+    @Override
+    public List<Objeto> search(Objeto filtro, int page, int size) {
+        Logger.info("ObjetoDaoNativeImpl.search - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            StringBuilder sb = new StringBuilder("SELECT id_objeto, nome, tipo, valor, descricao FROM Objeto WHERE 1=1");
+            Map<String, Object> params = new HashMap<>();
+            if (filtro.getNome() != null && !filtro.getNome().isEmpty()) {
+                sb.append(" AND nome=:nome");
+                params.put("nome", filtro.getNome());
+            }
+            if (filtro.getTipo() != null) {
+                sb.append(" AND tipo=:tipo");
+                params.put("tipo", filtro.getTipo());
+            }
+            if (filtro.getValor() != null) {
+                sb.append(" AND valor=:valor");
+                params.put("valor", filtro.getValor());
+            }
+            if (filtro.getDescricao() != null && !filtro.getDescricao().isEmpty()) {
+                sb.append(" AND descricao=:descricao");
+                params.put("descricao", filtro.getDescricao());
+            }
+            if (filtro.getFoto() != null) {
+                sb.append(" AND foto=:foto");
+                params.put("foto", filtro.getFoto());
+            }
+            if (page >= 0 && size > 0) {
+                sb.append(" LIMIT :limit OFFSET :offset");
+            }
+            Query query = em.createNativeQuery(sb.toString(), Objeto.class);
+            for (Map.Entry<String, Object> e : params.entrySet()) {
+                query.setParameter(e.getKey(), e.getValue());
+            }
+            if (page >= 0 && size > 0) {
+                query.setParameter("limit", size);
+                query.setParameter("offset", page * size);
+            }
+            List<Objeto> list = query.getResultList();
+            Logger.info("ObjetoDaoNativeImpl.search - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+}

--- a/src/main/java/dao/impl/PeriodoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/PeriodoDaoNativeImpl.java
@@ -1,0 +1,221 @@
+// path: src/main/java/dao/impl/PeriodoDaoNativeImpl.java
+package dao.impl;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import dao.api.PeriodoDao;
+import exception.PeriodoException;
+import infra.EntityManagerUtil;
+import infra.Logger;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import model.Periodo;
+
+public class PeriodoDaoNativeImpl implements PeriodoDao {
+
+    @Override
+    public void create(Periodo periodo) throws PeriodoException {
+        Logger.info("PeriodoDaoNativeImpl.create - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "INSERT INTO Periodo (id_periodo, ano, mes) VALUES (:id, :ano, :mes)";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("id", periodo.getIdPeriodo());
+            query.setParameter("ano", periodo.getAno());
+            query.setParameter("mes", periodo.getMes());
+            query.executeUpdate();
+            em.getTransaction().commit();
+            Logger.info("PeriodoDaoNativeImpl.create - sucesso");
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("PeriodoDaoNativeImpl.create - erro", e);
+            throw new PeriodoException("Erro ao criar Periodo", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Periodo update(Periodo periodo) throws PeriodoException {
+        Logger.info("PeriodoDaoNativeImpl.update - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "UPDATE Periodo SET ano=:ano, mes=:mes WHERE id_periodo=:id";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("ano", periodo.getAno());
+            query.setParameter("mes", periodo.getMes());
+            query.setParameter("id", periodo.getIdPeriodo());
+            int updated = query.executeUpdate();
+            if (updated == 0) {
+                throw new PeriodoException("Periodo não encontrado: id=" + periodo.getIdPeriodo());
+            }
+            em.getTransaction().commit();
+            Logger.info("PeriodoDaoNativeImpl.update - sucesso");
+            return findById(periodo.getIdPeriodo());
+        } catch (PeriodoException e) {
+            em.getTransaction().rollback();
+            Logger.error("PeriodoDaoNativeImpl.update - erro", e);
+            throw e;
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("PeriodoDaoNativeImpl.update - erro", e);
+            throw new PeriodoException("Erro ao atualizar Periodo", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public void deleteById(Integer id) throws PeriodoException {
+        Logger.info("PeriodoDaoNativeImpl.deleteById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "DELETE FROM Periodo WHERE id_periodo=:id";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("id", id);
+            int deleted = query.executeUpdate();
+            if (deleted == 0) {
+                throw new PeriodoException("Periodo não encontrado: id=" + id);
+            }
+            em.getTransaction().commit();
+            Logger.info("PeriodoDaoNativeImpl.deleteById - sucesso");
+        } catch (PeriodoException e) {
+            em.getTransaction().rollback();
+            Logger.error("PeriodoDaoNativeImpl.deleteById - erro", e);
+            throw e;
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("PeriodoDaoNativeImpl.deleteById - erro", e);
+            throw new PeriodoException("Erro ao deletar Periodo", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Periodo findById(Integer id) throws PeriodoException {
+        Logger.info("PeriodoDaoNativeImpl.findById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_periodo, ano, mes FROM Periodo WHERE id_periodo=:id";
+            Query query = em.createNativeQuery(sql, Periodo.class);
+            query.setParameter("id", id);
+            Periodo p = (Periodo) query.getSingleResult();
+            Logger.info("PeriodoDaoNativeImpl.findById - sucesso");
+            return p;
+        } catch (Exception e) {
+            Logger.error("PeriodoDaoNativeImpl.findById - erro", e);
+            throw new PeriodoException("Periodo não encontrado: id=" + id, e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Periodo> findAll() {
+        Logger.info("PeriodoDaoNativeImpl.findAll - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_periodo, ano, mes FROM Periodo";
+            Query query = em.createNativeQuery(sql, Periodo.class);
+            List<Periodo> list = query.getResultList();
+            Logger.info("PeriodoDaoNativeImpl.findAll - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Periodo> findAll(int page, int size) {
+        Logger.info("PeriodoDaoNativeImpl.findAll(page) - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_periodo, ano, mes FROM Periodo LIMIT :limit OFFSET :offset";
+            Query query = em.createNativeQuery(sql, Periodo.class);
+            query.setParameter("limit", size);
+            query.setParameter("offset", page * size);
+            List<Periodo> list = query.getResultList();
+            Logger.info("PeriodoDaoNativeImpl.findAll(page) - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Periodo> findByAno(Integer ano) {
+        Logger.info("PeriodoDaoNativeImpl.findByAno - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_periodo, ano, mes FROM Periodo WHERE ano=:ano";
+            Query query = em.createNativeQuery(sql, Periodo.class);
+            query.setParameter("ano", ano);
+            List<Periodo> list = query.getResultList();
+            Logger.info("PeriodoDaoNativeImpl.findByAno - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Periodo> findByMes(Integer mes) {
+        Logger.info("PeriodoDaoNativeImpl.findByMes - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_periodo, ano, mes FROM Periodo WHERE mes=:mes";
+            Query query = em.createNativeQuery(sql, Periodo.class);
+            query.setParameter("mes", mes);
+            List<Periodo> list = query.getResultList();
+            Logger.info("PeriodoDaoNativeImpl.findByMes - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Periodo> search(Periodo filtro) {
+        return search(filtro, -1, -1);
+    }
+
+    @Override
+    public List<Periodo> search(Periodo filtro, int page, int size) {
+        Logger.info("PeriodoDaoNativeImpl.search - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            StringBuilder sb = new StringBuilder("SELECT id_periodo, ano, mes FROM Periodo WHERE 1=1");
+            Map<String, Object> params = new HashMap<>();
+            if (filtro.getAno() != null) {
+                sb.append(" AND ano=:ano");
+                params.put("ano", filtro.getAno());
+            }
+            if (filtro.getMes() != null) {
+                sb.append(" AND mes=:mes");
+                params.put("mes", filtro.getMes());
+            }
+            if (page >= 0 && size > 0) {
+                sb.append(" LIMIT :limit OFFSET :offset");
+            }
+            Query query = em.createNativeQuery(sb.toString(), Periodo.class);
+            for (Map.Entry<String, Object> e : params.entrySet()) {
+                query.setParameter(e.getKey(), e.getValue());
+            }
+            if (page >= 0 && size > 0) {
+                query.setParameter("limit", size);
+                query.setParameter("offset", page * size);
+            }
+            List<Periodo> list = query.getResultList();
+            Logger.info("PeriodoDaoNativeImpl.search - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+}

--- a/src/main/java/dao/impl/SiteDaoNativeImpl.java
+++ b/src/main/java/dao/impl/SiteDaoNativeImpl.java
@@ -1,0 +1,262 @@
+// path: src/main/java/dao/impl/SiteDaoNativeImpl.java
+package dao.impl;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import dao.api.SiteDao;
+import exception.SiteException;
+import infra.EntityManagerUtil;
+import infra.Logger;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import model.Site;
+
+public class SiteDaoNativeImpl implements SiteDao {
+
+    @Override
+    public void create(Site site) throws SiteException {
+        Logger.info("SiteDaoNativeImpl.create - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "INSERT INTO Site (id_site, url, ativo, logo) VALUES (:id, :url, :ativo, :logo)";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("id", site.getIdSite());
+            query.setParameter("url", site.getUrl());
+            query.setParameter("ativo", site.getAtivo());
+            query.setParameter("logo", site.getLogo());
+            query.executeUpdate();
+            em.getTransaction().commit();
+            Logger.info("SiteDaoNativeImpl.create - sucesso");
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("SiteDaoNativeImpl.create - erro", e);
+            throw new SiteException("Erro ao criar Site", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Site update(Site site) throws SiteException {
+        Logger.info("SiteDaoNativeImpl.update - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "UPDATE Site SET url=:url, ativo=:ativo, logo=:logo WHERE id_site=:id";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("url", site.getUrl());
+            query.setParameter("ativo", site.getAtivo());
+            query.setParameter("logo", site.getLogo());
+            query.setParameter("id", site.getIdSite());
+            int updated = query.executeUpdate();
+            if (updated == 0) {
+                throw new SiteException("Site não encontrado: id=" + site.getIdSite());
+            }
+            em.getTransaction().commit();
+            Logger.info("SiteDaoNativeImpl.update - sucesso");
+            return findById(site.getIdSite());
+        } catch (SiteException e) {
+            em.getTransaction().rollback();
+            Logger.error("SiteDaoNativeImpl.update - erro", e);
+            throw e;
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("SiteDaoNativeImpl.update - erro", e);
+            throw new SiteException("Erro ao atualizar Site", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public void deleteById(Integer id) throws SiteException {
+        Logger.info("SiteDaoNativeImpl.deleteById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "DELETE FROM Site WHERE id_site=:id";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("id", id);
+            int deleted = query.executeUpdate();
+            if (deleted == 0) {
+                throw new SiteException("Site não encontrado: id=" + id);
+            }
+            em.getTransaction().commit();
+            Logger.info("SiteDaoNativeImpl.deleteById - sucesso");
+        } catch (SiteException e) {
+            em.getTransaction().rollback();
+            Logger.error("SiteDaoNativeImpl.deleteById - erro", e);
+            throw e;
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("SiteDaoNativeImpl.deleteById - erro", e);
+            throw new SiteException("Erro ao deletar Site", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Site findById(Integer id) throws SiteException {
+        Logger.info("SiteDaoNativeImpl.findById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_site, url, ativo FROM Site WHERE id_site=:id";
+            Query query = em.createNativeQuery(sql, Site.class);
+            query.setParameter("id", id);
+            Site s = (Site) query.getSingleResult();
+            Logger.info("SiteDaoNativeImpl.findById - sucesso");
+            return s;
+        } catch (Exception e) {
+            Logger.error("SiteDaoNativeImpl.findById - erro", e);
+            throw new SiteException("Site não encontrado: id=" + id, e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Site findWithLogoById(Integer id) throws SiteException {
+        Logger.info("SiteDaoNativeImpl.findWithLogoById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_site, url, ativo, logo FROM Site WHERE id_site=:id";
+            Query query = em.createNativeQuery(sql, Site.class);
+            query.setParameter("id", id);
+            Site s = (Site) query.getSingleResult();
+            Logger.info("SiteDaoNativeImpl.findWithLogoById - sucesso");
+            return s;
+        } catch (Exception e) {
+            Logger.error("SiteDaoNativeImpl.findWithLogoById - erro", e);
+            throw new SiteException("Site não encontrado: id=" + id, e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Site> findAll() {
+        Logger.info("SiteDaoNativeImpl.findAll - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_site, url, ativo FROM Site";
+            Query query = em.createNativeQuery(sql, Site.class);
+            List<Site> list = query.getResultList();
+            Logger.info("SiteDaoNativeImpl.findAll - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Site> findAll(int page, int size) {
+        Logger.info("SiteDaoNativeImpl.findAll(page) - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_site, url, ativo FROM Site LIMIT :limit OFFSET :offset";
+            Query query = em.createNativeQuery(sql, Site.class);
+            query.setParameter("limit", size);
+            query.setParameter("offset", page * size);
+            List<Site> list = query.getResultList();
+            Logger.info("SiteDaoNativeImpl.findAll(page) - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Site> findByUrl(String url) {
+        Logger.info("SiteDaoNativeImpl.findByUrl - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_site, url, ativo FROM Site WHERE url=:url";
+            Query query = em.createNativeQuery(sql, Site.class);
+            query.setParameter("url", url);
+            List<Site> list = query.getResultList();
+            Logger.info("SiteDaoNativeImpl.findByUrl - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Site> findByAtivo(Boolean ativo) {
+        Logger.info("SiteDaoNativeImpl.findByAtivo - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_site, url, ativo FROM Site WHERE ativo=:ativo";
+            Query query = em.createNativeQuery(sql, Site.class);
+            query.setParameter("ativo", ativo);
+            List<Site> list = query.getResultList();
+            Logger.info("SiteDaoNativeImpl.findByAtivo - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Site> findByLogo(byte[] logo) {
+        Logger.info("SiteDaoNativeImpl.findByLogo - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_site, url, ativo, logo FROM Site WHERE logo=:logo";
+            Query query = em.createNativeQuery(sql, Site.class);
+            query.setParameter("logo", logo);
+            List<Site> list = query.getResultList();
+            Logger.info("SiteDaoNativeImpl.findByLogo - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Site> search(Site filtro) {
+        return search(filtro, -1, -1);
+    }
+
+    @Override
+    public List<Site> search(Site filtro, int page, int size) {
+        Logger.info("SiteDaoNativeImpl.search - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            StringBuilder sb = new StringBuilder("SELECT id_site, url, ativo FROM Site WHERE 1=1");
+            Map<String, Object> params = new HashMap<>();
+            if (filtro.getUrl() != null && !filtro.getUrl().isEmpty()) {
+                sb.append(" AND url=:url");
+                params.put("url", filtro.getUrl());
+            }
+            if (filtro.getAtivo() != null) {
+                sb.append(" AND ativo=:ativo");
+                params.put("ativo", filtro.getAtivo());
+            }
+            if (filtro.getLogo() != null) {
+                sb.append(" AND logo=:logo");
+                params.put("logo", filtro.getLogo());
+            }
+            if (page >= 0 && size > 0) {
+                sb.append(" LIMIT :limit OFFSET :offset");
+            }
+            Query query = em.createNativeQuery(sb.toString(), Site.class);
+            for (Map.Entry<String, Object> e : params.entrySet()) {
+                query.setParameter(e.getKey(), e.getValue());
+            }
+            if (page >= 0 && size > 0) {
+                query.setParameter("limit", size);
+                query.setParameter("offset", page * size);
+            }
+            List<Site> list = query.getResultList();
+            Logger.info("SiteDaoNativeImpl.search - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+}

--- a/src/main/java/dao/impl/TreinoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/TreinoDaoNativeImpl.java
@@ -1,0 +1,243 @@
+// path: src/main/java/dao/impl/TreinoDaoNativeImpl.java
+package dao.impl;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import dao.api.TreinoDao;
+import exception.TreinoException;
+import infra.EntityManagerUtil;
+import infra.Logger;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import model.Treino;
+
+public class TreinoDaoNativeImpl implements TreinoDao {
+
+    @Override
+    public void create(Treino treino) throws TreinoException {
+        Logger.info("TreinoDaoNativeImpl.create - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "INSERT INTO Treino (id_treino, nome, classe, id_rotina) VALUES (:id, :nome, :classe, :idRotina)";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("id", treino.getIdTreino());
+            query.setParameter("nome", treino.getNome());
+            query.setParameter("classe", treino.getClasse());
+            query.setParameter("idRotina", treino.getIdRotina());
+            query.executeUpdate();
+            em.getTransaction().commit();
+            Logger.info("TreinoDaoNativeImpl.create - sucesso");
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("TreinoDaoNativeImpl.create - erro", e);
+            throw new TreinoException("Erro ao criar Treino", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Treino update(Treino treino) throws TreinoException {
+        Logger.info("TreinoDaoNativeImpl.update - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "UPDATE Treino SET nome=:nome, classe=:classe, id_rotina=:idRotina WHERE id_treino=:id";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("nome", treino.getNome());
+            query.setParameter("classe", treino.getClasse());
+            query.setParameter("idRotina", treino.getIdRotina());
+            query.setParameter("id", treino.getIdTreino());
+            int updated = query.executeUpdate();
+            if (updated == 0) {
+                throw new TreinoException("Treino não encontrado: id=" + treino.getIdTreino());
+            }
+            em.getTransaction().commit();
+            Logger.info("TreinoDaoNativeImpl.update - sucesso");
+            return findById(treino.getIdTreino());
+        } catch (TreinoException e) {
+            em.getTransaction().rollback();
+            Logger.error("TreinoDaoNativeImpl.update - erro", e);
+            throw e;
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("TreinoDaoNativeImpl.update - erro", e);
+            throw new TreinoException("Erro ao atualizar Treino", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public void deleteById(Integer id) throws TreinoException {
+        Logger.info("TreinoDaoNativeImpl.deleteById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            String sql = "DELETE FROM Treino WHERE id_treino=:id";
+            Query query = em.createNativeQuery(sql);
+            query.setParameter("id", id);
+            int deleted = query.executeUpdate();
+            if (deleted == 0) {
+                throw new TreinoException("Treino não encontrado: id=" + id);
+            }
+            em.getTransaction().commit();
+            Logger.info("TreinoDaoNativeImpl.deleteById - sucesso");
+        } catch (TreinoException e) {
+            em.getTransaction().rollback();
+            Logger.error("TreinoDaoNativeImpl.deleteById - erro", e);
+            throw e;
+        } catch (Exception e) {
+            em.getTransaction().rollback();
+            Logger.error("TreinoDaoNativeImpl.deleteById - erro", e);
+            throw new TreinoException("Erro ao deletar Treino", e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public Treino findById(Integer id) throws TreinoException {
+        Logger.info("TreinoDaoNativeImpl.findById - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_treino, nome, classe, id_rotina FROM Treino WHERE id_treino=:id";
+            Query query = em.createNativeQuery(sql, Treino.class);
+            query.setParameter("id", id);
+            Treino t = (Treino) query.getSingleResult();
+            Logger.info("TreinoDaoNativeImpl.findById - sucesso");
+            return t;
+        } catch (Exception e) {
+            Logger.error("TreinoDaoNativeImpl.findById - erro", e);
+            throw new TreinoException("Treino não encontrado: id=" + id, e);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Treino> findAll() {
+        Logger.info("TreinoDaoNativeImpl.findAll - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_treino, nome, classe, id_rotina FROM Treino";
+            Query query = em.createNativeQuery(sql, Treino.class);
+            List<Treino> list = query.getResultList();
+            Logger.info("TreinoDaoNativeImpl.findAll - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Treino> findAll(int page, int size) {
+        Logger.info("TreinoDaoNativeImpl.findAll(page) - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_treino, nome, classe, id_rotina FROM Treino LIMIT :limit OFFSET :offset";
+            Query query = em.createNativeQuery(sql, Treino.class);
+            query.setParameter("limit", size);
+            query.setParameter("offset", page * size);
+            List<Treino> list = query.getResultList();
+            Logger.info("TreinoDaoNativeImpl.findAll(page) - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Treino> findByNome(String nome) {
+        Logger.info("TreinoDaoNativeImpl.findByNome - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_treino, nome, classe, id_rotina FROM Treino WHERE nome=:nome";
+            Query query = em.createNativeQuery(sql, Treino.class);
+            query.setParameter("nome", nome);
+            List<Treino> list = query.getResultList();
+            Logger.info("TreinoDaoNativeImpl.findByNome - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Treino> findByClasse(String classe) {
+        Logger.info("TreinoDaoNativeImpl.findByClasse - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_treino, nome, classe, id_rotina FROM Treino WHERE classe=:classe";
+            Query query = em.createNativeQuery(sql, Treino.class);
+            query.setParameter("classe", classe);
+            List<Treino> list = query.getResultList();
+            Logger.info("TreinoDaoNativeImpl.findByClasse - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Treino> findByIdRotina(Integer idRotina) {
+        Logger.info("TreinoDaoNativeImpl.findByIdRotina - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            String sql = "SELECT id_treino, nome, classe, id_rotina FROM Treino WHERE id_rotina=:idRotina";
+            Query query = em.createNativeQuery(sql, Treino.class);
+            query.setParameter("idRotina", idRotina);
+            List<Treino> list = query.getResultList();
+            Logger.info("TreinoDaoNativeImpl.findByIdRotina - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<Treino> search(Treino filtro) {
+        return search(filtro, -1, -1);
+    }
+
+    @Override
+    public List<Treino> search(Treino filtro, int page, int size) {
+        Logger.info("TreinoDaoNativeImpl.search - inicio");
+        EntityManager em = EntityManagerUtil.getEntityManager();
+        try {
+            StringBuilder sb = new StringBuilder("SELECT id_treino, nome, classe, id_rotina FROM Treino WHERE 1=1");
+            Map<String, Object> params = new HashMap<>();
+            if (filtro.getNome() != null && !filtro.getNome().isEmpty()) {
+                sb.append(" AND nome=:nome");
+                params.put("nome", filtro.getNome());
+            }
+            if (filtro.getClasse() != null && !filtro.getClasse().isEmpty()) {
+                sb.append(" AND classe=:classe");
+                params.put("classe", filtro.getClasse());
+            }
+            if (filtro.getIdRotina() != null) {
+                sb.append(" AND id_rotina=:idRotina");
+                params.put("idRotina", filtro.getIdRotina());
+            }
+            if (page >= 0 && size > 0) {
+                sb.append(" LIMIT :limit OFFSET :offset");
+            }
+            Query query = em.createNativeQuery(sb.toString(), Treino.class);
+            for (Map.Entry<String, Object> e : params.entrySet()) {
+                query.setParameter(e.getKey(), e.getValue());
+            }
+            if (page >= 0 && size > 0) {
+                query.setParameter("limit", size);
+                query.setParameter("offset", page * size);
+            }
+            List<Treino> list = query.getResultList();
+            Logger.info("TreinoDaoNativeImpl.search - sucesso");
+            return list;
+        } finally {
+            em.close();
+        }
+    }
+}

--- a/src/main/java/exception/AlimentacaoException.java
+++ b/src/main/java/exception/AlimentacaoException.java
@@ -1,0 +1,12 @@
+// path: src/main/java/exception/AlimentacaoException.java
+package exception;
+
+public class AlimentacaoException extends RuntimeException {
+    public AlimentacaoException(String message) {
+        super(message);
+    }
+
+    public AlimentacaoException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/exception/CaixaException.java
+++ b/src/main/java/exception/CaixaException.java
@@ -1,0 +1,12 @@
+// path: src/main/java/exception/CaixaException.java
+package exception;
+
+public class CaixaException extends RuntimeException {
+    public CaixaException(String message) {
+        super(message);
+    }
+
+    public CaixaException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/exception/MonitoramentoException.java
+++ b/src/main/java/exception/MonitoramentoException.java
@@ -1,0 +1,12 @@
+// path: src/main/java/exception/MonitoramentoException.java
+package exception;
+
+public class MonitoramentoException extends RuntimeException {
+    public MonitoramentoException(String message) {
+        super(message);
+    }
+
+    public MonitoramentoException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/exception/ObjetoException.java
+++ b/src/main/java/exception/ObjetoException.java
@@ -1,0 +1,12 @@
+// path: src/main/java/exception/ObjetoException.java
+package exception;
+
+public class ObjetoException extends RuntimeException {
+    public ObjetoException(String message) {
+        super(message);
+    }
+
+    public ObjetoException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/exception/PeriodoException.java
+++ b/src/main/java/exception/PeriodoException.java
@@ -1,0 +1,12 @@
+// path: src/main/java/exception/PeriodoException.java
+package exception;
+
+public class PeriodoException extends RuntimeException {
+    public PeriodoException(String message) {
+        super(message);
+    }
+
+    public PeriodoException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/exception/SiteException.java
+++ b/src/main/java/exception/SiteException.java
@@ -1,0 +1,12 @@
+// path: src/main/java/exception/SiteException.java
+package exception;
+
+public class SiteException extends RuntimeException {
+    public SiteException(String message) {
+        super(message);
+    }
+
+    public SiteException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/exception/TreinoException.java
+++ b/src/main/java/exception/TreinoException.java
@@ -1,0 +1,12 @@
+// path: src/main/java/exception/TreinoException.java
+package exception;
+
+public class TreinoException extends RuntimeException {
+    public TreinoException(String message) {
+        super(message);
+    }
+
+    public TreinoException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/infra/EntityManagerUtil.java
+++ b/src/main/java/infra/EntityManagerUtil.java
@@ -1,0 +1,17 @@
+// path: src/main/java/infra/EntityManagerUtil.java
+package infra;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.Persistence;
+
+public class EntityManagerUtil {
+    private static final EntityManagerFactory emf = Persistence.createEntityManagerFactory("rotinamaisPU");
+
+    private EntityManagerUtil() {
+    }
+
+    public static EntityManager getEntityManager() {
+        return emf.createEntityManager();
+    }
+}

--- a/src/main/java/infra/Logger.java
+++ b/src/main/java/infra/Logger.java
@@ -1,0 +1,15 @@
+// path: src/main/java/infra/Logger.java
+package infra;
+
+public class Logger {
+    public static void info(String msg) {
+        System.out.println("INFO: " + msg);
+    }
+
+    public static void error(String msg, Throwable t) {
+        System.err.println("ERROR: " + msg);
+        if (t != null) {
+            t.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/model/Alimentacao.java
+++ b/src/main/java/model/Alimentacao.java
@@ -1,0 +1,119 @@
+// path: src/main/java/model/Alimentacao.java
+package model;
+
+import java.util.Objects;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "Alimentacao")
+public class Alimentacao {
+
+    @Id
+    @Column(name = "id_alimentacao")
+    private Integer idAlimentacao;
+
+    @Column(name = "status")
+    private Integer status;
+
+    @Column(name = "nome")
+    private String nome;
+
+    @Column(name = "link")
+    private String link;
+
+    @Lob
+    @Column(name = "video")
+    private byte[] video;
+
+    @Column(name = "preparo")
+    private String preparo;
+
+    @Column(name = "id_rotina")
+    private Integer idRotina;
+
+    public Integer getIdAlimentacao() {
+        return idAlimentacao;
+    }
+
+    public void setIdAlimentacao(Integer idAlimentacao) {
+        this.idAlimentacao = idAlimentacao;
+    }
+
+    public Integer getStatus() {
+        return status;
+    }
+
+    public void setStatus(Integer status) {
+        this.status = status;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public String getLink() {
+        return link;
+    }
+
+    public void setLink(String link) {
+        this.link = link;
+    }
+
+    public byte[] getVideo() {
+        return video;
+    }
+
+    public void setVideo(byte[] video) {
+        this.video = video;
+    }
+
+    public String getPreparo() {
+        return preparo;
+    }
+
+    public void setPreparo(String preparo) {
+        this.preparo = preparo;
+    }
+
+    public Integer getIdRotina() {
+        return idRotina;
+    }
+
+    public void setIdRotina(Integer idRotina) {
+        this.idRotina = idRotina;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Alimentacao)) return false;
+        Alimentacao that = (Alimentacao) o;
+        return Objects.equals(idAlimentacao, that.idAlimentacao);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idAlimentacao);
+    }
+
+    @Override
+    public String toString() {
+        return "Alimentacao{" +
+                "idAlimentacao=" + idAlimentacao +
+                ", status=" + status +
+                ", nome='" + nome + '\'' +
+                ", link='" + link + '\'' +
+                ", preparo='" + preparo + '\'' +
+                ", idRotina=" + idRotina +
+                '}';
+    }
+}

--- a/src/main/java/model/Caixa.java
+++ b/src/main/java/model/Caixa.java
@@ -1,0 +1,107 @@
+// path: src/main/java/model/Caixa.java
+package model;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "Caixa")
+public class Caixa {
+
+    @Id
+    @Column(name = "id_caixa")
+    private Integer idCaixa;
+
+    @Column(name = "nome")
+    private String nome;
+
+    @Column(name = "reserva_emergencia")
+    private BigDecimal reservaEmergencia;
+
+    @Column(name = "salario_medio")
+    private BigDecimal salarioMedio;
+
+    @Column(name = "valor_total")
+    private BigDecimal valorTotal;
+
+    @Column(name = "id_usuario")
+    private Integer idUsuario;
+
+    public Integer getIdCaixa() {
+        return idCaixa;
+    }
+
+    public void setIdCaixa(Integer idCaixa) {
+        this.idCaixa = idCaixa;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public BigDecimal getReservaEmergencia() {
+        return reservaEmergencia;
+    }
+
+    public void setReservaEmergencia(BigDecimal reservaEmergencia) {
+        this.reservaEmergencia = reservaEmergencia;
+    }
+
+    public BigDecimal getSalarioMedio() {
+        return salarioMedio;
+    }
+
+    public void setSalarioMedio(BigDecimal salarioMedio) {
+        this.salarioMedio = salarioMedio;
+    }
+
+    public BigDecimal getValorTotal() {
+        return valorTotal;
+    }
+
+    public void setValorTotal(BigDecimal valorTotal) {
+        this.valorTotal = valorTotal;
+    }
+
+    public Integer getIdUsuario() {
+        return idUsuario;
+    }
+
+    public void setIdUsuario(Integer idUsuario) {
+        this.idUsuario = idUsuario;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Caixa)) return false;
+        Caixa caixa = (Caixa) o;
+        return Objects.equals(idCaixa, caixa.idCaixa);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idCaixa);
+    }
+
+    @Override
+    public String toString() {
+        return "Caixa{" +
+                "idCaixa=" + idCaixa +
+                ", nome='" + nome + '\'' +
+                ", reservaEmergencia=" + reservaEmergencia +
+                ", salarioMedio=" + salarioMedio +
+                ", valorTotal=" + valorTotal +
+                ", idUsuario=" + idUsuario +
+                '}';
+    }
+}

--- a/src/main/java/model/Monitoramento.java
+++ b/src/main/java/model/Monitoramento.java
@@ -1,0 +1,107 @@
+// path: src/main/java/model/Monitoramento.java
+package model;
+
+import java.util.Objects;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "Monitoramento")
+public class Monitoramento {
+
+    @Id
+    @Column(name = "id_monitoramento")
+    private Integer idMonitoramento;
+
+    @Column(name = "status")
+    private Integer status;
+
+    @Column(name = "nome")
+    private String nome;
+
+    @Column(name = "descricao")
+    private String descricao;
+
+    @Lob
+    @Column(name = "foto")
+    private byte[] foto;
+
+    @Column(name = "id_periodo")
+    private Integer idPeriodo;
+
+    public Integer getIdMonitoramento() {
+        return idMonitoramento;
+    }
+
+    public void setIdMonitoramento(Integer idMonitoramento) {
+        this.idMonitoramento = idMonitoramento;
+    }
+
+    public Integer getStatus() {
+        return status;
+    }
+
+    public void setStatus(Integer status) {
+        this.status = status;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public String getDescricao() {
+        return descricao;
+    }
+
+    public void setDescricao(String descricao) {
+        this.descricao = descricao;
+    }
+
+    public byte[] getFoto() {
+        return foto;
+    }
+
+    public void setFoto(byte[] foto) {
+        this.foto = foto;
+    }
+
+    public Integer getIdPeriodo() {
+        return idPeriodo;
+    }
+
+    public void setIdPeriodo(Integer idPeriodo) {
+        this.idPeriodo = idPeriodo;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Monitoramento)) return false;
+        Monitoramento that = (Monitoramento) o;
+        return Objects.equals(idMonitoramento, that.idMonitoramento);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idMonitoramento);
+    }
+
+    @Override
+    public String toString() {
+        return "Monitoramento{" +
+                "idMonitoramento=" + idMonitoramento +
+                ", status=" + status +
+                ", nome='" + nome + '\'' +
+                ", descricao='" + descricao + '\'' +
+                ", idPeriodo=" + idPeriodo +
+                '}';
+    }
+}

--- a/src/main/java/model/Objeto.java
+++ b/src/main/java/model/Objeto.java
@@ -1,0 +1,108 @@
+// path: src/main/java/model/Objeto.java
+package model;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "Objeto")
+public class Objeto {
+
+    @Id
+    @Column(name = "id_objeto")
+    private Integer idObjeto;
+
+    @Column(name = "nome")
+    private String nome;
+
+    @Column(name = "tipo")
+    private Integer tipo;
+
+    @Column(name = "valor")
+    private BigDecimal valor;
+
+    @Column(name = "descricao")
+    private String descricao;
+
+    @Lob
+    @Column(name = "foto")
+    private byte[] foto;
+
+    public Integer getIdObjeto() {
+        return idObjeto;
+    }
+
+    public void setIdObjeto(Integer idObjeto) {
+        this.idObjeto = idObjeto;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public Integer getTipo() {
+        return tipo;
+    }
+
+    public void setTipo(Integer tipo) {
+        this.tipo = tipo;
+    }
+
+    public BigDecimal getValor() {
+        return valor;
+    }
+
+    public void setValor(BigDecimal valor) {
+        this.valor = valor;
+    }
+
+    public String getDescricao() {
+        return descricao;
+    }
+
+    public void setDescricao(String descricao) {
+        this.descricao = descricao;
+    }
+
+    public byte[] getFoto() {
+        return foto;
+    }
+
+    public void setFoto(byte[] foto) {
+        this.foto = foto;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Objeto)) return false;
+        Objeto objeto = (Objeto) o;
+        return Objects.equals(idObjeto, objeto.idObjeto);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idObjeto);
+    }
+
+    @Override
+    public String toString() {
+        return "Objeto{" +
+                "idObjeto=" + idObjeto +
+                ", nome='" + nome + '\'' +
+                ", tipo=" + tipo +
+                ", valor=" + valor +
+                ", descricao='" + descricao + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/model/Periodo.java
+++ b/src/main/java/model/Periodo.java
@@ -1,0 +1,70 @@
+// path: src/main/java/model/Periodo.java
+package model;
+
+import java.util.Objects;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "Periodo")
+public class Periodo {
+
+    @Id
+    @Column(name = "id_periodo")
+    private Integer idPeriodo;
+
+    @Column(name = "ano")
+    private Integer ano;
+
+    @Column(name = "mes")
+    private Integer mes;
+
+    public Integer getIdPeriodo() {
+        return idPeriodo;
+    }
+
+    public void setIdPeriodo(Integer idPeriodo) {
+        this.idPeriodo = idPeriodo;
+    }
+
+    public Integer getAno() {
+        return ano;
+    }
+
+    public void setAno(Integer ano) {
+        this.ano = ano;
+    }
+
+    public Integer getMes() {
+        return mes;
+    }
+
+    public void setMes(Integer mes) {
+        this.mes = mes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Periodo)) return false;
+        Periodo periodo = (Periodo) o;
+        return Objects.equals(idPeriodo, periodo.idPeriodo);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idPeriodo);
+    }
+
+    @Override
+    public String toString() {
+        return "Periodo{" +
+                "idPeriodo=" + idPeriodo +
+                ", ano=" + ano +
+                ", mes=" + mes +
+                '}';
+    }
+}

--- a/src/main/java/model/Site.java
+++ b/src/main/java/model/Site.java
@@ -1,0 +1,83 @@
+// path: src/main/java/model/Site.java
+package model;
+
+import java.util.Objects;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "Site")
+public class Site {
+
+    @Id
+    @Column(name = "id_site")
+    private Integer idSite;
+
+    @Column(name = "url")
+    private String url;
+
+    @Column(name = "ativo")
+    private Boolean ativo;
+
+    @Lob
+    @Column(name = "logo")
+    private byte[] logo;
+
+    public Integer getIdSite() {
+        return idSite;
+    }
+
+    public void setIdSite(Integer idSite) {
+        this.idSite = idSite;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public Boolean getAtivo() {
+        return ativo;
+    }
+
+    public void setAtivo(Boolean ativo) {
+        this.ativo = ativo;
+    }
+
+    public byte[] getLogo() {
+        return logo;
+    }
+
+    public void setLogo(byte[] logo) {
+        this.logo = logo;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Site)) return false;
+        Site site = (Site) o;
+        return Objects.equals(idSite, site.idSite);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idSite);
+    }
+
+    @Override
+    public String toString() {
+        return "Site{" +
+                "idSite=" + idSite +
+                ", url='" + url + '\'' +
+                ", ativo=" + ativo +
+                '}';
+    }
+}

--- a/src/main/java/model/Treino.java
+++ b/src/main/java/model/Treino.java
@@ -1,0 +1,82 @@
+// path: src/main/java/model/Treino.java
+package model;
+
+import java.util.Objects;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "Treino")
+public class Treino {
+
+    @Id
+    @Column(name = "id_treino")
+    private Integer idTreino;
+
+    @Column(name = "nome")
+    private String nome;
+
+    @Column(name = "classe")
+    private String classe;
+
+    @Column(name = "id_rotina")
+    private Integer idRotina;
+
+    public Integer getIdTreino() {
+        return idTreino;
+    }
+
+    public void setIdTreino(Integer idTreino) {
+        this.idTreino = idTreino;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public String getClasse() {
+        return classe;
+    }
+
+    public void setClasse(String classe) {
+        this.classe = classe;
+    }
+
+    public Integer getIdRotina() {
+        return idRotina;
+    }
+
+    public void setIdRotina(Integer idRotina) {
+        this.idRotina = idRotina;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Treino)) return false;
+        Treino treino = (Treino) o;
+        return Objects.equals(idTreino, treino.idTreino);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idTreino);
+    }
+
+    @Override
+    public String toString() {
+        return "Treino{" +
+                "idTreino=" + idTreino +
+                ", nome='" + nome + '\'' +
+                ", classe='" + classe + '\'' +
+                ", idRotina=" + idRotina +
+                '}';
+    }
+}

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,14 @@
+<!-- path: src/main/resources/META-INF/persistence.xml -->
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence" version="3.0">
+    <persistence-unit name="rotinamaisPU">
+        <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+        <properties>
+            <property name="jakarta.persistence.jdbc.driver" value="org.postgresql.Driver"/>
+            <property name="jakarta.persistence.jdbc.url" value="jdbc:postgresql://localhost:5432/rotinamais"/>
+            <property name="jakarta.persistence.jdbc.user" value="postgres"/>
+            <property name="jakarta.persistence.jdbc.password" value="postgres"/>
+            <property name="hibernate.dialect" value="org.hibernate.dialect.PostgreSQLDialect"/>
+            <property name="hibernate.hbm2ddl.auto" value="none"/>
+        </properties>
+    </persistence-unit>
+</persistence>


### PR DESCRIPTION
## Summary
- add Monitoramento, Alimentacao, Treino, Objeto, Site, Caixa and Periodo JPA models with native DAO layers
- implement controllers with field validation, logging and optional BLOB retrieval
- note JPA/DAO examples in README

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf64cd49288325890fe7732235f5da