### PR TITLE
feat: expand domain with join and finance entities

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,3 +4,6 @@ RotinaMaisDesktop (estrutura completa)
 - Utilitário de ícones: swing.icon.Icones (PNG/JPG em /resources/icon + fallback Material Icons).
 - Coloque seus PNGs/JPGs de ícones em: src/main/resources/icon/
 - Coloque TimingFramework-0.55.jar em: libs/TimingFramework-0.55.jar (ou ajuste o pom.xml).
+- Exemplos de entidades JPA e DAOs nativos adicionados para Meta, Cofre,
+  TreinoExercicio, RotinaPeriodo, AlimentacaoIngrediente, IngredienteFornecedor,
+  SiteObjeto, MonitoramentoObjeto, Papel, Carteira e Operacao.

--- a/src/main/java/controller/AlimentacaoIngredienteController.java
+++ b/src/main/java/controller/AlimentacaoIngredienteController.java
@@ -1,0 +1,76 @@
+package controller;
+
+import dao.api.AlimentacaoIngredienteDao;
+import exception.AlimentacaoIngredienteException;
+import infra.Logger;
+import model.AlimentacaoIngrediente;
+
+import java.util.List;
+
+public class AlimentacaoIngredienteController {
+    private final {dao} dao;
+
+    public AlimentacaoIngredienteController(AlimentacaoIngredienteDao dao) { this.dao = dao; }
+
+    public void criar(AlimentacaoIngrediente e) {
+        if (e == null || e.getIdAlimentacaoIngrediente() == null) throw new AlimentacaoIngredienteException("Id obrigatorio");
+        if (e.getQuantidade() == null) throw new AlimentacaoIngredienteException("quantidade obrigatorio");
+        if (e.getIdAlimentacao() == null) throw new AlimentacaoIngredienteException("idAlimentacao obrigatorio");
+        if (e.getIdIngrediente() == null) throw new AlimentacaoIngredienteException("idIngrediente obrigatorio");
+        Logger.info("AlimentacaoIngredienteController.criar");
+        dao.create(e);
+    }
+
+    public void atualizar(AlimentacaoIngrediente e) {
+        if (e == null || e.getIdAlimentacaoIngrediente() == null) throw new AlimentacaoIngredienteException("Id obrigatorio");
+        Logger.info("AlimentacaoIngredienteController.atualizar");
+        dao.update(e);
+    }
+
+    public void remover(Integer id) {
+        if (id == null) throw new AlimentacaoIngredienteException("Id obrigatorio");
+        Logger.info("AlimentacaoIngredienteController.remover");
+        dao.deleteById(id);
+    }
+
+    public AlimentacaoIngrediente buscarPorId(Integer id) {
+        if (id == null) throw new AlimentacaoIngredienteException("Id obrigatorio");
+        Logger.info("AlimentacaoIngredienteController.buscarPorId");
+        return dao.findById(id);
+    }
+
+    public List<AlimentacaoIngrediente> listar() {
+        Logger.info("AlimentacaoIngredienteController.listar");
+        return dao.findAll();
+    }
+
+    public List<AlimentacaoIngrediente> listar(int page, int size) {
+        Logger.info("AlimentacaoIngredienteController.listarPaginado");
+        return dao.findAll(page, size);
+    }
+
+    public List<AlimentacaoIngrediente> buscarPorQuantidade(Integer quantidade) {
+        Logger.info("AlimentacaoIngredienteController.buscarPorQuantidade");
+        return dao.findByQuantidade(quantidade);
+    }
+
+    public List<AlimentacaoIngrediente> buscarPorIdAlimentacao(Integer idAlimentacao) {
+        Logger.info("AlimentacaoIngredienteController.buscarPorIdAlimentacao");
+        return dao.findByIdAlimentacao(idAlimentacao);
+    }
+
+    public List<AlimentacaoIngrediente> buscarPorIdIngrediente(Integer idIngrediente) {
+        Logger.info("AlimentacaoIngredienteController.buscarPorIdIngrediente");
+        return dao.findByIdIngrediente(idIngrediente);
+    }
+
+    public List<AlimentacaoIngrediente> pesquisar(AlimentacaoIngrediente f) {
+        Logger.info("AlimentacaoIngredienteController.pesquisar");
+        return dao.search(f);
+    }
+
+    public List<AlimentacaoIngrediente> pesquisar(AlimentacaoIngrediente f, int page, int size) {
+        Logger.info("AlimentacaoIngredienteController.pesquisarPaginado");
+        return dao.search(f, page, size);
+    }
+}

--- a/src/main/java/controller/CarteiraController.java
+++ b/src/main/java/controller/CarteiraController.java
@@ -1,0 +1,82 @@
+package controller;
+
+import dao.api.CarteiraDao;
+import exception.CarteiraException;
+import infra.Logger;
+import model.Carteira;
+
+import java.util.List;
+
+public class CarteiraController {
+    private final {dao} dao;
+
+    public CarteiraController(CarteiraDao dao) { this.dao = dao; }
+
+    public void criar(Carteira e) {
+        if (e == null || e.getIdCarteira() == null) throw new CarteiraException("Id obrigatorio");
+        if (e.getNome() == null || e.getNome().isEmpty()) throw new CarteiraException("nome obrigatorio");
+        if (e.getTipo() == null || e.getTipo().isEmpty()) throw new CarteiraException("tipo obrigatorio");
+        if (e.getDataInicio() == null) throw new CarteiraException("dataInicio obrigatorio");
+        if (e.getIdUsuario() == null) throw new CarteiraException("idUsuario obrigatorio");
+        Logger.info("CarteiraController.criar");
+        dao.create(e);
+    }
+
+    public void atualizar(Carteira e) {
+        if (e == null || e.getIdCarteira() == null) throw new CarteiraException("Id obrigatorio");
+        Logger.info("CarteiraController.atualizar");
+        dao.update(e);
+    }
+
+    public void remover(Integer id) {
+        if (id == null) throw new CarteiraException("Id obrigatorio");
+        Logger.info("CarteiraController.remover");
+        dao.deleteById(id);
+    }
+
+    public Carteira buscarPorId(Integer id) {
+        if (id == null) throw new CarteiraException("Id obrigatorio");
+        Logger.info("CarteiraController.buscarPorId");
+        return dao.findById(id);
+    }
+
+    public List<Carteira> listar() {
+        Logger.info("CarteiraController.listar");
+        return dao.findAll();
+    }
+
+    public List<Carteira> listar(int page, int size) {
+        Logger.info("CarteiraController.listarPaginado");
+        return dao.findAll(page, size);
+    }
+
+    public List<Carteira> buscarPorNome(String nome) {
+        Logger.info("CarteiraController.buscarPorNome");
+        return dao.findByNome(nome);
+    }
+
+    public List<Carteira> buscarPorTipo(String tipo) {
+        Logger.info("CarteiraController.buscarPorTipo");
+        return dao.findByTipo(tipo);
+    }
+
+    public List<Carteira> buscarPorDataInicio(LocalDate dataInicio) {
+        Logger.info("CarteiraController.buscarPorDataInicio");
+        return dao.findByDataInicio(dataInicio);
+    }
+
+    public List<Carteira> buscarPorIdUsuario(Integer idUsuario) {
+        Logger.info("CarteiraController.buscarPorIdUsuario");
+        return dao.findByIdUsuario(idUsuario);
+    }
+
+    public List<Carteira> pesquisar(Carteira f) {
+        Logger.info("CarteiraController.pesquisar");
+        return dao.search(f);
+    }
+
+    public List<Carteira> pesquisar(Carteira f, int page, int size) {
+        Logger.info("CarteiraController.pesquisarPaginado");
+        return dao.search(f, page, size);
+    }
+}

--- a/src/main/java/controller/CofreController.java
+++ b/src/main/java/controller/CofreController.java
@@ -1,0 +1,64 @@
+package controller;
+
+import dao.api.CofreDao;
+import exception.CofreException;
+import infra.Logger;
+import model.Cofre;
+
+import java.util.List;
+
+public class CofreController {
+    private final CofreDao dao;
+
+    public CofreController(CofreDao dao) { this.dao = dao; }
+
+    public void criar(Cofre c) {
+        if (c == null || c.getIdCofre() == null) throw new CofreException("Id obrigatorio");
+        if (c.getLogin() == null || c.getLogin().isEmpty()) throw new CofreException("Login obrigatorio");
+        Logger.info("CofreController.criar");
+        dao.create(c);
+    }
+
+    public void atualizar(Cofre c) {
+        if (c == null || c.getIdCofre() == null) throw new CofreException("Id obrigatorio");
+        Logger.info("CofreController.atualizar");
+        dao.update(c);
+    }
+
+    public void remover(Integer id) {
+        if (id == null) throw new CofreException("Id obrigatorio");
+        Logger.info("CofreController.remover");
+        dao.deleteById(id);
+    }
+
+    public Cofre buscarPorId(Integer id) {
+        if (id == null) throw new CofreException("Id obrigatorio");
+        Logger.info("CofreController.buscarPorId");
+        return dao.findById(id);
+    }
+
+    public List<Cofre> listar() {
+        Logger.info("CofreController.listar");
+        return dao.findAll();
+    }
+
+    public List<Cofre> listar(int page, int size) {
+        Logger.info("CofreController.listarPaginado");
+        return dao.findAll(page, size);
+    }
+
+    public List<Cofre> buscarPorLogin(String login) {
+        Logger.info("CofreController.buscarPorLogin");
+        return dao.findByLogin(login);
+    }
+
+    public List<Cofre> pesquisar(Cofre filtro) {
+        Logger.info("CofreController.pesquisar");
+        return dao.search(filtro);
+    }
+
+    public List<Cofre> pesquisar(Cofre filtro, int page, int size) {
+        Logger.info("CofreController.pesquisarPaginado");
+        return dao.search(filtro, page, size);
+    }
+}

--- a/src/main/java/controller/IngredienteFornecedorController.java
+++ b/src/main/java/controller/IngredienteFornecedorController.java
@@ -1,0 +1,82 @@
+package controller;
+
+import dao.api.IngredienteFornecedorDao;
+import exception.IngredienteFornecedorException;
+import infra.Logger;
+import model.IngredienteFornecedor;
+
+import java.util.List;
+
+public class IngredienteFornecedorController {
+    private final {dao} dao;
+
+    public IngredienteFornecedorController(IngredienteFornecedorDao dao) { this.dao = dao; }
+
+    public void criar(IngredienteFornecedor e) {
+        if (e == null || e.getIdFornecedorIngrediente() == null) throw new IngredienteFornecedorException("Id obrigatorio");
+        if (e.getValor() == null) throw new IngredienteFornecedorException("valor obrigatorio");
+        if (e.getData() == null) throw new IngredienteFornecedorException("data obrigatorio");
+        if (e.getIdFornecedor() == null) throw new IngredienteFornecedorException("idFornecedor obrigatorio");
+        if (e.getIdIngrediente() == null) throw new IngredienteFornecedorException("idIngrediente obrigatorio");
+        Logger.info("IngredienteFornecedorController.criar");
+        dao.create(e);
+    }
+
+    public void atualizar(IngredienteFornecedor e) {
+        if (e == null || e.getIdFornecedorIngrediente() == null) throw new IngredienteFornecedorException("Id obrigatorio");
+        Logger.info("IngredienteFornecedorController.atualizar");
+        dao.update(e);
+    }
+
+    public void remover(Integer id) {
+        if (id == null) throw new IngredienteFornecedorException("Id obrigatorio");
+        Logger.info("IngredienteFornecedorController.remover");
+        dao.deleteById(id);
+    }
+
+    public IngredienteFornecedor buscarPorId(Integer id) {
+        if (id == null) throw new IngredienteFornecedorException("Id obrigatorio");
+        Logger.info("IngredienteFornecedorController.buscarPorId");
+        return dao.findById(id);
+    }
+
+    public List<IngredienteFornecedor> listar() {
+        Logger.info("IngredienteFornecedorController.listar");
+        return dao.findAll();
+    }
+
+    public List<IngredienteFornecedor> listar(int page, int size) {
+        Logger.info("IngredienteFornecedorController.listarPaginado");
+        return dao.findAll(page, size);
+    }
+
+    public List<IngredienteFornecedor> buscarPorValor(BigDecimal valor) {
+        Logger.info("IngredienteFornecedorController.buscarPorValor");
+        return dao.findByValor(valor);
+    }
+
+    public List<IngredienteFornecedor> buscarPorData(LocalDate data) {
+        Logger.info("IngredienteFornecedorController.buscarPorData");
+        return dao.findByData(data);
+    }
+
+    public List<IngredienteFornecedor> buscarPorIdFornecedor(Integer idFornecedor) {
+        Logger.info("IngredienteFornecedorController.buscarPorIdFornecedor");
+        return dao.findByIdFornecedor(idFornecedor);
+    }
+
+    public List<IngredienteFornecedor> buscarPorIdIngrediente(Integer idIngrediente) {
+        Logger.info("IngredienteFornecedorController.buscarPorIdIngrediente");
+        return dao.findByIdIngrediente(idIngrediente);
+    }
+
+    public List<IngredienteFornecedor> pesquisar(IngredienteFornecedor f) {
+        Logger.info("IngredienteFornecedorController.pesquisar");
+        return dao.search(f);
+    }
+
+    public List<IngredienteFornecedor> pesquisar(IngredienteFornecedor f, int page, int size) {
+        Logger.info("IngredienteFornecedorController.pesquisarPaginado");
+        return dao.search(f, page, size);
+    }
+}

--- a/src/main/java/controller/MetaController.java
+++ b/src/main/java/controller/MetaController.java
@@ -1,0 +1,69 @@
+package controller;
+
+import dao.api.MetaDao;
+import exception.MetaException;
+import infra.Logger;
+import model.Meta;
+
+import java.util.List;
+
+public class MetaController {
+    private final MetaDao dao;
+
+    public MetaController(MetaDao dao) { this.dao = dao; }
+
+    public void criar(Meta meta) {
+        if (meta == null || meta.getIdMeta() == null) throw new MetaException("Id obrigatorio");
+        Logger.info("MetaController.criar");
+        dao.create(meta);
+    }
+
+    public void atualizar(Meta meta) {
+        if (meta == null || meta.getIdMeta() == null) throw new MetaException("Id obrigatorio");
+        Logger.info("MetaController.atualizar");
+        dao.update(meta);
+    }
+
+    public void remover(Integer id) {
+        if (id == null) throw new MetaException("Id obrigatorio");
+        Logger.info("MetaController.remover");
+        dao.deleteById(id);
+    }
+
+    public Meta buscarPorId(Integer id) {
+        if (id == null) throw new MetaException("Id obrigatorio");
+        Logger.info("MetaController.buscarPorId");
+        return dao.findById(id);
+    }
+
+    public Meta buscarComFotoPorId(Integer id) {
+        if (id == null) throw new MetaException("Id obrigatorio");
+        Logger.info("MetaController.buscarComFotoPorId");
+        return dao.findWithFotoById(id);
+    }
+
+    public List<Meta> listar() {
+        Logger.info("MetaController.listar");
+        return dao.findAll();
+    }
+
+    public List<Meta> listar(int page, int size) {
+        Logger.info("MetaController.listarPaginado");
+        return dao.findAll(page, size);
+    }
+
+    public List<Meta> buscarPorStatus(Integer status) {
+        Logger.info("MetaController.buscarPorStatus");
+        return dao.findByStatus(status);
+    }
+
+    public List<Meta> pesquisar(Meta filtro) {
+        Logger.info("MetaController.pesquisar");
+        return dao.search(filtro);
+    }
+
+    public List<Meta> pesquisar(Meta filtro, int page, int size) {
+        Logger.info("MetaController.pesquisarPaginado");
+        return dao.search(filtro, page, size);
+    }
+}

--- a/src/main/java/controller/MonitoramentoObjetoController.java
+++ b/src/main/java/controller/MonitoramentoObjetoController.java
@@ -1,0 +1,76 @@
+package controller;
+
+import dao.api.MonitoramentoObjetoDao;
+import exception.MonitoramentoObjetoException;
+import infra.Logger;
+import model.MonitoramentoObjeto;
+
+import java.util.List;
+
+public class MonitoramentoObjetoController {
+    private final {dao} dao;
+
+    public MonitoramentoObjetoController(MonitoramentoObjetoDao dao) { this.dao = dao; }
+
+    public void criar(MonitoramentoObjeto e) {
+        if (e == null || e.getIdMonitoramentoObjeto() == null) throw new MonitoramentoObjetoException("Id obrigatorio");
+        if (e.getData() == null) throw new MonitoramentoObjetoException("data obrigatorio");
+        if (e.getIdMonitoramento() == null) throw new MonitoramentoObjetoException("idMonitoramento obrigatorio");
+        if (e.getIdObjeto() == null) throw new MonitoramentoObjetoException("idObjeto obrigatorio");
+        Logger.info("MonitoramentoObjetoController.criar");
+        dao.create(e);
+    }
+
+    public void atualizar(MonitoramentoObjeto e) {
+        if (e == null || e.getIdMonitoramentoObjeto() == null) throw new MonitoramentoObjetoException("Id obrigatorio");
+        Logger.info("MonitoramentoObjetoController.atualizar");
+        dao.update(e);
+    }
+
+    public void remover(LocalDate id) {
+        if (id == null) throw new MonitoramentoObjetoException("Id obrigatorio");
+        Logger.info("MonitoramentoObjetoController.remover");
+        dao.deleteById(id);
+    }
+
+    public MonitoramentoObjeto buscarPorId(LocalDate id) {
+        if (id == null) throw new MonitoramentoObjetoException("Id obrigatorio");
+        Logger.info("MonitoramentoObjetoController.buscarPorId");
+        return dao.findById(id);
+    }
+
+    public List<MonitoramentoObjeto> listar() {
+        Logger.info("MonitoramentoObjetoController.listar");
+        return dao.findAll();
+    }
+
+    public List<MonitoramentoObjeto> listar(int page, int size) {
+        Logger.info("MonitoramentoObjetoController.listarPaginado");
+        return dao.findAll(page, size);
+    }
+
+    public List<MonitoramentoObjeto> buscarPorData(LocalDate data) {
+        Logger.info("MonitoramentoObjetoController.buscarPorData");
+        return dao.findByData(data);
+    }
+
+    public List<MonitoramentoObjeto> buscarPorIdMonitoramento(Integer idMonitoramento) {
+        Logger.info("MonitoramentoObjetoController.buscarPorIdMonitoramento");
+        return dao.findByIdMonitoramento(idMonitoramento);
+    }
+
+    public List<MonitoramentoObjeto> buscarPorIdObjeto(Integer idObjeto) {
+        Logger.info("MonitoramentoObjetoController.buscarPorIdObjeto");
+        return dao.findByIdObjeto(idObjeto);
+    }
+
+    public List<MonitoramentoObjeto> pesquisar(MonitoramentoObjeto f) {
+        Logger.info("MonitoramentoObjetoController.pesquisar");
+        return dao.search(f);
+    }
+
+    public List<MonitoramentoObjeto> pesquisar(MonitoramentoObjeto f, int page, int size) {
+        Logger.info("MonitoramentoObjetoController.pesquisarPaginado");
+        return dao.search(f, page, size);
+    }
+}

--- a/src/main/java/controller/OperacaoController.java
+++ b/src/main/java/controller/OperacaoController.java
@@ -1,0 +1,172 @@
+package controller;
+
+import dao.api.OperacaoDao;
+import exception.OperacaoException;
+import infra.Logger;
+import model.Operacao;
+
+import java.util.List;
+
+public class OperacaoController {
+    private final {dao} dao;
+
+    public OperacaoController(OperacaoDao dao) { this.dao = dao; }
+
+    public void criar(Operacao e) {
+        if (e == null || e.getIdOperacao() == null) throw new OperacaoException("Id obrigatorio");
+        if (e.getFechamento() == null) throw new OperacaoException("fechamento obrigatorio");
+        if (e.getTempoOperacao() == null) throw new OperacaoException("tempoOperacao obrigatorio");
+        if (e.getQtdCompra() == null) throw new OperacaoException("qtdCompra obrigatorio");
+        if (e.getAbertura() == null) throw new OperacaoException("abertura obrigatorio");
+        if (e.getQtdVenda() == null) throw new OperacaoException("qtdVenda obrigatorio");
+        if (e.getLado() == null || e.getLado().isEmpty()) throw new OperacaoException("lado obrigatorio");
+        if (e.getPrecoCompra() == null) throw new OperacaoException("precoCompra obrigatorio");
+        if (e.getPrecoVenda() == null) throw new OperacaoException("precoVenda obrigatorio");
+        if (e.getPrecoMedio() == null) throw new OperacaoException("precoMedio obrigatorio");
+        if (e.getResIntervalo() == null || e.getResIntervalo().isEmpty()) throw new OperacaoException("resIntervalo obrigatorio");
+        if (e.getNumeroOperacao() == null) throw new OperacaoException("numeroOperacao obrigatorio");
+        if (e.getResOperacao() == null || e.getResOperacao().isEmpty()) throw new OperacaoException("resOperacao obrigatorio");
+        if (e.getDrawdon() == null) throw new OperacaoException("drawdon obrigatorio");
+        if (e.getGanhoMax() == null) throw new OperacaoException("ganhoMax obrigatorio");
+        if (e.getPerdaMax() == null) throw new OperacaoException("perdaMax obrigatorio");
+        if (e.getTet() == null || e.getTet().isEmpty()) throw new OperacaoException("tet obrigatorio");
+        if (e.getTotal() == null) throw new OperacaoException("total obrigatorio");
+        if (e.getIdCarteira() == null) throw new OperacaoException("idCarteira obrigatorio");
+        if (e.getIdPapel() == null) throw new OperacaoException("idPapel obrigatorio");
+        Logger.info("OperacaoController.criar");
+        dao.create(e);
+    }
+
+    public void atualizar(Operacao e) {
+        if (e == null || e.getIdOperacao() == null) throw new OperacaoException("Id obrigatorio");
+        Logger.info("OperacaoController.atualizar");
+        dao.update(e);
+    }
+
+    public void remover(Integer id) {
+        if (id == null) throw new OperacaoException("Id obrigatorio");
+        Logger.info("OperacaoController.remover");
+        dao.deleteById(id);
+    }
+
+    public Operacao buscarPorId(Integer id) {
+        if (id == null) throw new OperacaoException("Id obrigatorio");
+        Logger.info("OperacaoController.buscarPorId");
+        return dao.findById(id);
+    }
+
+    public List<Operacao> listar() {
+        Logger.info("OperacaoController.listar");
+        return dao.findAll();
+    }
+
+    public List<Operacao> listar(int page, int size) {
+        Logger.info("OperacaoController.listarPaginado");
+        return dao.findAll(page, size);
+    }
+
+    public List<Operacao> buscarPorFechamento(BigDecimal fechamento) {
+        Logger.info("OperacaoController.buscarPorFechamento");
+        return dao.findByFechamento(fechamento);
+    }
+
+    public List<Operacao> buscarPorTempoOperacao(LocalTime tempoOperacao) {
+        Logger.info("OperacaoController.buscarPorTempoOperacao");
+        return dao.findByTempoOperacao(tempoOperacao);
+    }
+
+    public List<Operacao> buscarPorQtdCompra(Integer qtdCompra) {
+        Logger.info("OperacaoController.buscarPorQtdCompra");
+        return dao.findByQtdCompra(qtdCompra);
+    }
+
+    public List<Operacao> buscarPorAbertura(BigDecimal abertura) {
+        Logger.info("OperacaoController.buscarPorAbertura");
+        return dao.findByAbertura(abertura);
+    }
+
+    public List<Operacao> buscarPorQtdVenda(Integer qtdVenda) {
+        Logger.info("OperacaoController.buscarPorQtdVenda");
+        return dao.findByQtdVenda(qtdVenda);
+    }
+
+    public List<Operacao> buscarPorLado(String lado) {
+        Logger.info("OperacaoController.buscarPorLado");
+        return dao.findByLado(lado);
+    }
+
+    public List<Operacao> buscarPorPrecoCompra(BigDecimal precoCompra) {
+        Logger.info("OperacaoController.buscarPorPrecoCompra");
+        return dao.findByPrecoCompra(precoCompra);
+    }
+
+    public List<Operacao> buscarPorPrecoVenda(BigDecimal precoVenda) {
+        Logger.info("OperacaoController.buscarPorPrecoVenda");
+        return dao.findByPrecoVenda(precoVenda);
+    }
+
+    public List<Operacao> buscarPorPrecoMedio(BigDecimal precoMedio) {
+        Logger.info("OperacaoController.buscarPorPrecoMedio");
+        return dao.findByPrecoMedio(precoMedio);
+    }
+
+    public List<Operacao> buscarPorResIntervalo(String resIntervalo) {
+        Logger.info("OperacaoController.buscarPorResIntervalo");
+        return dao.findByResIntervalo(resIntervalo);
+    }
+
+    public List<Operacao> buscarPorNumeroOperacao(BigDecimal numeroOperacao) {
+        Logger.info("OperacaoController.buscarPorNumeroOperacao");
+        return dao.findByNumeroOperacao(numeroOperacao);
+    }
+
+    public List<Operacao> buscarPorResOperacao(String resOperacao) {
+        Logger.info("OperacaoController.buscarPorResOperacao");
+        return dao.findByResOperacao(resOperacao);
+    }
+
+    public List<Operacao> buscarPorDrawdon(BigDecimal drawdon) {
+        Logger.info("OperacaoController.buscarPorDrawdon");
+        return dao.findByDrawdon(drawdon);
+    }
+
+    public List<Operacao> buscarPorGanhoMax(BigDecimal ganhoMax) {
+        Logger.info("OperacaoController.buscarPorGanhoMax");
+        return dao.findByGanhoMax(ganhoMax);
+    }
+
+    public List<Operacao> buscarPorPerdaMax(BigDecimal perdaMax) {
+        Logger.info("OperacaoController.buscarPorPerdaMax");
+        return dao.findByPerdaMax(perdaMax);
+    }
+
+    public List<Operacao> buscarPorTet(String tet) {
+        Logger.info("OperacaoController.buscarPorTet");
+        return dao.findByTet(tet);
+    }
+
+    public List<Operacao> buscarPorTotal(BigDecimal total) {
+        Logger.info("OperacaoController.buscarPorTotal");
+        return dao.findByTotal(total);
+    }
+
+    public List<Operacao> buscarPorIdCarteira(Integer idCarteira) {
+        Logger.info("OperacaoController.buscarPorIdCarteira");
+        return dao.findByIdCarteira(idCarteira);
+    }
+
+    public List<Operacao> buscarPorIdPapel(Integer idPapel) {
+        Logger.info("OperacaoController.buscarPorIdPapel");
+        return dao.findByIdPapel(idPapel);
+    }
+
+    public List<Operacao> pesquisar(Operacao f) {
+        Logger.info("OperacaoController.pesquisar");
+        return dao.search(f);
+    }
+
+    public List<Operacao> pesquisar(Operacao f, int page, int size) {
+        Logger.info("OperacaoController.pesquisarPaginado");
+        return dao.search(f, page, size);
+    }
+}

--- a/src/main/java/controller/PapelController.java
+++ b/src/main/java/controller/PapelController.java
@@ -1,0 +1,76 @@
+package controller;
+
+import dao.api.PapelDao;
+import exception.PapelException;
+import infra.Logger;
+import model.Papel;
+
+import java.util.List;
+
+public class PapelController {
+    private final {dao} dao;
+
+    public PapelController(PapelDao dao) { this.dao = dao; }
+
+    public void criar(Papel e) {
+        if (e == null || e.getIdPapel() == null) throw new PapelException("Id obrigatorio");
+        if (e.getCodigo() == null || e.getCodigo().isEmpty()) throw new PapelException("codigo obrigatorio");
+        if (e.getTipo() == null || e.getTipo().isEmpty()) throw new PapelException("tipo obrigatorio");
+        if (e.getVencimento() == null) throw new PapelException("vencimento obrigatorio");
+        Logger.info("PapelController.criar");
+        dao.create(e);
+    }
+
+    public void atualizar(Papel e) {
+        if (e == null || e.getIdPapel() == null) throw new PapelException("Id obrigatorio");
+        Logger.info("PapelController.atualizar");
+        dao.update(e);
+    }
+
+    public void remover(Integer id) {
+        if (id == null) throw new PapelException("Id obrigatorio");
+        Logger.info("PapelController.remover");
+        dao.deleteById(id);
+    }
+
+    public Papel buscarPorId(Integer id) {
+        if (id == null) throw new PapelException("Id obrigatorio");
+        Logger.info("PapelController.buscarPorId");
+        return dao.findById(id);
+    }
+
+    public List<Papel> listar() {
+        Logger.info("PapelController.listar");
+        return dao.findAll();
+    }
+
+    public List<Papel> listar(int page, int size) {
+        Logger.info("PapelController.listarPaginado");
+        return dao.findAll(page, size);
+    }
+
+    public List<Papel> buscarPorCodigo(String codigo) {
+        Logger.info("PapelController.buscarPorCodigo");
+        return dao.findByCodigo(codigo);
+    }
+
+    public List<Papel> buscarPorTipo(String tipo) {
+        Logger.info("PapelController.buscarPorTipo");
+        return dao.findByTipo(tipo);
+    }
+
+    public List<Papel> buscarPorVencimento(LocalDate vencimento) {
+        Logger.info("PapelController.buscarPorVencimento");
+        return dao.findByVencimento(vencimento);
+    }
+
+    public List<Papel> pesquisar(Papel f) {
+        Logger.info("PapelController.pesquisar");
+        return dao.search(f);
+    }
+
+    public List<Papel> pesquisar(Papel f, int page, int size) {
+        Logger.info("PapelController.pesquisarPaginado");
+        return dao.search(f, page, size);
+    }
+}

--- a/src/main/java/controller/RotinaPeriodoController.java
+++ b/src/main/java/controller/RotinaPeriodoController.java
@@ -1,0 +1,70 @@
+package controller;
+
+import dao.api.RotinaPeriodoDao;
+import exception.RotinaPeriodoException;
+import infra.Logger;
+import model.RotinaPeriodo;
+
+import java.util.List;
+
+public class RotinaPeriodoController {
+    private final {dao} dao;
+
+    public RotinaPeriodoController(RotinaPeriodoDao dao) { this.dao = dao; }
+
+    public void criar(RotinaPeriodo e) {
+        if (e == null || e.getIdRotinaPeriodo() == null) throw new RotinaPeriodoException("Id obrigatorio");
+        if (e.getIdRotina() == null) throw new RotinaPeriodoException("idRotina obrigatorio");
+        if (e.getIdPeriodo() == null) throw new RotinaPeriodoException("idPeriodo obrigatorio");
+        Logger.info("RotinaPeriodoController.criar");
+        dao.create(e);
+    }
+
+    public void atualizar(RotinaPeriodo e) {
+        if (e == null || e.getIdRotinaPeriodo() == null) throw new RotinaPeriodoException("Id obrigatorio");
+        Logger.info("RotinaPeriodoController.atualizar");
+        dao.update(e);
+    }
+
+    public void remover(Integer id) {
+        if (id == null) throw new RotinaPeriodoException("Id obrigatorio");
+        Logger.info("RotinaPeriodoController.remover");
+        dao.deleteById(id);
+    }
+
+    public RotinaPeriodo buscarPorId(Integer id) {
+        if (id == null) throw new RotinaPeriodoException("Id obrigatorio");
+        Logger.info("RotinaPeriodoController.buscarPorId");
+        return dao.findById(id);
+    }
+
+    public List<RotinaPeriodo> listar() {
+        Logger.info("RotinaPeriodoController.listar");
+        return dao.findAll();
+    }
+
+    public List<RotinaPeriodo> listar(int page, int size) {
+        Logger.info("RotinaPeriodoController.listarPaginado");
+        return dao.findAll(page, size);
+    }
+
+    public List<RotinaPeriodo> buscarPorIdRotina(Integer idRotina) {
+        Logger.info("RotinaPeriodoController.buscarPorIdRotina");
+        return dao.findByIdRotina(idRotina);
+    }
+
+    public List<RotinaPeriodo> buscarPorIdPeriodo(Integer idPeriodo) {
+        Logger.info("RotinaPeriodoController.buscarPorIdPeriodo");
+        return dao.findByIdPeriodo(idPeriodo);
+    }
+
+    public List<RotinaPeriodo> pesquisar(RotinaPeriodo f) {
+        Logger.info("RotinaPeriodoController.pesquisar");
+        return dao.search(f);
+    }
+
+    public List<RotinaPeriodo> pesquisar(RotinaPeriodo f, int page, int size) {
+        Logger.info("RotinaPeriodoController.pesquisarPaginado");
+        return dao.search(f, page, size);
+    }
+}

--- a/src/main/java/controller/SiteObjetoController.java
+++ b/src/main/java/controller/SiteObjetoController.java
@@ -1,0 +1,70 @@
+package controller;
+
+import dao.api.SiteObjetoDao;
+import exception.SiteObjetoException;
+import infra.Logger;
+import model.SiteObjeto;
+
+import java.util.List;
+
+public class SiteObjetoController {
+    private final {dao} dao;
+
+    public SiteObjetoController(SiteObjetoDao dao) { this.dao = dao; }
+
+    public void criar(SiteObjeto e) {
+        if (e == null || e.getIdSiteObjeto() == null) throw new SiteObjetoException("Id obrigatorio");
+        if (e.getIdSite() == null) throw new SiteObjetoException("idSite obrigatorio");
+        if (e.getIdObjeto() == null) throw new SiteObjetoException("idObjeto obrigatorio");
+        Logger.info("SiteObjetoController.criar");
+        dao.create(e);
+    }
+
+    public void atualizar(SiteObjeto e) {
+        if (e == null || e.getIdSiteObjeto() == null) throw new SiteObjetoException("Id obrigatorio");
+        Logger.info("SiteObjetoController.atualizar");
+        dao.update(e);
+    }
+
+    public void remover(Integer id) {
+        if (id == null) throw new SiteObjetoException("Id obrigatorio");
+        Logger.info("SiteObjetoController.remover");
+        dao.deleteById(id);
+    }
+
+    public SiteObjeto buscarPorId(Integer id) {
+        if (id == null) throw new SiteObjetoException("Id obrigatorio");
+        Logger.info("SiteObjetoController.buscarPorId");
+        return dao.findById(id);
+    }
+
+    public List<SiteObjeto> listar() {
+        Logger.info("SiteObjetoController.listar");
+        return dao.findAll();
+    }
+
+    public List<SiteObjeto> listar(int page, int size) {
+        Logger.info("SiteObjetoController.listarPaginado");
+        return dao.findAll(page, size);
+    }
+
+    public List<SiteObjeto> buscarPorIdSite(Integer idSite) {
+        Logger.info("SiteObjetoController.buscarPorIdSite");
+        return dao.findByIdSite(idSite);
+    }
+
+    public List<SiteObjeto> buscarPorIdObjeto(Integer idObjeto) {
+        Logger.info("SiteObjetoController.buscarPorIdObjeto");
+        return dao.findByIdObjeto(idObjeto);
+    }
+
+    public List<SiteObjeto> pesquisar(SiteObjeto f) {
+        Logger.info("SiteObjetoController.pesquisar");
+        return dao.search(f);
+    }
+
+    public List<SiteObjeto> pesquisar(SiteObjeto f, int page, int size) {
+        Logger.info("SiteObjetoController.pesquisarPaginado");
+        return dao.search(f, page, size);
+    }
+}

--- a/src/main/java/controller/TreinoExercicioController.java
+++ b/src/main/java/controller/TreinoExercicioController.java
@@ -1,0 +1,94 @@
+package controller;
+
+import dao.api.TreinoExercicioDao;
+import exception.TreinoExercicioException;
+import infra.Logger;
+import model.TreinoExercicio;
+
+import java.util.List;
+
+public class TreinoExercicioController {
+    private final {dao} dao;
+
+    public TreinoExercicioController(TreinoExercicioDao dao) { this.dao = dao; }
+
+    public void criar(TreinoExercicio e) {
+        if (e == null || e.getIdTreinoExercicio() == null) throw new TreinoExercicioException("Id obrigatorio");
+        if (e.getQtdRepeticao() == null) throw new TreinoExercicioException("qtdRepeticao obrigatorio");
+        if (e.getTempoDescanso() == null || e.getTempoDescanso().isEmpty()) throw new TreinoExercicioException("tempoDescanso obrigatorio");
+        if (e.getOrdem() == null) throw new TreinoExercicioException("ordem obrigatorio");
+        if (e.getFeito() == null) throw new TreinoExercicioException("feito obrigatorio");
+        if (e.getIdExercicio() == null) throw new TreinoExercicioException("idExercicio obrigatorio");
+        if (e.getIdTreino() == null) throw new TreinoExercicioException("idTreino obrigatorio");
+        Logger.info("TreinoExercicioController.criar");
+        dao.create(e);
+    }
+
+    public void atualizar(TreinoExercicio e) {
+        if (e == null || e.getIdTreinoExercicio() == null) throw new TreinoExercicioException("Id obrigatorio");
+        Logger.info("TreinoExercicioController.atualizar");
+        dao.update(e);
+    }
+
+    public void remover(Integer id) {
+        if (id == null) throw new TreinoExercicioException("Id obrigatorio");
+        Logger.info("TreinoExercicioController.remover");
+        dao.deleteById(id);
+    }
+
+    public TreinoExercicio buscarPorId(Integer id) {
+        if (id == null) throw new TreinoExercicioException("Id obrigatorio");
+        Logger.info("TreinoExercicioController.buscarPorId");
+        return dao.findById(id);
+    }
+
+    public List<TreinoExercicio> listar() {
+        Logger.info("TreinoExercicioController.listar");
+        return dao.findAll();
+    }
+
+    public List<TreinoExercicio> listar(int page, int size) {
+        Logger.info("TreinoExercicioController.listarPaginado");
+        return dao.findAll(page, size);
+    }
+
+    public List<TreinoExercicio> buscarPorQtdRepeticao(Integer qtdRepeticao) {
+        Logger.info("TreinoExercicioController.buscarPorQtdRepeticao");
+        return dao.findByQtdRepeticao(qtdRepeticao);
+    }
+
+    public List<TreinoExercicio> buscarPorTempoDescanso(String tempoDescanso) {
+        Logger.info("TreinoExercicioController.buscarPorTempoDescanso");
+        return dao.findByTempoDescanso(tempoDescanso);
+    }
+
+    public List<TreinoExercicio> buscarPorOrdem(Integer ordem) {
+        Logger.info("TreinoExercicioController.buscarPorOrdem");
+        return dao.findByOrdem(ordem);
+    }
+
+    public List<TreinoExercicio> buscarPorFeito(Boolean feito) {
+        Logger.info("TreinoExercicioController.buscarPorFeito");
+        return dao.findByFeito(feito);
+    }
+
+    public List<TreinoExercicio> buscarPorIdExercicio(Integer idExercicio) {
+        Logger.info("TreinoExercicioController.buscarPorIdExercicio");
+        return dao.findByIdExercicio(idExercicio);
+    }
+
+    public List<TreinoExercicio> buscarPorIdTreino(Integer idTreino) {
+        Logger.info("TreinoExercicioController.buscarPorIdTreino");
+        return dao.findByIdTreino(idTreino);
+    }
+
+    public List<TreinoExercicio> pesquisar(TreinoExercicio f) {
+        Logger.info("TreinoExercicioController.pesquisar");
+        return dao.search(f);
+    }
+
+    public List<TreinoExercicio> pesquisar(TreinoExercicio f, int page, int size) {
+        Logger.info("TreinoExercicioController.pesquisarPaginado");
+        return dao.search(f, page, size);
+    }
+}

--- a/src/main/java/dao/api/AlimentacaoIngredienteDao.java
+++ b/src/main/java/dao/api/AlimentacaoIngredienteDao.java
@@ -1,0 +1,18 @@
+package dao.api;
+
+import model.AlimentacaoIngrediente;
+import java.util.List;
+
+public interface AlimentacaoIngredienteDao {
+    void create(AlimentacaoIngrediente e);
+    void update(AlimentacaoIngrediente e);
+    void deleteById(Integer id);
+    AlimentacaoIngrediente findById(Integer id);
+    List<AlimentacaoIngrediente> findAll();
+    List<AlimentacaoIngrediente> findAll(int page, int size);
+    List<AlimentacaoIngrediente> findByQuantidade(Integer quantidade);
+    List<AlimentacaoIngrediente> findByIdAlimentacao(Integer idAlimentacao);
+    List<AlimentacaoIngrediente> findByIdIngrediente(Integer idIngrediente);
+    List<AlimentacaoIngrediente> search(AlimentacaoIngrediente f);
+    List<AlimentacaoIngrediente> search(AlimentacaoIngrediente f, int page, int size);
+}

--- a/src/main/java/dao/api/CarteiraDao.java
+++ b/src/main/java/dao/api/CarteiraDao.java
@@ -1,0 +1,19 @@
+package dao.api;
+
+import model.Carteira;
+import java.util.List;
+
+public interface CarteiraDao {
+    void create(Carteira e);
+    void update(Carteira e);
+    void deleteById(Integer id);
+    Carteira findById(Integer id);
+    List<Carteira> findAll();
+    List<Carteira> findAll(int page, int size);
+    List<Carteira> findByNome(String nome);
+    List<Carteira> findByTipo(String tipo);
+    List<Carteira> findByDataInicio(LocalDate dataInicio);
+    List<Carteira> findByIdUsuario(Integer idUsuario);
+    List<Carteira> search(Carteira f);
+    List<Carteira> search(Carteira f, int page, int size);
+}

--- a/src/main/java/dao/api/CofreDao.java
+++ b/src/main/java/dao/api/CofreDao.java
@@ -1,0 +1,18 @@
+package dao.api;
+
+import model.Cofre;
+import java.util.List;
+
+public interface CofreDao {
+    void create(Cofre c);
+    void update(Cofre c);
+    void deleteById(Integer id);
+    Cofre findById(Integer id);
+    List<Cofre> findAll();
+    List<Cofre> findAll(int page, int size);
+    List<Cofre> findByLogin(String login);
+    List<Cofre> findByTipo(Integer tipo);
+    List<Cofre> findByIdUsuario(Integer idUsuario);
+    List<Cofre> search(Cofre filtro);
+    List<Cofre> search(Cofre filtro, int page, int size);
+}

--- a/src/main/java/dao/api/IngredienteFornecedorDao.java
+++ b/src/main/java/dao/api/IngredienteFornecedorDao.java
@@ -1,0 +1,19 @@
+package dao.api;
+
+import model.IngredienteFornecedor;
+import java.util.List;
+
+public interface IngredienteFornecedorDao {
+    void create(IngredienteFornecedor e);
+    void update(IngredienteFornecedor e);
+    void deleteById(Integer id);
+    IngredienteFornecedor findById(Integer id);
+    List<IngredienteFornecedor> findAll();
+    List<IngredienteFornecedor> findAll(int page, int size);
+    List<IngredienteFornecedor> findByValor(BigDecimal valor);
+    List<IngredienteFornecedor> findByData(LocalDate data);
+    List<IngredienteFornecedor> findByIdFornecedor(Integer idFornecedor);
+    List<IngredienteFornecedor> findByIdIngrediente(Integer idIngrediente);
+    List<IngredienteFornecedor> search(IngredienteFornecedor f);
+    List<IngredienteFornecedor> search(IngredienteFornecedor f, int page, int size);
+}

--- a/src/main/java/dao/api/MetaDao.java
+++ b/src/main/java/dao/api/MetaDao.java
@@ -1,0 +1,21 @@
+package dao.api;
+
+import model.Meta;
+import java.util.List;
+
+public interface MetaDao {
+    void create(Meta meta);
+    void update(Meta meta);
+    void deleteById(Integer id);
+    Meta findById(Integer id);
+    Meta findWithFotoById(Integer id);
+    List<Meta> findAll();
+    List<Meta> findAll(int page, int size);
+    List<Meta> findByPontoMinimo(Integer pontoMinimo);
+    List<Meta> findByPontoMedio(Integer pontoMedio);
+    List<Meta> findByPontoMaximo(Integer pontoMaximo);
+    List<Meta> findByStatus(Integer status);
+    List<Meta> findByIdPeriodo(Integer idPeriodo);
+    List<Meta> search(Meta filtro);
+    List<Meta> search(Meta filtro, int page, int size);
+}

--- a/src/main/java/dao/api/MonitoramentoObjetoDao.java
+++ b/src/main/java/dao/api/MonitoramentoObjetoDao.java
@@ -1,0 +1,18 @@
+package dao.api;
+
+import model.MonitoramentoObjeto;
+import java.util.List;
+
+public interface MonitoramentoObjetoDao {
+    void create(MonitoramentoObjeto e);
+    void update(MonitoramentoObjeto e);
+    void deleteById(LocalDate id);
+    MonitoramentoObjeto findById(LocalDate id);
+    List<MonitoramentoObjeto> findAll();
+    List<MonitoramentoObjeto> findAll(int page, int size);
+    List<MonitoramentoObjeto> findByData(LocalDate data);
+    List<MonitoramentoObjeto> findByIdMonitoramento(Integer idMonitoramento);
+    List<MonitoramentoObjeto> findByIdObjeto(Integer idObjeto);
+    List<MonitoramentoObjeto> search(MonitoramentoObjeto f);
+    List<MonitoramentoObjeto> search(MonitoramentoObjeto f, int page, int size);
+}

--- a/src/main/java/dao/api/OperacaoDao.java
+++ b/src/main/java/dao/api/OperacaoDao.java
@@ -1,0 +1,34 @@
+package dao.api;
+
+import model.Operacao;
+import java.util.List;
+
+public interface OperacaoDao {
+    void create(Operacao e);
+    void update(Operacao e);
+    void deleteById(Integer id);
+    Operacao findById(Integer id);
+    List<Operacao> findAll();
+    List<Operacao> findAll(int page, int size);
+    List<Operacao> findByFechamento(BigDecimal fechamento);
+    List<Operacao> findByTempoOperacao(LocalTime tempoOperacao);
+    List<Operacao> findByQtdCompra(Integer qtdCompra);
+    List<Operacao> findByAbertura(BigDecimal abertura);
+    List<Operacao> findByQtdVenda(Integer qtdVenda);
+    List<Operacao> findByLado(String lado);
+    List<Operacao> findByPrecoCompra(BigDecimal precoCompra);
+    List<Operacao> findByPrecoVenda(BigDecimal precoVenda);
+    List<Operacao> findByPrecoMedio(BigDecimal precoMedio);
+    List<Operacao> findByResIntervalo(String resIntervalo);
+    List<Operacao> findByNumeroOperacao(BigDecimal numeroOperacao);
+    List<Operacao> findByResOperacao(String resOperacao);
+    List<Operacao> findByDrawdon(BigDecimal drawdon);
+    List<Operacao> findByGanhoMax(BigDecimal ganhoMax);
+    List<Operacao> findByPerdaMax(BigDecimal perdaMax);
+    List<Operacao> findByTet(String tet);
+    List<Operacao> findByTotal(BigDecimal total);
+    List<Operacao> findByIdCarteira(Integer idCarteira);
+    List<Operacao> findByIdPapel(Integer idPapel);
+    List<Operacao> search(Operacao f);
+    List<Operacao> search(Operacao f, int page, int size);
+}

--- a/src/main/java/dao/api/PapelDao.java
+++ b/src/main/java/dao/api/PapelDao.java
@@ -1,0 +1,18 @@
+package dao.api;
+
+import model.Papel;
+import java.util.List;
+
+public interface PapelDao {
+    void create(Papel e);
+    void update(Papel e);
+    void deleteById(Integer id);
+    Papel findById(Integer id);
+    List<Papel> findAll();
+    List<Papel> findAll(int page, int size);
+    List<Papel> findByCodigo(String codigo);
+    List<Papel> findByTipo(String tipo);
+    List<Papel> findByVencimento(LocalDate vencimento);
+    List<Papel> search(Papel f);
+    List<Papel> search(Papel f, int page, int size);
+}

--- a/src/main/java/dao/api/RotinaPeriodoDao.java
+++ b/src/main/java/dao/api/RotinaPeriodoDao.java
@@ -1,0 +1,17 @@
+package dao.api;
+
+import model.RotinaPeriodo;
+import java.util.List;
+
+public interface RotinaPeriodoDao {
+    void create(RotinaPeriodo e);
+    void update(RotinaPeriodo e);
+    void deleteById(Integer id);
+    RotinaPeriodo findById(Integer id);
+    List<RotinaPeriodo> findAll();
+    List<RotinaPeriodo> findAll(int page, int size);
+    List<RotinaPeriodo> findByIdRotina(Integer idRotina);
+    List<RotinaPeriodo> findByIdPeriodo(Integer idPeriodo);
+    List<RotinaPeriodo> search(RotinaPeriodo f);
+    List<RotinaPeriodo> search(RotinaPeriodo f, int page, int size);
+}

--- a/src/main/java/dao/api/SiteObjetoDao.java
+++ b/src/main/java/dao/api/SiteObjetoDao.java
@@ -1,0 +1,17 @@
+package dao.api;
+
+import model.SiteObjeto;
+import java.util.List;
+
+public interface SiteObjetoDao {
+    void create(SiteObjeto e);
+    void update(SiteObjeto e);
+    void deleteById(Integer id);
+    SiteObjeto findById(Integer id);
+    List<SiteObjeto> findAll();
+    List<SiteObjeto> findAll(int page, int size);
+    List<SiteObjeto> findByIdSite(Integer idSite);
+    List<SiteObjeto> findByIdObjeto(Integer idObjeto);
+    List<SiteObjeto> search(SiteObjeto f);
+    List<SiteObjeto> search(SiteObjeto f, int page, int size);
+}

--- a/src/main/java/dao/api/TreinoExercicioDao.java
+++ b/src/main/java/dao/api/TreinoExercicioDao.java
@@ -1,0 +1,21 @@
+package dao.api;
+
+import model.TreinoExercicio;
+import java.util.List;
+
+public interface TreinoExercicioDao {
+    void create(TreinoExercicio e);
+    void update(TreinoExercicio e);
+    void deleteById(Integer id);
+    TreinoExercicio findById(Integer id);
+    List<TreinoExercicio> findAll();
+    List<TreinoExercicio> findAll(int page, int size);
+    List<TreinoExercicio> findByQtdRepeticao(Integer qtdRepeticao);
+    List<TreinoExercicio> findByTempoDescanso(String tempoDescanso);
+    List<TreinoExercicio> findByOrdem(Integer ordem);
+    List<TreinoExercicio> findByFeito(Boolean feito);
+    List<TreinoExercicio> findByIdExercicio(Integer idExercicio);
+    List<TreinoExercicio> findByIdTreino(Integer idTreino);
+    List<TreinoExercicio> search(TreinoExercicio f);
+    List<TreinoExercicio> search(TreinoExercicio f, int page, int size);
+}

--- a/src/main/java/dao/impl/AlimentacaoIngredienteDaoNativeImpl.java
+++ b/src/main/java/dao/impl/AlimentacaoIngredienteDaoNativeImpl.java
@@ -1,0 +1,98 @@
+package dao.impl;
+
+import dao.api.AlimentacaoIngredienteDao;
+import exception.AlimentacaoIngredienteException;
+import infra.EntityManagerUtil;
+import infra.Logger;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import model.AlimentacaoIngrediente;
+
+import java.util.List;
+
+public class AlimentacaoIngredienteDaoNativeImpl implements AlimentacaoIngredienteDao {
+    private final EntityManager em = EntityManagerUtil.getEntityManager();
+
+    @Override
+    public void create(AlimentacaoIngrediente e) {
+        Logger.info("AlimentacaoIngredienteDaoNativeImpl.create");
+        em.getTransaction().begin();
+        em.persist(e);
+        em.getTransaction().commit();
+    }
+
+    @Override
+    public void update(AlimentacaoIngrediente e) {
+        Logger.info("AlimentacaoIngredienteDaoNativeImpl.update");
+        em.getTransaction().begin();
+        em.merge(e);
+        em.getTransaction().commit();
+    }
+
+    @Override
+    public void deleteById(Integer id) {
+        Logger.info("AlimentacaoIngredienteDaoNativeImpl.deleteById");
+        AlimentacaoIngrediente e = em.find(AlimentacaoIngrediente.class, id);
+        if (e == null) throw new AlimentacaoIngredienteException("AlimentacaoIngrediente nao encontrado: id=" + id);
+        em.getTransaction().begin();
+        em.remove(e);
+        em.getTransaction().commit();
+    }
+
+    @Override
+    public AlimentacaoIngrediente findById(Integer id) {
+        String sql = "SELECT {select_cols} FROM {table} WHERE {e['fields'][0][2]} = :id";
+        Query q = em.createNativeQuery(sql, {cname}.class).setParameter("id", id);
+        return ({cname}) q.getSingleResult();
+    }
+
+    @Override
+    public List<AlimentacaoIngrediente> findAll() {
+        String sql = "SELECT {select_cols} FROM {table}";
+        return em.createNativeQuery(sql, {cname}.class).getResultList();
+    }
+
+    @Override
+    public List<AlimentacaoIngrediente> findAll(int page, int size) {
+        String sql = "SELECT {select_cols} FROM {table} LIMIT :size OFFSET :off";
+        return em.createNativeQuery(sql, {cname}.class).setParameter("size", size).setParameter("off", page * size).getResultList();
+    }
+
+    @Override
+    public List<AlimentacaoIngrediente> findByQuantidade(Integer quantidade) {
+        String sql = "SELECT id_alimentacao_ingrediente, quantidade, id_alimentacao, id_ingrediente FROM Alimentacao_Ingrediente WHERE quantidade = :v";
+        return em.createNativeQuery(sql, AlimentacaoIngrediente.class).setParameter("v", quantidade).getResultList();
+    }
+
+    @Override
+    public List<AlimentacaoIngrediente> findByIdAlimentacao(Integer idAlimentacao) {
+        String sql = "SELECT id_alimentacao_ingrediente, quantidade, id_alimentacao, id_ingrediente FROM Alimentacao_Ingrediente WHERE id_alimentacao = :v";
+        return em.createNativeQuery(sql, AlimentacaoIngrediente.class).setParameter("v", idAlimentacao).getResultList();
+    }
+
+    @Override
+    public List<AlimentacaoIngrediente> findByIdIngrediente(Integer idIngrediente) {
+        String sql = "SELECT id_alimentacao_ingrediente, quantidade, id_alimentacao, id_ingrediente FROM Alimentacao_Ingrediente WHERE id_ingrediente = :v";
+        return em.createNativeQuery(sql, AlimentacaoIngrediente.class).setParameter("v", idIngrediente).getResultList();
+    }
+
+    @Override
+    public List<AlimentacaoIngrediente> search(AlimentacaoIngrediente f) {
+        return search(f, 0, Integer.MAX_VALUE);
+    }
+
+    @Override
+    public List<AlimentacaoIngrediente> search(AlimentacaoIngrediente f, int page, int size) {
+        StringBuilder sb = new StringBuilder("SELECT id_alimentacao_ingrediente, quantidade, id_alimentacao, id_ingrediente FROM Alimentacao_Ingrediente WHERE 1=1");
+        if (f.getQuantidade() != null) sb.append(" AND quantidade = :quantidade");
+        if (f.getIdAlimentacao() != null) sb.append(" AND id_alimentacao = :idAlimentacao");
+        if (f.getIdIngrediente() != null) sb.append(" AND id_ingrediente = :idIngrediente");
+        Query q = em.createNativeQuery(sb.toString(), AlimentacaoIngrediente.class);
+        if (f.getQuantidade() != null) q.setParameter("quantidade", f.getQuantidade());
+        if (f.getIdAlimentacao() != null) q.setParameter("idAlimentacao", f.getIdAlimentacao());
+        if (f.getIdIngrediente() != null) q.setParameter("idIngrediente", f.getIdIngrediente());
+        q.setFirstResult(page * size);
+        q.setMaxResults(size);
+        return q.getResultList();
+    }
+}

--- a/src/main/java/dao/impl/CarteiraDaoNativeImpl.java
+++ b/src/main/java/dao/impl/CarteiraDaoNativeImpl.java
@@ -1,0 +1,106 @@
+package dao.impl;
+
+import dao.api.CarteiraDao;
+import exception.CarteiraException;
+import infra.EntityManagerUtil;
+import infra.Logger;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import model.Carteira;
+
+import java.util.List;
+
+public class CarteiraDaoNativeImpl implements CarteiraDao {
+    private final EntityManager em = EntityManagerUtil.getEntityManager();
+
+    @Override
+    public void create(Carteira e) {
+        Logger.info("CarteiraDaoNativeImpl.create");
+        em.getTransaction().begin();
+        em.persist(e);
+        em.getTransaction().commit();
+    }
+
+    @Override
+    public void update(Carteira e) {
+        Logger.info("CarteiraDaoNativeImpl.update");
+        em.getTransaction().begin();
+        em.merge(e);
+        em.getTransaction().commit();
+    }
+
+    @Override
+    public void deleteById(Integer id) {
+        Logger.info("CarteiraDaoNativeImpl.deleteById");
+        Carteira e = em.find(Carteira.class, id);
+        if (e == null) throw new CarteiraException("Carteira nao encontrado: id=" + id);
+        em.getTransaction().begin();
+        em.remove(e);
+        em.getTransaction().commit();
+    }
+
+    @Override
+    public Carteira findById(Integer id) {
+        String sql = "SELECT {select_cols} FROM {table} WHERE {e['fields'][0][2]} = :id";
+        Query q = em.createNativeQuery(sql, {cname}.class).setParameter("id", id);
+        return ({cname}) q.getSingleResult();
+    }
+
+    @Override
+    public List<Carteira> findAll() {
+        String sql = "SELECT {select_cols} FROM {table}";
+        return em.createNativeQuery(sql, {cname}.class).getResultList();
+    }
+
+    @Override
+    public List<Carteira> findAll(int page, int size) {
+        String sql = "SELECT {select_cols} FROM {table} LIMIT :size OFFSET :off";
+        return em.createNativeQuery(sql, {cname}.class).setParameter("size", size).setParameter("off", page * size).getResultList();
+    }
+
+    @Override
+    public List<Carteira> findByNome(String nome) {
+        String sql = "SELECT id_carteira, nome, tipo, dataInicio, id_usuario FROM Carteira WHERE nome = :v";
+        return em.createNativeQuery(sql, Carteira.class).setParameter("v", nome).getResultList();
+    }
+
+    @Override
+    public List<Carteira> findByTipo(String tipo) {
+        String sql = "SELECT id_carteira, nome, tipo, dataInicio, id_usuario FROM Carteira WHERE tipo = :v";
+        return em.createNativeQuery(sql, Carteira.class).setParameter("v", tipo).getResultList();
+    }
+
+    @Override
+    public List<Carteira> findByDataInicio(LocalDate dataInicio) {
+        String sql = "SELECT id_carteira, nome, tipo, dataInicio, id_usuario FROM Carteira WHERE dataInicio = :v";
+        return em.createNativeQuery(sql, Carteira.class).setParameter("v", dataInicio).getResultList();
+    }
+
+    @Override
+    public List<Carteira> findByIdUsuario(Integer idUsuario) {
+        String sql = "SELECT id_carteira, nome, tipo, dataInicio, id_usuario FROM Carteira WHERE id_usuario = :v";
+        return em.createNativeQuery(sql, Carteira.class).setParameter("v", idUsuario).getResultList();
+    }
+
+    @Override
+    public List<Carteira> search(Carteira f) {
+        return search(f, 0, Integer.MAX_VALUE);
+    }
+
+    @Override
+    public List<Carteira> search(Carteira f, int page, int size) {
+        StringBuilder sb = new StringBuilder("SELECT id_carteira, nome, tipo, dataInicio, id_usuario FROM Carteira WHERE 1=1");
+        if (f.getNome() != null && !f.getNome().isEmpty()) sb.append(" AND nome = :nome");
+        if (f.getTipo() != null && !f.getTipo().isEmpty()) sb.append(" AND tipo = :tipo");
+        if (f.getDataInicio() != null) sb.append(" AND dataInicio = :dataInicio");
+        if (f.getIdUsuario() != null) sb.append(" AND id_usuario = :idUsuario");
+        Query q = em.createNativeQuery(sb.toString(), Carteira.class);
+        if (f.getNome() != null && !f.getNome().isEmpty()) q.setParameter("nome", f.getNome());
+        if (f.getTipo() != null && !f.getTipo().isEmpty()) q.setParameter("tipo", f.getTipo());
+        if (f.getDataInicio() != null) q.setParameter("dataInicio", f.getDataInicio());
+        if (f.getIdUsuario() != null) q.setParameter("idUsuario", f.getIdUsuario());
+        q.setFirstResult(page * size);
+        q.setMaxResults(size);
+        return q.getResultList();
+    }
+}

--- a/src/main/java/dao/impl/CofreDaoNativeImpl.java
+++ b/src/main/java/dao/impl/CofreDaoNativeImpl.java
@@ -1,0 +1,101 @@
+package dao.impl;
+
+import dao.api.CofreDao;
+import exception.CofreException;
+import infra.EntityManagerUtil;
+import infra.Logger;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import model.Cofre;
+
+import java.util.List;
+
+public class CofreDaoNativeImpl implements CofreDao {
+    private final EntityManager em = EntityManagerUtil.getEntityManager();
+
+    @Override
+    public void create(Cofre c) {
+        Logger.info("CofreDao.create");
+        em.getTransaction().begin();
+        em.persist(c);
+        em.getTransaction().commit();
+    }
+
+    @Override
+    public void update(Cofre c) {
+        Logger.info("CofreDao.update");
+        em.getTransaction().begin();
+        em.merge(c);
+        em.getTransaction().commit();
+    }
+
+    @Override
+    public void deleteById(Integer id) {
+        Logger.info("CofreDao.deleteById");
+        Cofre c = em.find(Cofre.class, id);
+        if (c == null) throw new CofreException("Cofre nao encontrado: id=" + id);
+        em.getTransaction().begin();
+        em.remove(c);
+        em.getTransaction().commit();
+    }
+
+    @Override
+    public Cofre findById(Integer id) {
+        String sql = "SELECT id_cofre, login, senha, tipo, plataforma, id_usuario FROM Cofre WHERE id_cofre = :id";
+        Query q = em.createNativeQuery(sql, Cofre.class).setParameter("id", id);
+        return (Cofre) q.getSingleResult();
+    }
+
+    @Override
+    public List<Cofre> findAll() {
+        String sql = "SELECT id_cofre, login, senha, tipo, plataforma, id_usuario FROM Cofre";
+        return em.createNativeQuery(sql, Cofre.class).getResultList();
+    }
+
+    @Override
+    public List<Cofre> findAll(int page, int size) {
+        String sql = "SELECT id_cofre, login, senha, tipo, plataforma, id_usuario FROM Cofre LIMIT :size OFFSET :off";
+        return em.createNativeQuery(sql, Cofre.class)
+                .setParameter("size", size)
+                .setParameter("off", page * size)
+                .getResultList();
+    }
+
+    @Override
+    public List<Cofre> findByLogin(String login) {
+        String sql = "SELECT id_cofre, login, senha, tipo, plataforma, id_usuario FROM Cofre WHERE login = :v";
+        return em.createNativeQuery(sql, Cofre.class).setParameter("v", login).getResultList();
+    }
+
+    @Override
+    public List<Cofre> findByTipo(Integer tipo) {
+        String sql = "SELECT id_cofre, login, senha, tipo, plataforma, id_usuario FROM Cofre WHERE tipo = :v";
+        return em.createNativeQuery(sql, Cofre.class).setParameter("v", tipo).getResultList();
+    }
+
+    @Override
+    public List<Cofre> findByIdUsuario(Integer idUsuario) {
+        String sql = "SELECT id_cofre, login, senha, tipo, plataforma, id_usuario FROM Cofre WHERE id_usuario = :v";
+        return em.createNativeQuery(sql, Cofre.class).setParameter("v", idUsuario).getResultList();
+    }
+
+    @Override
+    public List<Cofre> search(Cofre f) {
+        return search(f, 0, Integer.MAX_VALUE);
+    }
+
+    @Override
+    public List<Cofre> search(Cofre f, int page, int size) {
+        StringBuilder sb = new StringBuilder("SELECT id_cofre, login, senha, tipo, plataforma, id_usuario FROM Cofre WHERE 1=1");
+        if (f.getLogin() != null && !f.getLogin().isEmpty()) sb.append(" AND login = :login");
+        if (f.getTipo() != null) sb.append(" AND tipo = :tipo");
+        if (f.getIdUsuario() != null) sb.append(" AND id_usuario = :idUsuario");
+        Query q = em.createNativeQuery(sb.toString(), Cofre.class);
+        if (f.getLogin() != null && !f.getLogin().isEmpty()) q.setParameter("login", f.getLogin());
+        if (f.getTipo() != null) q.setParameter("tipo", f.getTipo());
+        if (f.getIdUsuario() != null) q.setParameter("idUsuario", f.getIdUsuario());
+        q.setFirstResult(page * size);
+        q.setMaxResults(size);
+        return q.getResultList();
+    }
+}

--- a/src/main/java/dao/impl/IngredienteFornecedorDaoNativeImpl.java
+++ b/src/main/java/dao/impl/IngredienteFornecedorDaoNativeImpl.java
@@ -1,0 +1,106 @@
+package dao.impl;
+
+import dao.api.IngredienteFornecedorDao;
+import exception.IngredienteFornecedorException;
+import infra.EntityManagerUtil;
+import infra.Logger;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import model.IngredienteFornecedor;
+
+import java.util.List;
+
+public class IngredienteFornecedorDaoNativeImpl implements IngredienteFornecedorDao {
+    private final EntityManager em = EntityManagerUtil.getEntityManager();
+
+    @Override
+    public void create(IngredienteFornecedor e) {
+        Logger.info("IngredienteFornecedorDaoNativeImpl.create");
+        em.getTransaction().begin();
+        em.persist(e);
+        em.getTransaction().commit();
+    }
+
+    @Override
+    public void update(IngredienteFornecedor e) {
+        Logger.info("IngredienteFornecedorDaoNativeImpl.update");
+        em.getTransaction().begin();
+        em.merge(e);
+        em.getTransaction().commit();
+    }
+
+    @Override
+    public void deleteById(Integer id) {
+        Logger.info("IngredienteFornecedorDaoNativeImpl.deleteById");
+        IngredienteFornecedor e = em.find(IngredienteFornecedor.class, id);
+        if (e == null) throw new IngredienteFornecedorException("IngredienteFornecedor nao encontrado: id=" + id);
+        em.getTransaction().begin();
+        em.remove(e);
+        em.getTransaction().commit();
+    }
+
+    @Override
+    public IngredienteFornecedor findById(Integer id) {
+        String sql = "SELECT {select_cols} FROM {table} WHERE {e['fields'][0][2]} = :id";
+        Query q = em.createNativeQuery(sql, {cname}.class).setParameter("id", id);
+        return ({cname}) q.getSingleResult();
+    }
+
+    @Override
+    public List<IngredienteFornecedor> findAll() {
+        String sql = "SELECT {select_cols} FROM {table}";
+        return em.createNativeQuery(sql, {cname}.class).getResultList();
+    }
+
+    @Override
+    public List<IngredienteFornecedor> findAll(int page, int size) {
+        String sql = "SELECT {select_cols} FROM {table} LIMIT :size OFFSET :off";
+        return em.createNativeQuery(sql, {cname}.class).setParameter("size", size).setParameter("off", page * size).getResultList();
+    }
+
+    @Override
+    public List<IngredienteFornecedor> findByValor(BigDecimal valor) {
+        String sql = "SELECT id_fornecedor_ingrediente, valor, data, id_fornecedor, id_ingrediente FROM Ingrediente_fornecedor WHERE valor = :v";
+        return em.createNativeQuery(sql, IngredienteFornecedor.class).setParameter("v", valor).getResultList();
+    }
+
+    @Override
+    public List<IngredienteFornecedor> findByData(LocalDate data) {
+        String sql = "SELECT id_fornecedor_ingrediente, valor, data, id_fornecedor, id_ingrediente FROM Ingrediente_fornecedor WHERE data = :v";
+        return em.createNativeQuery(sql, IngredienteFornecedor.class).setParameter("v", data).getResultList();
+    }
+
+    @Override
+    public List<IngredienteFornecedor> findByIdFornecedor(Integer idFornecedor) {
+        String sql = "SELECT id_fornecedor_ingrediente, valor, data, id_fornecedor, id_ingrediente FROM Ingrediente_fornecedor WHERE id_fornecedor = :v";
+        return em.createNativeQuery(sql, IngredienteFornecedor.class).setParameter("v", idFornecedor).getResultList();
+    }
+
+    @Override
+    public List<IngredienteFornecedor> findByIdIngrediente(Integer idIngrediente) {
+        String sql = "SELECT id_fornecedor_ingrediente, valor, data, id_fornecedor, id_ingrediente FROM Ingrediente_fornecedor WHERE id_ingrediente = :v";
+        return em.createNativeQuery(sql, IngredienteFornecedor.class).setParameter("v", idIngrediente).getResultList();
+    }
+
+    @Override
+    public List<IngredienteFornecedor> search(IngredienteFornecedor f) {
+        return search(f, 0, Integer.MAX_VALUE);
+    }
+
+    @Override
+    public List<IngredienteFornecedor> search(IngredienteFornecedor f, int page, int size) {
+        StringBuilder sb = new StringBuilder("SELECT id_fornecedor_ingrediente, valor, data, id_fornecedor, id_ingrediente FROM Ingrediente_fornecedor WHERE 1=1");
+        if (f.getValor() != null) sb.append(" AND valor = :valor");
+        if (f.getData() != null) sb.append(" AND data = :data");
+        if (f.getIdFornecedor() != null) sb.append(" AND id_fornecedor = :idFornecedor");
+        if (f.getIdIngrediente() != null) sb.append(" AND id_ingrediente = :idIngrediente");
+        Query q = em.createNativeQuery(sb.toString(), IngredienteFornecedor.class);
+        if (f.getValor() != null) q.setParameter("valor", f.getValor());
+        if (f.getData() != null) q.setParameter("data", f.getData());
+        if (f.getIdFornecedor() != null) q.setParameter("idFornecedor", f.getIdFornecedor());
+        if (f.getIdIngrediente() != null) q.setParameter("idIngrediente", f.getIdIngrediente());
+        q.setFirstResult(page * size);
+        q.setMaxResults(size);
+        return q.getResultList();
+    }
+}

--- a/src/main/java/dao/impl/MetaDaoNativeImpl.java
+++ b/src/main/java/dao/impl/MetaDaoNativeImpl.java
@@ -1,0 +1,124 @@
+package dao.impl;
+
+import dao.api.MetaDao;
+import exception.MetaException;
+import infra.EntityManagerUtil;
+import infra.Logger;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import model.Meta;
+
+import java.util.List;
+
+public class MetaDaoNativeImpl implements MetaDao {
+    private final EntityManager em = EntityManagerUtil.getEntityManager();
+
+    @Override
+    public void create(Meta meta) {
+        Logger.info("MetaDao.create");
+        em.getTransaction().begin();
+        em.persist(meta);
+        em.getTransaction().commit();
+    }
+
+    @Override
+    public void update(Meta meta) {
+        Logger.info("MetaDao.update" );
+        em.getTransaction().begin();
+        em.merge(meta);
+        em.getTransaction().commit();
+    }
+
+    @Override
+    public void deleteById(Integer id) {
+        Logger.info("MetaDao.deleteById" );
+        Meta m = em.find(Meta.class, id);
+        if (m == null) throw new MetaException("Meta nao encontrada: id=" + id);
+        em.getTransaction().begin();
+        em.remove(m);
+        em.getTransaction().commit();
+    }
+
+    @Override
+    public Meta findById(Integer id) {
+        String sql = "SELECT id_meta, ponto_minimo, ponto_medio, ponto_maximo, status, NULL as foto, id_periodo FROM Meta WHERE id_meta = :id";
+        Query q = em.createNativeQuery(sql, Meta.class).setParameter("id", id);
+        return (Meta) q.getSingleResult();
+    }
+
+    @Override
+    public Meta findWithFotoById(Integer id) {
+        String sql = "SELECT * FROM Meta WHERE id_meta = :id";
+        Query q = em.createNativeQuery(sql, Meta.class).setParameter("id", id);
+        return (Meta) q.getSingleResult();
+    }
+
+    @Override
+    public List<Meta> findAll() {
+        String sql = "SELECT id_meta, ponto_minimo, ponto_medio, ponto_maximo, status, NULL as foto, id_periodo FROM Meta";
+        return em.createNativeQuery(sql, Meta.class).getResultList();
+    }
+
+    @Override
+    public List<Meta> findAll(int page, int size) {
+        String sql = "SELECT id_meta, ponto_minimo, ponto_medio, ponto_maximo, status, NULL as foto, id_periodo FROM Meta LIMIT :size OFFSET :off";
+        return em.createNativeQuery(sql, Meta.class)
+                .setParameter("size", size)
+                .setParameter("off", page * size)
+                .getResultList();
+    }
+
+    @Override
+    public List<Meta> findByPontoMinimo(Integer pontoMinimo) {
+        String sql = "SELECT id_meta, ponto_minimo, ponto_medio, ponto_maximo, status, NULL as foto, id_periodo FROM Meta WHERE ponto_minimo = :v";
+        return em.createNativeQuery(sql, Meta.class).setParameter("v", pontoMinimo).getResultList();
+    }
+
+    @Override
+    public List<Meta> findByPontoMedio(Integer pontoMedio) {
+        String sql = "SELECT id_meta, ponto_minimo, ponto_medio, ponto_maximo, status, NULL as foto, id_periodo FROM Meta WHERE ponto_medio = :v";
+        return em.createNativeQuery(sql, Meta.class).setParameter("v", pontoMedio).getResultList();
+    }
+
+    @Override
+    public List<Meta> findByPontoMaximo(Integer pontoMaximo) {
+        String sql = "SELECT id_meta, ponto_minimo, ponto_medio, ponto_maximo, status, NULL as foto, id_periodo FROM Meta WHERE ponto_maximo = :v";
+        return em.createNativeQuery(sql, Meta.class).setParameter("v", pontoMaximo).getResultList();
+    }
+
+    @Override
+    public List<Meta> findByStatus(Integer status) {
+        String sql = "SELECT id_meta, ponto_minimo, ponto_medio, ponto_maximo, status, NULL as foto, id_periodo FROM Meta WHERE status = :v";
+        return em.createNativeQuery(sql, Meta.class).setParameter("v", status).getResultList();
+    }
+
+    @Override
+    public List<Meta> findByIdPeriodo(Integer idPeriodo) {
+        String sql = "SELECT id_meta, ponto_minimo, ponto_medio, ponto_maximo, status, NULL as foto, id_periodo FROM Meta WHERE id_periodo = :v";
+        return em.createNativeQuery(sql, Meta.class).setParameter("v", idPeriodo).getResultList();
+    }
+
+    @Override
+    public List<Meta> search(Meta f) {
+        return search(f, 0, Integer.MAX_VALUE);
+    }
+
+    @Override
+    public List<Meta> search(Meta f, int page, int size) {
+        StringBuilder sb = new StringBuilder("SELECT id_meta, ponto_minimo, ponto_medio, ponto_maximo, status, NULL as foto, id_periodo FROM Meta WHERE 1=1");
+        if (f.getPontoMinimo() != null) sb.append(" AND ponto_minimo = :pontoMinimo");
+        if (f.getPontoMedio() != null) sb.append(" AND ponto_medio = :pontoMedio");
+        if (f.getPontoMaximo() != null) sb.append(" AND ponto_maximo = :pontoMaximo");
+        if (f.getStatus() != null) sb.append(" AND status = :status");
+        if (f.getIdPeriodo() != null) sb.append(" AND id_periodo = :idPeriodo");
+        Query q = em.createNativeQuery(sb.toString(), Meta.class);
+        if (f.getPontoMinimo() != null) q.setParameter("pontoMinimo", f.getPontoMinimo());
+        if (f.getPontoMedio() != null) q.setParameter("pontoMedio", f.getPontoMedio());
+        if (f.getPontoMaximo() != null) q.setParameter("pontoMaximo", f.getPontoMaximo());
+        if (f.getStatus() != null) q.setParameter("status", f.getStatus());
+        if (f.getIdPeriodo() != null) q.setParameter("idPeriodo", f.getIdPeriodo());
+        q.setFirstResult(page * size);
+        q.setMaxResults(size);
+        return q.getResultList();
+    }
+}

--- a/src/main/java/dao/impl/MonitoramentoObjetoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/MonitoramentoObjetoDaoNativeImpl.java
@@ -1,0 +1,98 @@
+package dao.impl;
+
+import dao.api.MonitoramentoObjetoDao;
+import exception.MonitoramentoObjetoException;
+import infra.EntityManagerUtil;
+import infra.Logger;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import model.MonitoramentoObjeto;
+
+import java.util.List;
+
+public class MonitoramentoObjetoDaoNativeImpl implements MonitoramentoObjetoDao {
+    private final EntityManager em = EntityManagerUtil.getEntityManager();
+
+    @Override
+    public void create(MonitoramentoObjeto e) {
+        Logger.info("MonitoramentoObjetoDaoNativeImpl.create");
+        em.getTransaction().begin();
+        em.persist(e);
+        em.getTransaction().commit();
+    }
+
+    @Override
+    public void update(MonitoramentoObjeto e) {
+        Logger.info("MonitoramentoObjetoDaoNativeImpl.update");
+        em.getTransaction().begin();
+        em.merge(e);
+        em.getTransaction().commit();
+    }
+
+    @Override
+    public void deleteById(LocalDate id) {
+        Logger.info("MonitoramentoObjetoDaoNativeImpl.deleteById");
+        MonitoramentoObjeto e = em.find(MonitoramentoObjeto.class, id);
+        if (e == null) throw new MonitoramentoObjetoException("MonitoramentoObjeto nao encontrado: id=" + id);
+        em.getTransaction().begin();
+        em.remove(e);
+        em.getTransaction().commit();
+    }
+
+    @Override
+    public MonitoramentoObjeto findById(LocalDate id) {
+        String sql = "SELECT {select_cols} FROM {table} WHERE {e['fields'][0][2]} = :id";
+        Query q = em.createNativeQuery(sql, {cname}.class).setParameter("id", id);
+        return ({cname}) q.getSingleResult();
+    }
+
+    @Override
+    public List<MonitoramentoObjeto> findAll() {
+        String sql = "SELECT {select_cols} FROM {table}";
+        return em.createNativeQuery(sql, {cname}.class).getResultList();
+    }
+
+    @Override
+    public List<MonitoramentoObjeto> findAll(int page, int size) {
+        String sql = "SELECT {select_cols} FROM {table} LIMIT :size OFFSET :off";
+        return em.createNativeQuery(sql, {cname}.class).setParameter("size", size).setParameter("off", page * size).getResultList();
+    }
+
+    @Override
+    public List<MonitoramentoObjeto> findByData(LocalDate data) {
+        String sql = "SELECT id_monitoramento_objeto, data, id_monitoramento, id_objeto FROM Monitoramento_Objeto WHERE data = :v";
+        return em.createNativeQuery(sql, MonitoramentoObjeto.class).setParameter("v", data).getResultList();
+    }
+
+    @Override
+    public List<MonitoramentoObjeto> findByIdMonitoramento(Integer idMonitoramento) {
+        String sql = "SELECT id_monitoramento_objeto, data, id_monitoramento, id_objeto FROM Monitoramento_Objeto WHERE id_monitoramento = :v";
+        return em.createNativeQuery(sql, MonitoramentoObjeto.class).setParameter("v", idMonitoramento).getResultList();
+    }
+
+    @Override
+    public List<MonitoramentoObjeto> findByIdObjeto(Integer idObjeto) {
+        String sql = "SELECT id_monitoramento_objeto, data, id_monitoramento, id_objeto FROM Monitoramento_Objeto WHERE id_objeto = :v";
+        return em.createNativeQuery(sql, MonitoramentoObjeto.class).setParameter("v", idObjeto).getResultList();
+    }
+
+    @Override
+    public List<MonitoramentoObjeto> search(MonitoramentoObjeto f) {
+        return search(f, 0, Integer.MAX_VALUE);
+    }
+
+    @Override
+    public List<MonitoramentoObjeto> search(MonitoramentoObjeto f, int page, int size) {
+        StringBuilder sb = new StringBuilder("SELECT id_monitoramento_objeto, data, id_monitoramento, id_objeto FROM Monitoramento_Objeto WHERE 1=1");
+        if (f.getData() != null) sb.append(" AND data = :data");
+        if (f.getIdMonitoramento() != null) sb.append(" AND id_monitoramento = :idMonitoramento");
+        if (f.getIdObjeto() != null) sb.append(" AND id_objeto = :idObjeto");
+        Query q = em.createNativeQuery(sb.toString(), MonitoramentoObjeto.class);
+        if (f.getData() != null) q.setParameter("data", f.getData());
+        if (f.getIdMonitoramento() != null) q.setParameter("idMonitoramento", f.getIdMonitoramento());
+        if (f.getIdObjeto() != null) q.setParameter("idObjeto", f.getIdObjeto());
+        q.setFirstResult(page * size);
+        q.setMaxResults(size);
+        return q.getResultList();
+    }
+}

--- a/src/main/java/dao/impl/OperacaoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/OperacaoDaoNativeImpl.java
@@ -1,0 +1,226 @@
+package dao.impl;
+
+import dao.api.OperacaoDao;
+import exception.OperacaoException;
+import infra.EntityManagerUtil;
+import infra.Logger;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import model.Operacao;
+
+import java.util.List;
+
+public class OperacaoDaoNativeImpl implements OperacaoDao {
+    private final EntityManager em = EntityManagerUtil.getEntityManager();
+
+    @Override
+    public void create(Operacao e) {
+        Logger.info("OperacaoDaoNativeImpl.create");
+        em.getTransaction().begin();
+        em.persist(e);
+        em.getTransaction().commit();
+    }
+
+    @Override
+    public void update(Operacao e) {
+        Logger.info("OperacaoDaoNativeImpl.update");
+        em.getTransaction().begin();
+        em.merge(e);
+        em.getTransaction().commit();
+    }
+
+    @Override
+    public void deleteById(Integer id) {
+        Logger.info("OperacaoDaoNativeImpl.deleteById");
+        Operacao e = em.find(Operacao.class, id);
+        if (e == null) throw new OperacaoException("Operacao nao encontrado: id=" + id);
+        em.getTransaction().begin();
+        em.remove(e);
+        em.getTransaction().commit();
+    }
+
+    @Override
+    public Operacao findById(Integer id) {
+        String sql = "SELECT {select_cols} FROM {table} WHERE {e['fields'][0][2]} = :id";
+        Query q = em.createNativeQuery(sql, {cname}.class).setParameter("id", id);
+        return ({cname}) q.getSingleResult();
+    }
+
+    @Override
+    public List<Operacao> findAll() {
+        String sql = "SELECT {select_cols} FROM {table}";
+        return em.createNativeQuery(sql, {cname}.class).getResultList();
+    }
+
+    @Override
+    public List<Operacao> findAll(int page, int size) {
+        String sql = "SELECT {select_cols} FROM {table} LIMIT :size OFFSET :off";
+        return em.createNativeQuery(sql, {cname}.class).setParameter("size", size).setParameter("off", page * size).getResultList();
+    }
+
+    @Override
+    public List<Operacao> findByFechamento(BigDecimal fechamento) {
+        String sql = "SELECT id_operacao, fechamento, tempo_operacao, qtd_compra, abertura, qtd_venda, lado, preco_compra, preco_venda, preco_medio, res_intervalo, numero_operacao, res_operacao, drawdon, ganhoMax, perdaMax, tet, total, id_carteira, id_papel FROM Operacao WHERE fechamento = :v";
+        return em.createNativeQuery(sql, Operacao.class).setParameter("v", fechamento).getResultList();
+    }
+
+    @Override
+    public List<Operacao> findByTempoOperacao(LocalTime tempoOperacao) {
+        String sql = "SELECT id_operacao, fechamento, tempo_operacao, qtd_compra, abertura, qtd_venda, lado, preco_compra, preco_venda, preco_medio, res_intervalo, numero_operacao, res_operacao, drawdon, ganhoMax, perdaMax, tet, total, id_carteira, id_papel FROM Operacao WHERE tempo_operacao = :v";
+        return em.createNativeQuery(sql, Operacao.class).setParameter("v", tempoOperacao).getResultList();
+    }
+
+    @Override
+    public List<Operacao> findByQtdCompra(Integer qtdCompra) {
+        String sql = "SELECT id_operacao, fechamento, tempo_operacao, qtd_compra, abertura, qtd_venda, lado, preco_compra, preco_venda, preco_medio, res_intervalo, numero_operacao, res_operacao, drawdon, ganhoMax, perdaMax, tet, total, id_carteira, id_papel FROM Operacao WHERE qtd_compra = :v";
+        return em.createNativeQuery(sql, Operacao.class).setParameter("v", qtdCompra).getResultList();
+    }
+
+    @Override
+    public List<Operacao> findByAbertura(BigDecimal abertura) {
+        String sql = "SELECT id_operacao, fechamento, tempo_operacao, qtd_compra, abertura, qtd_venda, lado, preco_compra, preco_venda, preco_medio, res_intervalo, numero_operacao, res_operacao, drawdon, ganhoMax, perdaMax, tet, total, id_carteira, id_papel FROM Operacao WHERE abertura = :v";
+        return em.createNativeQuery(sql, Operacao.class).setParameter("v", abertura).getResultList();
+    }
+
+    @Override
+    public List<Operacao> findByQtdVenda(Integer qtdVenda) {
+        String sql = "SELECT id_operacao, fechamento, tempo_operacao, qtd_compra, abertura, qtd_venda, lado, preco_compra, preco_venda, preco_medio, res_intervalo, numero_operacao, res_operacao, drawdon, ganhoMax, perdaMax, tet, total, id_carteira, id_papel FROM Operacao WHERE qtd_venda = :v";
+        return em.createNativeQuery(sql, Operacao.class).setParameter("v", qtdVenda).getResultList();
+    }
+
+    @Override
+    public List<Operacao> findByLado(String lado) {
+        String sql = "SELECT id_operacao, fechamento, tempo_operacao, qtd_compra, abertura, qtd_venda, lado, preco_compra, preco_venda, preco_medio, res_intervalo, numero_operacao, res_operacao, drawdon, ganhoMax, perdaMax, tet, total, id_carteira, id_papel FROM Operacao WHERE lado = :v";
+        return em.createNativeQuery(sql, Operacao.class).setParameter("v", lado).getResultList();
+    }
+
+    @Override
+    public List<Operacao> findByPrecoCompra(BigDecimal precoCompra) {
+        String sql = "SELECT id_operacao, fechamento, tempo_operacao, qtd_compra, abertura, qtd_venda, lado, preco_compra, preco_venda, preco_medio, res_intervalo, numero_operacao, res_operacao, drawdon, ganhoMax, perdaMax, tet, total, id_carteira, id_papel FROM Operacao WHERE preco_compra = :v";
+        return em.createNativeQuery(sql, Operacao.class).setParameter("v", precoCompra).getResultList();
+    }
+
+    @Override
+    public List<Operacao> findByPrecoVenda(BigDecimal precoVenda) {
+        String sql = "SELECT id_operacao, fechamento, tempo_operacao, qtd_compra, abertura, qtd_venda, lado, preco_compra, preco_venda, preco_medio, res_intervalo, numero_operacao, res_operacao, drawdon, ganhoMax, perdaMax, tet, total, id_carteira, id_papel FROM Operacao WHERE preco_venda = :v";
+        return em.createNativeQuery(sql, Operacao.class).setParameter("v", precoVenda).getResultList();
+    }
+
+    @Override
+    public List<Operacao> findByPrecoMedio(BigDecimal precoMedio) {
+        String sql = "SELECT id_operacao, fechamento, tempo_operacao, qtd_compra, abertura, qtd_venda, lado, preco_compra, preco_venda, preco_medio, res_intervalo, numero_operacao, res_operacao, drawdon, ganhoMax, perdaMax, tet, total, id_carteira, id_papel FROM Operacao WHERE preco_medio = :v";
+        return em.createNativeQuery(sql, Operacao.class).setParameter("v", precoMedio).getResultList();
+    }
+
+    @Override
+    public List<Operacao> findByResIntervalo(String resIntervalo) {
+        String sql = "SELECT id_operacao, fechamento, tempo_operacao, qtd_compra, abertura, qtd_venda, lado, preco_compra, preco_venda, preco_medio, res_intervalo, numero_operacao, res_operacao, drawdon, ganhoMax, perdaMax, tet, total, id_carteira, id_papel FROM Operacao WHERE res_intervalo = :v";
+        return em.createNativeQuery(sql, Operacao.class).setParameter("v", resIntervalo).getResultList();
+    }
+
+    @Override
+    public List<Operacao> findByNumeroOperacao(BigDecimal numeroOperacao) {
+        String sql = "SELECT id_operacao, fechamento, tempo_operacao, qtd_compra, abertura, qtd_venda, lado, preco_compra, preco_venda, preco_medio, res_intervalo, numero_operacao, res_operacao, drawdon, ganhoMax, perdaMax, tet, total, id_carteira, id_papel FROM Operacao WHERE numero_operacao = :v";
+        return em.createNativeQuery(sql, Operacao.class).setParameter("v", numeroOperacao).getResultList();
+    }
+
+    @Override
+    public List<Operacao> findByResOperacao(String resOperacao) {
+        String sql = "SELECT id_operacao, fechamento, tempo_operacao, qtd_compra, abertura, qtd_venda, lado, preco_compra, preco_venda, preco_medio, res_intervalo, numero_operacao, res_operacao, drawdon, ganhoMax, perdaMax, tet, total, id_carteira, id_papel FROM Operacao WHERE res_operacao = :v";
+        return em.createNativeQuery(sql, Operacao.class).setParameter("v", resOperacao).getResultList();
+    }
+
+    @Override
+    public List<Operacao> findByDrawdon(BigDecimal drawdon) {
+        String sql = "SELECT id_operacao, fechamento, tempo_operacao, qtd_compra, abertura, qtd_venda, lado, preco_compra, preco_venda, preco_medio, res_intervalo, numero_operacao, res_operacao, drawdon, ganhoMax, perdaMax, tet, total, id_carteira, id_papel FROM Operacao WHERE drawdon = :v";
+        return em.createNativeQuery(sql, Operacao.class).setParameter("v", drawdon).getResultList();
+    }
+
+    @Override
+    public List<Operacao> findByGanhoMax(BigDecimal ganhoMax) {
+        String sql = "SELECT id_operacao, fechamento, tempo_operacao, qtd_compra, abertura, qtd_venda, lado, preco_compra, preco_venda, preco_medio, res_intervalo, numero_operacao, res_operacao, drawdon, ganhoMax, perdaMax, tet, total, id_carteira, id_papel FROM Operacao WHERE ganhoMax = :v";
+        return em.createNativeQuery(sql, Operacao.class).setParameter("v", ganhoMax).getResultList();
+    }
+
+    @Override
+    public List<Operacao> findByPerdaMax(BigDecimal perdaMax) {
+        String sql = "SELECT id_operacao, fechamento, tempo_operacao, qtd_compra, abertura, qtd_venda, lado, preco_compra, preco_venda, preco_medio, res_intervalo, numero_operacao, res_operacao, drawdon, ganhoMax, perdaMax, tet, total, id_carteira, id_papel FROM Operacao WHERE perdaMax = :v";
+        return em.createNativeQuery(sql, Operacao.class).setParameter("v", perdaMax).getResultList();
+    }
+
+    @Override
+    public List<Operacao> findByTet(String tet) {
+        String sql = "SELECT id_operacao, fechamento, tempo_operacao, qtd_compra, abertura, qtd_venda, lado, preco_compra, preco_venda, preco_medio, res_intervalo, numero_operacao, res_operacao, drawdon, ganhoMax, perdaMax, tet, total, id_carteira, id_papel FROM Operacao WHERE tet = :v";
+        return em.createNativeQuery(sql, Operacao.class).setParameter("v", tet).getResultList();
+    }
+
+    @Override
+    public List<Operacao> findByTotal(BigDecimal total) {
+        String sql = "SELECT id_operacao, fechamento, tempo_operacao, qtd_compra, abertura, qtd_venda, lado, preco_compra, preco_venda, preco_medio, res_intervalo, numero_operacao, res_operacao, drawdon, ganhoMax, perdaMax, tet, total, id_carteira, id_papel FROM Operacao WHERE total = :v";
+        return em.createNativeQuery(sql, Operacao.class).setParameter("v", total).getResultList();
+    }
+
+    @Override
+    public List<Operacao> findByIdCarteira(Integer idCarteira) {
+        String sql = "SELECT id_operacao, fechamento, tempo_operacao, qtd_compra, abertura, qtd_venda, lado, preco_compra, preco_venda, preco_medio, res_intervalo, numero_operacao, res_operacao, drawdon, ganhoMax, perdaMax, tet, total, id_carteira, id_papel FROM Operacao WHERE id_carteira = :v";
+        return em.createNativeQuery(sql, Operacao.class).setParameter("v", idCarteira).getResultList();
+    }
+
+    @Override
+    public List<Operacao> findByIdPapel(Integer idPapel) {
+        String sql = "SELECT id_operacao, fechamento, tempo_operacao, qtd_compra, abertura, qtd_venda, lado, preco_compra, preco_venda, preco_medio, res_intervalo, numero_operacao, res_operacao, drawdon, ganhoMax, perdaMax, tet, total, id_carteira, id_papel FROM Operacao WHERE id_papel = :v";
+        return em.createNativeQuery(sql, Operacao.class).setParameter("v", idPapel).getResultList();
+    }
+
+    @Override
+    public List<Operacao> search(Operacao f) {
+        return search(f, 0, Integer.MAX_VALUE);
+    }
+
+    @Override
+    public List<Operacao> search(Operacao f, int page, int size) {
+        StringBuilder sb = new StringBuilder("SELECT id_operacao, fechamento, tempo_operacao, qtd_compra, abertura, qtd_venda, lado, preco_compra, preco_venda, preco_medio, res_intervalo, numero_operacao, res_operacao, drawdon, ganhoMax, perdaMax, tet, total, id_carteira, id_papel FROM Operacao WHERE 1=1");
+        if (f.getFechamento() != null) sb.append(" AND fechamento = :fechamento");
+        if (f.getTempoOperacao() != null) sb.append(" AND tempo_operacao = :tempoOperacao");
+        if (f.getQtdCompra() != null) sb.append(" AND qtd_compra = :qtdCompra");
+        if (f.getAbertura() != null) sb.append(" AND abertura = :abertura");
+        if (f.getQtdVenda() != null) sb.append(" AND qtd_venda = :qtdVenda");
+        if (f.getLado() != null && !f.getLado().isEmpty()) sb.append(" AND lado = :lado");
+        if (f.getPrecoCompra() != null) sb.append(" AND preco_compra = :precoCompra");
+        if (f.getPrecoVenda() != null) sb.append(" AND preco_venda = :precoVenda");
+        if (f.getPrecoMedio() != null) sb.append(" AND preco_medio = :precoMedio");
+        if (f.getResIntervalo() != null && !f.getResIntervalo().isEmpty()) sb.append(" AND res_intervalo = :resIntervalo");
+        if (f.getNumeroOperacao() != null) sb.append(" AND numero_operacao = :numeroOperacao");
+        if (f.getResOperacao() != null && !f.getResOperacao().isEmpty()) sb.append(" AND res_operacao = :resOperacao");
+        if (f.getDrawdon() != null) sb.append(" AND drawdon = :drawdon");
+        if (f.getGanhoMax() != null) sb.append(" AND ganhoMax = :ganhoMax");
+        if (f.getPerdaMax() != null) sb.append(" AND perdaMax = :perdaMax");
+        if (f.getTet() != null && !f.getTet().isEmpty()) sb.append(" AND tet = :tet");
+        if (f.getTotal() != null) sb.append(" AND total = :total");
+        if (f.getIdCarteira() != null) sb.append(" AND id_carteira = :idCarteira");
+        if (f.getIdPapel() != null) sb.append(" AND id_papel = :idPapel");
+        Query q = em.createNativeQuery(sb.toString(), Operacao.class);
+        if (f.getFechamento() != null) q.setParameter("fechamento", f.getFechamento());
+        if (f.getTempoOperacao() != null) q.setParameter("tempoOperacao", f.getTempoOperacao());
+        if (f.getQtdCompra() != null) q.setParameter("qtdCompra", f.getQtdCompra());
+        if (f.getAbertura() != null) q.setParameter("abertura", f.getAbertura());
+        if (f.getQtdVenda() != null) q.setParameter("qtdVenda", f.getQtdVenda());
+        if (f.getLado() != null && !f.getLado().isEmpty()) q.setParameter("lado", f.getLado());
+        if (f.getPrecoCompra() != null) q.setParameter("precoCompra", f.getPrecoCompra());
+        if (f.getPrecoVenda() != null) q.setParameter("precoVenda", f.getPrecoVenda());
+        if (f.getPrecoMedio() != null) q.setParameter("precoMedio", f.getPrecoMedio());
+        if (f.getResIntervalo() != null && !f.getResIntervalo().isEmpty()) q.setParameter("resIntervalo", f.getResIntervalo());
+        if (f.getNumeroOperacao() != null) q.setParameter("numeroOperacao", f.getNumeroOperacao());
+        if (f.getResOperacao() != null && !f.getResOperacao().isEmpty()) q.setParameter("resOperacao", f.getResOperacao());
+        if (f.getDrawdon() != null) q.setParameter("drawdon", f.getDrawdon());
+        if (f.getGanhoMax() != null) q.setParameter("ganhoMax", f.getGanhoMax());
+        if (f.getPerdaMax() != null) q.setParameter("perdaMax", f.getPerdaMax());
+        if (f.getTet() != null && !f.getTet().isEmpty()) q.setParameter("tet", f.getTet());
+        if (f.getTotal() != null) q.setParameter("total", f.getTotal());
+        if (f.getIdCarteira() != null) q.setParameter("idCarteira", f.getIdCarteira());
+        if (f.getIdPapel() != null) q.setParameter("idPapel", f.getIdPapel());
+        q.setFirstResult(page * size);
+        q.setMaxResults(size);
+        return q.getResultList();
+    }
+}

--- a/src/main/java/dao/impl/PapelDaoNativeImpl.java
+++ b/src/main/java/dao/impl/PapelDaoNativeImpl.java
@@ -1,0 +1,98 @@
+package dao.impl;
+
+import dao.api.PapelDao;
+import exception.PapelException;
+import infra.EntityManagerUtil;
+import infra.Logger;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import model.Papel;
+
+import java.util.List;
+
+public class PapelDaoNativeImpl implements PapelDao {
+    private final EntityManager em = EntityManagerUtil.getEntityManager();
+
+    @Override
+    public void create(Papel e) {
+        Logger.info("PapelDaoNativeImpl.create");
+        em.getTransaction().begin();
+        em.persist(e);
+        em.getTransaction().commit();
+    }
+
+    @Override
+    public void update(Papel e) {
+        Logger.info("PapelDaoNativeImpl.update");
+        em.getTransaction().begin();
+        em.merge(e);
+        em.getTransaction().commit();
+    }
+
+    @Override
+    public void deleteById(Integer id) {
+        Logger.info("PapelDaoNativeImpl.deleteById");
+        Papel e = em.find(Papel.class, id);
+        if (e == null) throw new PapelException("Papel nao encontrado: id=" + id);
+        em.getTransaction().begin();
+        em.remove(e);
+        em.getTransaction().commit();
+    }
+
+    @Override
+    public Papel findById(Integer id) {
+        String sql = "SELECT {select_cols} FROM {table} WHERE {e['fields'][0][2]} = :id";
+        Query q = em.createNativeQuery(sql, {cname}.class).setParameter("id", id);
+        return ({cname}) q.getSingleResult();
+    }
+
+    @Override
+    public List<Papel> findAll() {
+        String sql = "SELECT {select_cols} FROM {table}";
+        return em.createNativeQuery(sql, {cname}.class).getResultList();
+    }
+
+    @Override
+    public List<Papel> findAll(int page, int size) {
+        String sql = "SELECT {select_cols} FROM {table} LIMIT :size OFFSET :off";
+        return em.createNativeQuery(sql, {cname}.class).setParameter("size", size).setParameter("off", page * size).getResultList();
+    }
+
+    @Override
+    public List<Papel> findByCodigo(String codigo) {
+        String sql = "SELECT id_papel, codigo, tipo, vencimento FROM Papel WHERE codigo = :v";
+        return em.createNativeQuery(sql, Papel.class).setParameter("v", codigo).getResultList();
+    }
+
+    @Override
+    public List<Papel> findByTipo(String tipo) {
+        String sql = "SELECT id_papel, codigo, tipo, vencimento FROM Papel WHERE tipo = :v";
+        return em.createNativeQuery(sql, Papel.class).setParameter("v", tipo).getResultList();
+    }
+
+    @Override
+    public List<Papel> findByVencimento(LocalDate vencimento) {
+        String sql = "SELECT id_papel, codigo, tipo, vencimento FROM Papel WHERE vencimento = :v";
+        return em.createNativeQuery(sql, Papel.class).setParameter("v", vencimento).getResultList();
+    }
+
+    @Override
+    public List<Papel> search(Papel f) {
+        return search(f, 0, Integer.MAX_VALUE);
+    }
+
+    @Override
+    public List<Papel> search(Papel f, int page, int size) {
+        StringBuilder sb = new StringBuilder("SELECT id_papel, codigo, tipo, vencimento FROM Papel WHERE 1=1");
+        if (f.getCodigo() != null && !f.getCodigo().isEmpty()) sb.append(" AND codigo = :codigo");
+        if (f.getTipo() != null && !f.getTipo().isEmpty()) sb.append(" AND tipo = :tipo");
+        if (f.getVencimento() != null) sb.append(" AND vencimento = :vencimento");
+        Query q = em.createNativeQuery(sb.toString(), Papel.class);
+        if (f.getCodigo() != null && !f.getCodigo().isEmpty()) q.setParameter("codigo", f.getCodigo());
+        if (f.getTipo() != null && !f.getTipo().isEmpty()) q.setParameter("tipo", f.getTipo());
+        if (f.getVencimento() != null) q.setParameter("vencimento", f.getVencimento());
+        q.setFirstResult(page * size);
+        q.setMaxResults(size);
+        return q.getResultList();
+    }
+}

--- a/src/main/java/dao/impl/RotinaPeriodoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/RotinaPeriodoDaoNativeImpl.java
@@ -1,0 +1,90 @@
+package dao.impl;
+
+import dao.api.RotinaPeriodoDao;
+import exception.RotinaPeriodoException;
+import infra.EntityManagerUtil;
+import infra.Logger;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import model.RotinaPeriodo;
+
+import java.util.List;
+
+public class RotinaPeriodoDaoNativeImpl implements RotinaPeriodoDao {
+    private final EntityManager em = EntityManagerUtil.getEntityManager();
+
+    @Override
+    public void create(RotinaPeriodo e) {
+        Logger.info("RotinaPeriodoDaoNativeImpl.create");
+        em.getTransaction().begin();
+        em.persist(e);
+        em.getTransaction().commit();
+    }
+
+    @Override
+    public void update(RotinaPeriodo e) {
+        Logger.info("RotinaPeriodoDaoNativeImpl.update");
+        em.getTransaction().begin();
+        em.merge(e);
+        em.getTransaction().commit();
+    }
+
+    @Override
+    public void deleteById(Integer id) {
+        Logger.info("RotinaPeriodoDaoNativeImpl.deleteById");
+        RotinaPeriodo e = em.find(RotinaPeriodo.class, id);
+        if (e == null) throw new RotinaPeriodoException("RotinaPeriodo nao encontrado: id=" + id);
+        em.getTransaction().begin();
+        em.remove(e);
+        em.getTransaction().commit();
+    }
+
+    @Override
+    public RotinaPeriodo findById(Integer id) {
+        String sql = "SELECT {select_cols} FROM {table} WHERE {e['fields'][0][2]} = :id";
+        Query q = em.createNativeQuery(sql, {cname}.class).setParameter("id", id);
+        return ({cname}) q.getSingleResult();
+    }
+
+    @Override
+    public List<RotinaPeriodo> findAll() {
+        String sql = "SELECT {select_cols} FROM {table}";
+        return em.createNativeQuery(sql, {cname}.class).getResultList();
+    }
+
+    @Override
+    public List<RotinaPeriodo> findAll(int page, int size) {
+        String sql = "SELECT {select_cols} FROM {table} LIMIT :size OFFSET :off";
+        return em.createNativeQuery(sql, {cname}.class).setParameter("size", size).setParameter("off", page * size).getResultList();
+    }
+
+    @Override
+    public List<RotinaPeriodo> findByIdRotina(Integer idRotina) {
+        String sql = "SELECT id_rotina_periodo, id_rotina, id_periodo FROM Rotina_Periodo WHERE id_rotina = :v";
+        return em.createNativeQuery(sql, RotinaPeriodo.class).setParameter("v", idRotina).getResultList();
+    }
+
+    @Override
+    public List<RotinaPeriodo> findByIdPeriodo(Integer idPeriodo) {
+        String sql = "SELECT id_rotina_periodo, id_rotina, id_periodo FROM Rotina_Periodo WHERE id_periodo = :v";
+        return em.createNativeQuery(sql, RotinaPeriodo.class).setParameter("v", idPeriodo).getResultList();
+    }
+
+    @Override
+    public List<RotinaPeriodo> search(RotinaPeriodo f) {
+        return search(f, 0, Integer.MAX_VALUE);
+    }
+
+    @Override
+    public List<RotinaPeriodo> search(RotinaPeriodo f, int page, int size) {
+        StringBuilder sb = new StringBuilder("SELECT id_rotina_periodo, id_rotina, id_periodo FROM Rotina_Periodo WHERE 1=1");
+        if (f.getIdRotina() != null) sb.append(" AND id_rotina = :idRotina");
+        if (f.getIdPeriodo() != null) sb.append(" AND id_periodo = :idPeriodo");
+        Query q = em.createNativeQuery(sb.toString(), RotinaPeriodo.class);
+        if (f.getIdRotina() != null) q.setParameter("idRotina", f.getIdRotina());
+        if (f.getIdPeriodo() != null) q.setParameter("idPeriodo", f.getIdPeriodo());
+        q.setFirstResult(page * size);
+        q.setMaxResults(size);
+        return q.getResultList();
+    }
+}

--- a/src/main/java/dao/impl/SiteObjetoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/SiteObjetoDaoNativeImpl.java
@@ -1,0 +1,90 @@
+package dao.impl;
+
+import dao.api.SiteObjetoDao;
+import exception.SiteObjetoException;
+import infra.EntityManagerUtil;
+import infra.Logger;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import model.SiteObjeto;
+
+import java.util.List;
+
+public class SiteObjetoDaoNativeImpl implements SiteObjetoDao {
+    private final EntityManager em = EntityManagerUtil.getEntityManager();
+
+    @Override
+    public void create(SiteObjeto e) {
+        Logger.info("SiteObjetoDaoNativeImpl.create");
+        em.getTransaction().begin();
+        em.persist(e);
+        em.getTransaction().commit();
+    }
+
+    @Override
+    public void update(SiteObjeto e) {
+        Logger.info("SiteObjetoDaoNativeImpl.update");
+        em.getTransaction().begin();
+        em.merge(e);
+        em.getTransaction().commit();
+    }
+
+    @Override
+    public void deleteById(Integer id) {
+        Logger.info("SiteObjetoDaoNativeImpl.deleteById");
+        SiteObjeto e = em.find(SiteObjeto.class, id);
+        if (e == null) throw new SiteObjetoException("SiteObjeto nao encontrado: id=" + id);
+        em.getTransaction().begin();
+        em.remove(e);
+        em.getTransaction().commit();
+    }
+
+    @Override
+    public SiteObjeto findById(Integer id) {
+        String sql = "SELECT {select_cols} FROM {table} WHERE {e['fields'][0][2]} = :id";
+        Query q = em.createNativeQuery(sql, {cname}.class).setParameter("id", id);
+        return ({cname}) q.getSingleResult();
+    }
+
+    @Override
+    public List<SiteObjeto> findAll() {
+        String sql = "SELECT {select_cols} FROM {table}";
+        return em.createNativeQuery(sql, {cname}.class).getResultList();
+    }
+
+    @Override
+    public List<SiteObjeto> findAll(int page, int size) {
+        String sql = "SELECT {select_cols} FROM {table} LIMIT :size OFFSET :off";
+        return em.createNativeQuery(sql, {cname}.class).setParameter("size", size).setParameter("off", page * size).getResultList();
+    }
+
+    @Override
+    public List<SiteObjeto> findByIdSite(Integer idSite) {
+        String sql = "SELECT id_site_objeto, id_site, id_objeto FROM Site_Objeto WHERE id_site = :v";
+        return em.createNativeQuery(sql, SiteObjeto.class).setParameter("v", idSite).getResultList();
+    }
+
+    @Override
+    public List<SiteObjeto> findByIdObjeto(Integer idObjeto) {
+        String sql = "SELECT id_site_objeto, id_site, id_objeto FROM Site_Objeto WHERE id_objeto = :v";
+        return em.createNativeQuery(sql, SiteObjeto.class).setParameter("v", idObjeto).getResultList();
+    }
+
+    @Override
+    public List<SiteObjeto> search(SiteObjeto f) {
+        return search(f, 0, Integer.MAX_VALUE);
+    }
+
+    @Override
+    public List<SiteObjeto> search(SiteObjeto f, int page, int size) {
+        StringBuilder sb = new StringBuilder("SELECT id_site_objeto, id_site, id_objeto FROM Site_Objeto WHERE 1=1");
+        if (f.getIdSite() != null) sb.append(" AND id_site = :idSite");
+        if (f.getIdObjeto() != null) sb.append(" AND id_objeto = :idObjeto");
+        Query q = em.createNativeQuery(sb.toString(), SiteObjeto.class);
+        if (f.getIdSite() != null) q.setParameter("idSite", f.getIdSite());
+        if (f.getIdObjeto() != null) q.setParameter("idObjeto", f.getIdObjeto());
+        q.setFirstResult(page * size);
+        q.setMaxResults(size);
+        return q.getResultList();
+    }
+}

--- a/src/main/java/dao/impl/TreinoExercicioDaoNativeImpl.java
+++ b/src/main/java/dao/impl/TreinoExercicioDaoNativeImpl.java
@@ -1,0 +1,122 @@
+package dao.impl;
+
+import dao.api.TreinoExercicioDao;
+import exception.TreinoExercicioException;
+import infra.EntityManagerUtil;
+import infra.Logger;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import model.TreinoExercicio;
+
+import java.util.List;
+
+public class TreinoExercicioDaoNativeImpl implements TreinoExercicioDao {
+    private final EntityManager em = EntityManagerUtil.getEntityManager();
+
+    @Override
+    public void create(TreinoExercicio e) {
+        Logger.info("TreinoExercicioDaoNativeImpl.create");
+        em.getTransaction().begin();
+        em.persist(e);
+        em.getTransaction().commit();
+    }
+
+    @Override
+    public void update(TreinoExercicio e) {
+        Logger.info("TreinoExercicioDaoNativeImpl.update");
+        em.getTransaction().begin();
+        em.merge(e);
+        em.getTransaction().commit();
+    }
+
+    @Override
+    public void deleteById(Integer id) {
+        Logger.info("TreinoExercicioDaoNativeImpl.deleteById");
+        TreinoExercicio e = em.find(TreinoExercicio.class, id);
+        if (e == null) throw new TreinoExercicioException("TreinoExercicio nao encontrado: id=" + id);
+        em.getTransaction().begin();
+        em.remove(e);
+        em.getTransaction().commit();
+    }
+
+    @Override
+    public TreinoExercicio findById(Integer id) {
+        String sql = "SELECT {select_cols} FROM {table} WHERE {e['fields'][0][2]} = :id";
+        Query q = em.createNativeQuery(sql, {cname}.class).setParameter("id", id);
+        return ({cname}) q.getSingleResult();
+    }
+
+    @Override
+    public List<TreinoExercicio> findAll() {
+        String sql = "SELECT {select_cols} FROM {table}";
+        return em.createNativeQuery(sql, {cname}.class).getResultList();
+    }
+
+    @Override
+    public List<TreinoExercicio> findAll(int page, int size) {
+        String sql = "SELECT {select_cols} FROM {table} LIMIT :size OFFSET :off";
+        return em.createNativeQuery(sql, {cname}.class).setParameter("size", size).setParameter("off", page * size).getResultList();
+    }
+
+    @Override
+    public List<TreinoExercicio> findByQtdRepeticao(Integer qtdRepeticao) {
+        String sql = "SELECT id_treino_exercicio, qtd_repeticao, tempo_descanso, ordem, feito, id_exercicio, id_treino FROM Treino_Exercicio WHERE qtd_repeticao = :v";
+        return em.createNativeQuery(sql, TreinoExercicio.class).setParameter("v", qtdRepeticao).getResultList();
+    }
+
+    @Override
+    public List<TreinoExercicio> findByTempoDescanso(String tempoDescanso) {
+        String sql = "SELECT id_treino_exercicio, qtd_repeticao, tempo_descanso, ordem, feito, id_exercicio, id_treino FROM Treino_Exercicio WHERE tempo_descanso = :v";
+        return em.createNativeQuery(sql, TreinoExercicio.class).setParameter("v", tempoDescanso).getResultList();
+    }
+
+    @Override
+    public List<TreinoExercicio> findByOrdem(Integer ordem) {
+        String sql = "SELECT id_treino_exercicio, qtd_repeticao, tempo_descanso, ordem, feito, id_exercicio, id_treino FROM Treino_Exercicio WHERE ordem = :v";
+        return em.createNativeQuery(sql, TreinoExercicio.class).setParameter("v", ordem).getResultList();
+    }
+
+    @Override
+    public List<TreinoExercicio> findByFeito(Boolean feito) {
+        String sql = "SELECT id_treino_exercicio, qtd_repeticao, tempo_descanso, ordem, feito, id_exercicio, id_treino FROM Treino_Exercicio WHERE feito = :v";
+        return em.createNativeQuery(sql, TreinoExercicio.class).setParameter("v", feito).getResultList();
+    }
+
+    @Override
+    public List<TreinoExercicio> findByIdExercicio(Integer idExercicio) {
+        String sql = "SELECT id_treino_exercicio, qtd_repeticao, tempo_descanso, ordem, feito, id_exercicio, id_treino FROM Treino_Exercicio WHERE id_exercicio = :v";
+        return em.createNativeQuery(sql, TreinoExercicio.class).setParameter("v", idExercicio).getResultList();
+    }
+
+    @Override
+    public List<TreinoExercicio> findByIdTreino(Integer idTreino) {
+        String sql = "SELECT id_treino_exercicio, qtd_repeticao, tempo_descanso, ordem, feito, id_exercicio, id_treino FROM Treino_Exercicio WHERE id_treino = :v";
+        return em.createNativeQuery(sql, TreinoExercicio.class).setParameter("v", idTreino).getResultList();
+    }
+
+    @Override
+    public List<TreinoExercicio> search(TreinoExercicio f) {
+        return search(f, 0, Integer.MAX_VALUE);
+    }
+
+    @Override
+    public List<TreinoExercicio> search(TreinoExercicio f, int page, int size) {
+        StringBuilder sb = new StringBuilder("SELECT id_treino_exercicio, qtd_repeticao, tempo_descanso, ordem, feito, id_exercicio, id_treino FROM Treino_Exercicio WHERE 1=1");
+        if (f.getQtdRepeticao() != null) sb.append(" AND qtd_repeticao = :qtdRepeticao");
+        if (f.getTempoDescanso() != null && !f.getTempoDescanso().isEmpty()) sb.append(" AND tempo_descanso = :tempoDescanso");
+        if (f.getOrdem() != null) sb.append(" AND ordem = :ordem");
+        if (f.getFeito() != null) sb.append(" AND feito = :feito");
+        if (f.getIdExercicio() != null) sb.append(" AND id_exercicio = :idExercicio");
+        if (f.getIdTreino() != null) sb.append(" AND id_treino = :idTreino");
+        Query q = em.createNativeQuery(sb.toString(), TreinoExercicio.class);
+        if (f.getQtdRepeticao() != null) q.setParameter("qtdRepeticao", f.getQtdRepeticao());
+        if (f.getTempoDescanso() != null && !f.getTempoDescanso().isEmpty()) q.setParameter("tempoDescanso", f.getTempoDescanso());
+        if (f.getOrdem() != null) q.setParameter("ordem", f.getOrdem());
+        if (f.getFeito() != null) q.setParameter("feito", f.getFeito());
+        if (f.getIdExercicio() != null) q.setParameter("idExercicio", f.getIdExercicio());
+        if (f.getIdTreino() != null) q.setParameter("idTreino", f.getIdTreino());
+        q.setFirstResult(page * size);
+        q.setMaxResults(size);
+        return q.getResultList();
+    }
+}

--- a/src/main/java/exception/AlimentacaoIngredienteException.java
+++ b/src/main/java/exception/AlimentacaoIngredienteException.java
@@ -1,0 +1,6 @@
+package exception;
+
+public class AlimentacaoIngredienteException extends RuntimeException {
+    public AlimentacaoIngredienteException(String msg) { super(msg); }
+    public AlimentacaoIngredienteException(String msg, Throwable t) { super(msg, t); }
+}

--- a/src/main/java/exception/CarteiraException.java
+++ b/src/main/java/exception/CarteiraException.java
@@ -1,0 +1,6 @@
+package exception;
+
+public class CarteiraException extends RuntimeException {
+    public CarteiraException(String msg) { super(msg); }
+    public CarteiraException(String msg, Throwable t) { super(msg, t); }
+}

--- a/src/main/java/exception/CofreException.java
+++ b/src/main/java/exception/CofreException.java
@@ -1,0 +1,6 @@
+package exception;
+
+public class CofreException extends RuntimeException {
+    public CofreException(String message) { super(message); }
+    public CofreException(String message, Throwable cause) { super(message, cause); }
+}

--- a/src/main/java/exception/IngredienteFornecedorException.java
+++ b/src/main/java/exception/IngredienteFornecedorException.java
@@ -1,0 +1,6 @@
+package exception;
+
+public class IngredienteFornecedorException extends RuntimeException {
+    public IngredienteFornecedorException(String msg) { super(msg); }
+    public IngredienteFornecedorException(String msg, Throwable t) { super(msg, t); }
+}

--- a/src/main/java/exception/MetaException.java
+++ b/src/main/java/exception/MetaException.java
@@ -1,0 +1,6 @@
+package exception;
+
+public class MetaException extends RuntimeException {
+    public MetaException(String message) { super(message); }
+    public MetaException(String message, Throwable cause) { super(message, cause); }
+}

--- a/src/main/java/exception/MonitoramentoObjetoException.java
+++ b/src/main/java/exception/MonitoramentoObjetoException.java
@@ -1,0 +1,6 @@
+package exception;
+
+public class MonitoramentoObjetoException extends RuntimeException {
+    public MonitoramentoObjetoException(String msg) { super(msg); }
+    public MonitoramentoObjetoException(String msg, Throwable t) { super(msg, t); }
+}

--- a/src/main/java/exception/OperacaoException.java
+++ b/src/main/java/exception/OperacaoException.java
@@ -1,0 +1,6 @@
+package exception;
+
+public class OperacaoException extends RuntimeException {
+    public OperacaoException(String msg) { super(msg); }
+    public OperacaoException(String msg, Throwable t) { super(msg, t); }
+}

--- a/src/main/java/exception/PapelException.java
+++ b/src/main/java/exception/PapelException.java
@@ -1,0 +1,6 @@
+package exception;
+
+public class PapelException extends RuntimeException {
+    public PapelException(String msg) { super(msg); }
+    public PapelException(String msg, Throwable t) { super(msg, t); }
+}

--- a/src/main/java/exception/RotinaPeriodoException.java
+++ b/src/main/java/exception/RotinaPeriodoException.java
@@ -1,0 +1,6 @@
+package exception;
+
+public class RotinaPeriodoException extends RuntimeException {
+    public RotinaPeriodoException(String msg) { super(msg); }
+    public RotinaPeriodoException(String msg, Throwable t) { super(msg, t); }
+}

--- a/src/main/java/exception/SiteObjetoException.java
+++ b/src/main/java/exception/SiteObjetoException.java
@@ -1,0 +1,6 @@
+package exception;
+
+public class SiteObjetoException extends RuntimeException {
+    public SiteObjetoException(String msg) { super(msg); }
+    public SiteObjetoException(String msg, Throwable t) { super(msg, t); }
+}

--- a/src/main/java/exception/TreinoExercicioException.java
+++ b/src/main/java/exception/TreinoExercicioException.java
@@ -1,0 +1,6 @@
+package exception;
+
+public class TreinoExercicioException extends RuntimeException {
+    public TreinoExercicioException(String msg) { super(msg); }
+    public TreinoExercicioException(String msg, Throwable t) { super(msg, t); }
+}

--- a/src/main/java/infra/EntityManagerUtil.java
+++ b/src/main/java/infra/EntityManagerUtil.java
@@ -1,0 +1,17 @@
+// path: src/main/java/infra/EntityManagerUtil.java
+package infra;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.Persistence;
+
+public class EntityManagerUtil {
+    private static final EntityManagerFactory emf = Persistence.createEntityManagerFactory("rotinamaisPU");
+
+    private EntityManagerUtil() {
+    }
+
+    public static EntityManager getEntityManager() {
+        return emf.createEntityManager();
+    }
+}

--- a/src/main/java/infra/Logger.java
+++ b/src/main/java/infra/Logger.java
@@ -1,0 +1,15 @@
+// path: src/main/java/infra/Logger.java
+package infra;
+
+public class Logger {
+    public static void info(String msg) {
+        System.out.println("INFO: " + msg);
+    }
+
+    public static void error(String msg, Throwable t) {
+        System.err.println("ERROR: " + msg);
+        if (t != null) {
+            t.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/model/AlimentacaoIngrediente.java
+++ b/src/main/java/model/AlimentacaoIngrediente.java
@@ -1,0 +1,59 @@
+package model;
+
+import jakarta.persistence.*;
+import java.util.Objects;
+
+@Entity
+@Table(name = "Alimentacao_Ingrediente")
+public class AlimentacaoIngrediente {
+    @Id
+    @Column(name = "id_alimentacao_ingrediente")
+    private Integer idAlimentacaoIngrediente;
+
+    
+    @Column(name = "quantidade")
+    private Integer quantidade;
+
+    
+    @Column(name = "id_alimentacao")
+    private Integer idAlimentacao;
+
+    
+    @Column(name = "id_ingrediente")
+    private Integer idIngrediente;
+
+    public Integer getIdAlimentacaoIngrediente() { return idAlimentacaoIngrediente; }
+    public void setIdAlimentacaoIngrediente(Integer idAlimentacaoIngrediente) { this.idAlimentacaoIngrediente = idAlimentacaoIngrediente; }
+
+    public Integer getQuantidade() { return quantidade; }
+    public void setQuantidade(Integer quantidade) { this.quantidade = quantidade; }
+
+    public Integer getIdAlimentacao() { return idAlimentacao; }
+    public void setIdAlimentacao(Integer idAlimentacao) { this.idAlimentacao = idAlimentacao; }
+
+    public Integer getIdIngrediente() { return idIngrediente; }
+    public void setIdIngrediente(Integer idIngrediente) { this.idIngrediente = idIngrediente; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AlimentacaoIngrediente that = (AlimentacaoIngrediente) o;
+        return Objects.equals(idAlimentacaoIngrediente, that.idAlimentacaoIngrediente);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idAlimentacaoIngrediente);
+    }
+
+    @Override
+    public String toString() {
+        return "AlimentacaoIngrediente{" +
+                "idAlimentacaoIngrediente=" + idAlimentacaoIngrediente +
+                ", quantidade=" + quantidade +
+                ", idAlimentacao=" + idAlimentacao +
+                ", idIngrediente=" + idIngrediente
+                '}';
+    }
+}

--- a/src/main/java/model/Carteira.java
+++ b/src/main/java/model/Carteira.java
@@ -1,0 +1,68 @@
+package model;
+
+import jakarta.persistence.*;
+import java.time.LocalDate;
+import java.util.Objects;
+
+@Entity
+@Table(name = "Carteira")
+public class Carteira {
+    @Id
+    @Column(name = "id_carteira")
+    private Integer idCarteira;
+
+    
+    @Column(name = "nome")
+    private String nome;
+
+    
+    @Column(name = "tipo")
+    private String tipo;
+
+    
+    @Column(name = "dataInicio")
+    private LocalDate dataInicio;
+
+    
+    @Column(name = "id_usuario")
+    private Integer idUsuario;
+
+    public Integer getIdCarteira() { return idCarteira; }
+    public void setIdCarteira(Integer idCarteira) { this.idCarteira = idCarteira; }
+
+    public String getNome() { return nome; }
+    public void setNome(String nome) { this.nome = nome; }
+
+    public String getTipo() { return tipo; }
+    public void setTipo(String tipo) { this.tipo = tipo; }
+
+    public LocalDate getDataInicio() { return dataInicio; }
+    public void setDataInicio(LocalDate dataInicio) { this.dataInicio = dataInicio; }
+
+    public Integer getIdUsuario() { return idUsuario; }
+    public void setIdUsuario(Integer idUsuario) { this.idUsuario = idUsuario; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Carteira that = (Carteira) o;
+        return Objects.equals(idCarteira, that.idCarteira);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idCarteira);
+    }
+
+    @Override
+    public String toString() {
+        return "Carteira{" +
+                "idCarteira=" + idCarteira +
+                ", nome=" + nome +
+                ", tipo=" + tipo +
+                ", dataInicio=" + dataInicio +
+                ", idUsuario=" + idUsuario
+                '}';
+    }
+}

--- a/src/main/java/model/Cofre.java
+++ b/src/main/java/model/Cofre.java
@@ -1,0 +1,65 @@
+package model;
+
+import jakarta.persistence.*;
+import java.util.Objects;
+
+@Entity
+@Table(name = "Cofre")
+public class Cofre {
+    @Id
+    @Column(name = "id_cofre")
+    private Integer idCofre;
+
+    @Column(name = "login")
+    private String login;
+
+    @Column(name = "senha")
+    private String senha;
+
+    @Column(name = "tipo")
+    private Integer tipo;
+
+    @Column(name = "plataforma")
+    private String plataforma;
+
+    @Column(name = "id_usuario")
+    private Integer idUsuario;
+
+    // getters and setters
+    public Integer getIdCofre() { return idCofre; }
+    public void setIdCofre(Integer idCofre) { this.idCofre = idCofre; }
+    public String getLogin() { return login; }
+    public void setLogin(String login) { this.login = login; }
+    public String getSenha() { return senha; }
+    public void setSenha(String senha) { this.senha = senha; }
+    public Integer getTipo() { return tipo; }
+    public void setTipo(Integer tipo) { this.tipo = tipo; }
+    public String getPlataforma() { return plataforma; }
+    public void setPlataforma(String plataforma) { this.plataforma = plataforma; }
+    public Integer getIdUsuario() { return idUsuario; }
+    public void setIdUsuario(Integer idUsuario) { this.idUsuario = idUsuario; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Cofre cofre = (Cofre) o;
+        return Objects.equals(idCofre, cofre.idCofre);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idCofre);
+    }
+
+    @Override
+    public String toString() {
+        return "Cofre{" +
+                "idCofre=" + idCofre +
+                ", login='" + login + '\'' +
+                ", tipo=" + tipo +
+                ", plataforma='" + plataforma + '\'' +
+                ", idUsuario=" + idUsuario +
+                '}';
+    }
+}

--- a/src/main/java/model/IngredienteFornecedor.java
+++ b/src/main/java/model/IngredienteFornecedor.java
@@ -1,0 +1,69 @@
+package model;
+
+import jakarta.persistence.*;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Objects;
+
+@Entity
+@Table(name = "Ingrediente_fornecedor")
+public class IngredienteFornecedor {
+    @Id
+    @Column(name = "id_fornecedor_ingrediente")
+    private Integer idFornecedorIngrediente;
+
+    
+    @Column(name = "valor")
+    private BigDecimal valor;
+
+    
+    @Column(name = "data")
+    private LocalDate data;
+
+    
+    @Column(name = "id_fornecedor")
+    private Integer idFornecedor;
+
+    
+    @Column(name = "id_ingrediente")
+    private Integer idIngrediente;
+
+    public Integer getIdFornecedorIngrediente() { return idFornecedorIngrediente; }
+    public void setIdFornecedorIngrediente(Integer idFornecedorIngrediente) { this.idFornecedorIngrediente = idFornecedorIngrediente; }
+
+    public BigDecimal getValor() { return valor; }
+    public void setValor(BigDecimal valor) { this.valor = valor; }
+
+    public LocalDate getData() { return data; }
+    public void setData(LocalDate data) { this.data = data; }
+
+    public Integer getIdFornecedor() { return idFornecedor; }
+    public void setIdFornecedor(Integer idFornecedor) { this.idFornecedor = idFornecedor; }
+
+    public Integer getIdIngrediente() { return idIngrediente; }
+    public void setIdIngrediente(Integer idIngrediente) { this.idIngrediente = idIngrediente; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        IngredienteFornecedor that = (IngredienteFornecedor) o;
+        return Objects.equals(idFornecedorIngrediente, that.idFornecedorIngrediente);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idFornecedorIngrediente);
+    }
+
+    @Override
+    public String toString() {
+        return "IngredienteFornecedor{" +
+                "idFornecedorIngrediente=" + idFornecedorIngrediente +
+                ", valor=" + valor +
+                ", data=" + data +
+                ", idFornecedor=" + idFornecedor +
+                ", idIngrediente=" + idIngrediente
+                '}';
+    }
+}

--- a/src/main/java/model/Meta.java
+++ b/src/main/java/model/Meta.java
@@ -1,0 +1,73 @@
+package model;
+
+import jakarta.persistence.*;
+import java.time.LocalDate;
+import java.util.Objects;
+
+@Entity
+@Table(name = "Meta")
+public class Meta {
+    @Id
+    @Column(name = "id_meta")
+    private Integer idMeta;
+
+    @Column(name = "ponto_minimo")
+    private Integer pontoMinimo;
+
+    @Column(name = "ponto_medio")
+    private Integer pontoMedio;
+
+    @Column(name = "ponto_maximo")
+    private Integer pontoMaximo;
+
+    @Column(name = "status")
+    private Integer status;
+
+    @Lob
+    @Column(name = "foto")
+    private byte[] foto;
+
+    @Column(name = "id_periodo")
+    private Integer idPeriodo;
+
+    // getters and setters
+    public Integer getIdMeta() { return idMeta; }
+    public void setIdMeta(Integer idMeta) { this.idMeta = idMeta; }
+    public Integer getPontoMinimo() { return pontoMinimo; }
+    public void setPontoMinimo(Integer pontoMinimo) { this.pontoMinimo = pontoMinimo; }
+    public Integer getPontoMedio() { return pontoMedio; }
+    public void setPontoMedio(Integer pontoMedio) { this.pontoMedio = pontoMedio; }
+    public Integer getPontoMaximo() { return pontoMaximo; }
+    public void setPontoMaximo(Integer pontoMaximo) { this.pontoMaximo = pontoMaximo; }
+    public Integer getStatus() { return status; }
+    public void setStatus(Integer status) { this.status = status; }
+    public byte[] getFoto() { return foto; }
+    public void setFoto(byte[] foto) { this.foto = foto; }
+    public Integer getIdPeriodo() { return idPeriodo; }
+    public void setIdPeriodo(Integer idPeriodo) { this.idPeriodo = idPeriodo; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Meta meta = (Meta) o;
+        return Objects.equals(idMeta, meta.idMeta);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idMeta);
+    }
+
+    @Override
+    public String toString() {
+        return "Meta{" +
+                "idMeta=" + idMeta +
+                ", pontoMinimo=" + pontoMinimo +
+                ", pontoMedio=" + pontoMedio +
+                ", pontoMaximo=" + pontoMaximo +
+                ", status=" + status +
+                ", idPeriodo=" + idPeriodo +
+                '}';
+    }
+}

--- a/src/main/java/model/MonitoramentoObjeto.java
+++ b/src/main/java/model/MonitoramentoObjeto.java
@@ -1,0 +1,60 @@
+package model;
+
+import jakarta.persistence.*;
+import java.time.LocalDate;
+import java.util.Objects;
+
+@Entity
+@Table(name = "Monitoramento_Objeto")
+public class MonitoramentoObjeto {
+    @Id
+    @Column(name = "id_monitoramento_objeto")
+    private LocalDate idMonitoramentoObjeto;
+
+    
+    @Column(name = "data")
+    private LocalDate data;
+
+    
+    @Column(name = "id_monitoramento")
+    private Integer idMonitoramento;
+
+    
+    @Column(name = "id_objeto")
+    private Integer idObjeto;
+
+    public LocalDate getIdMonitoramentoObjeto() { return idMonitoramentoObjeto; }
+    public void setIdMonitoramentoObjeto(LocalDate idMonitoramentoObjeto) { this.idMonitoramentoObjeto = idMonitoramentoObjeto; }
+
+    public LocalDate getData() { return data; }
+    public void setData(LocalDate data) { this.data = data; }
+
+    public Integer getIdMonitoramento() { return idMonitoramento; }
+    public void setIdMonitoramento(Integer idMonitoramento) { this.idMonitoramento = idMonitoramento; }
+
+    public Integer getIdObjeto() { return idObjeto; }
+    public void setIdObjeto(Integer idObjeto) { this.idObjeto = idObjeto; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MonitoramentoObjeto that = (MonitoramentoObjeto) o;
+        return Objects.equals(idMonitoramentoObjeto, that.idMonitoramentoObjeto);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idMonitoramentoObjeto);
+    }
+
+    @Override
+    public String toString() {
+        return "MonitoramentoObjeto{" +
+                "idMonitoramentoObjeto=" + idMonitoramentoObjeto +
+                ", data=" + data +
+                ", idMonitoramento=" + idMonitoramento +
+                ", idObjeto=" + idObjeto
+                '}';
+    }
+}

--- a/src/main/java/model/Operacao.java
+++ b/src/main/java/model/Operacao.java
@@ -1,0 +1,189 @@
+package model;
+
+import jakarta.persistence.*;
+import java.math.BigDecimal;
+import java.time.LocalTime;
+import java.util.Objects;
+
+@Entity
+@Table(name = "Operacao")
+public class Operacao {
+    @Id
+    @Column(name = "id_operacao")
+    private Integer idOperacao;
+
+    
+    @Column(name = "fechamento")
+    private BigDecimal fechamento;
+
+    
+    @Column(name = "tempo_operacao")
+    private LocalTime tempoOperacao;
+
+    
+    @Column(name = "qtd_compra")
+    private Integer qtdCompra;
+
+    
+    @Column(name = "abertura")
+    private BigDecimal abertura;
+
+    
+    @Column(name = "qtd_venda")
+    private Integer qtdVenda;
+
+    
+    @Column(name = "lado")
+    private String lado;
+
+    
+    @Column(name = "preco_compra")
+    private BigDecimal precoCompra;
+
+    
+    @Column(name = "preco_venda")
+    private BigDecimal precoVenda;
+
+    
+    @Column(name = "preco_medio")
+    private BigDecimal precoMedio;
+
+    
+    @Column(name = "res_intervalo")
+    private String resIntervalo;
+
+    
+    @Column(name = "numero_operacao")
+    private BigDecimal numeroOperacao;
+
+    
+    @Column(name = "res_operacao")
+    private String resOperacao;
+
+    
+    @Column(name = "drawdon")
+    private BigDecimal drawdon;
+
+    
+    @Column(name = "ganhoMax")
+    private BigDecimal ganhoMax;
+
+    
+    @Column(name = "perdaMax")
+    private BigDecimal perdaMax;
+
+    
+    @Column(name = "tet")
+    private String tet;
+
+    
+    @Column(name = "total")
+    private BigDecimal total;
+
+    
+    @Column(name = "id_carteira")
+    private Integer idCarteira;
+
+    
+    @Column(name = "id_papel")
+    private Integer idPapel;
+
+    public Integer getIdOperacao() { return idOperacao; }
+    public void setIdOperacao(Integer idOperacao) { this.idOperacao = idOperacao; }
+
+    public BigDecimal getFechamento() { return fechamento; }
+    public void setFechamento(BigDecimal fechamento) { this.fechamento = fechamento; }
+
+    public LocalTime getTempoOperacao() { return tempoOperacao; }
+    public void setTempoOperacao(LocalTime tempoOperacao) { this.tempoOperacao = tempoOperacao; }
+
+    public Integer getQtdCompra() { return qtdCompra; }
+    public void setQtdCompra(Integer qtdCompra) { this.qtdCompra = qtdCompra; }
+
+    public BigDecimal getAbertura() { return abertura; }
+    public void setAbertura(BigDecimal abertura) { this.abertura = abertura; }
+
+    public Integer getQtdVenda() { return qtdVenda; }
+    public void setQtdVenda(Integer qtdVenda) { this.qtdVenda = qtdVenda; }
+
+    public String getLado() { return lado; }
+    public void setLado(String lado) { this.lado = lado; }
+
+    public BigDecimal getPrecoCompra() { return precoCompra; }
+    public void setPrecoCompra(BigDecimal precoCompra) { this.precoCompra = precoCompra; }
+
+    public BigDecimal getPrecoVenda() { return precoVenda; }
+    public void setPrecoVenda(BigDecimal precoVenda) { this.precoVenda = precoVenda; }
+
+    public BigDecimal getPrecoMedio() { return precoMedio; }
+    public void setPrecoMedio(BigDecimal precoMedio) { this.precoMedio = precoMedio; }
+
+    public String getResIntervalo() { return resIntervalo; }
+    public void setResIntervalo(String resIntervalo) { this.resIntervalo = resIntervalo; }
+
+    public BigDecimal getNumeroOperacao() { return numeroOperacao; }
+    public void setNumeroOperacao(BigDecimal numeroOperacao) { this.numeroOperacao = numeroOperacao; }
+
+    public String getResOperacao() { return resOperacao; }
+    public void setResOperacao(String resOperacao) { this.resOperacao = resOperacao; }
+
+    public BigDecimal getDrawdon() { return drawdon; }
+    public void setDrawdon(BigDecimal drawdon) { this.drawdon = drawdon; }
+
+    public BigDecimal getGanhoMax() { return ganhoMax; }
+    public void setGanhoMax(BigDecimal ganhoMax) { this.ganhoMax = ganhoMax; }
+
+    public BigDecimal getPerdaMax() { return perdaMax; }
+    public void setPerdaMax(BigDecimal perdaMax) { this.perdaMax = perdaMax; }
+
+    public String getTet() { return tet; }
+    public void setTet(String tet) { this.tet = tet; }
+
+    public BigDecimal getTotal() { return total; }
+    public void setTotal(BigDecimal total) { this.total = total; }
+
+    public Integer getIdCarteira() { return idCarteira; }
+    public void setIdCarteira(Integer idCarteira) { this.idCarteira = idCarteira; }
+
+    public Integer getIdPapel() { return idPapel; }
+    public void setIdPapel(Integer idPapel) { this.idPapel = idPapel; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Operacao that = (Operacao) o;
+        return Objects.equals(idOperacao, that.idOperacao);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idOperacao);
+    }
+
+    @Override
+    public String toString() {
+        return "Operacao{" +
+                "idOperacao=" + idOperacao +
+                ", fechamento=" + fechamento +
+                ", tempoOperacao=" + tempoOperacao +
+                ", qtdCompra=" + qtdCompra +
+                ", abertura=" + abertura +
+                ", qtdVenda=" + qtdVenda +
+                ", lado=" + lado +
+                ", precoCompra=" + precoCompra +
+                ", precoVenda=" + precoVenda +
+                ", precoMedio=" + precoMedio +
+                ", resIntervalo=" + resIntervalo +
+                ", numeroOperacao=" + numeroOperacao +
+                ", resOperacao=" + resOperacao +
+                ", drawdon=" + drawdon +
+                ", ganhoMax=" + ganhoMax +
+                ", perdaMax=" + perdaMax +
+                ", tet=" + tet +
+                ", total=" + total +
+                ", idCarteira=" + idCarteira +
+                ", idPapel=" + idPapel
+                '}';
+    }
+}

--- a/src/main/java/model/Papel.java
+++ b/src/main/java/model/Papel.java
@@ -1,0 +1,60 @@
+package model;
+
+import jakarta.persistence.*;
+import java.time.LocalDate;
+import java.util.Objects;
+
+@Entity
+@Table(name = "Papel")
+public class Papel {
+    @Id
+    @Column(name = "id_papel")
+    private Integer idPapel;
+
+    
+    @Column(name = "codigo")
+    private String codigo;
+
+    
+    @Column(name = "tipo")
+    private String tipo;
+
+    
+    @Column(name = "vencimento")
+    private LocalDate vencimento;
+
+    public Integer getIdPapel() { return idPapel; }
+    public void setIdPapel(Integer idPapel) { this.idPapel = idPapel; }
+
+    public String getCodigo() { return codigo; }
+    public void setCodigo(String codigo) { this.codigo = codigo; }
+
+    public String getTipo() { return tipo; }
+    public void setTipo(String tipo) { this.tipo = tipo; }
+
+    public LocalDate getVencimento() { return vencimento; }
+    public void setVencimento(LocalDate vencimento) { this.vencimento = vencimento; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Papel that = (Papel) o;
+        return Objects.equals(idPapel, that.idPapel);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idPapel);
+    }
+
+    @Override
+    public String toString() {
+        return "Papel{" +
+                "idPapel=" + idPapel +
+                ", codigo=" + codigo +
+                ", tipo=" + tipo +
+                ", vencimento=" + vencimento
+                '}';
+    }
+}

--- a/src/main/java/model/RotinaPeriodo.java
+++ b/src/main/java/model/RotinaPeriodo.java
@@ -1,0 +1,51 @@
+package model;
+
+import jakarta.persistence.*;
+import java.util.Objects;
+
+@Entity
+@Table(name = "Rotina_Periodo")
+public class RotinaPeriodo {
+    @Id
+    @Column(name = "id_rotina_periodo")
+    private Integer idRotinaPeriodo;
+
+    
+    @Column(name = "id_rotina")
+    private Integer idRotina;
+
+    
+    @Column(name = "id_periodo")
+    private Integer idPeriodo;
+
+    public Integer getIdRotinaPeriodo() { return idRotinaPeriodo; }
+    public void setIdRotinaPeriodo(Integer idRotinaPeriodo) { this.idRotinaPeriodo = idRotinaPeriodo; }
+
+    public Integer getIdRotina() { return idRotina; }
+    public void setIdRotina(Integer idRotina) { this.idRotina = idRotina; }
+
+    public Integer getIdPeriodo() { return idPeriodo; }
+    public void setIdPeriodo(Integer idPeriodo) { this.idPeriodo = idPeriodo; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RotinaPeriodo that = (RotinaPeriodo) o;
+        return Objects.equals(idRotinaPeriodo, that.idRotinaPeriodo);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idRotinaPeriodo);
+    }
+
+    @Override
+    public String toString() {
+        return "RotinaPeriodo{" +
+                "idRotinaPeriodo=" + idRotinaPeriodo +
+                ", idRotina=" + idRotina +
+                ", idPeriodo=" + idPeriodo
+                '}';
+    }
+}

--- a/src/main/java/model/SiteObjeto.java
+++ b/src/main/java/model/SiteObjeto.java
@@ -1,0 +1,51 @@
+package model;
+
+import jakarta.persistence.*;
+import java.util.Objects;
+
+@Entity
+@Table(name = "Site_Objeto")
+public class SiteObjeto {
+    @Id
+    @Column(name = "id_site_objeto")
+    private Integer idSiteObjeto;
+
+    
+    @Column(name = "id_site")
+    private Integer idSite;
+
+    
+    @Column(name = "id_objeto")
+    private Integer idObjeto;
+
+    public Integer getIdSiteObjeto() { return idSiteObjeto; }
+    public void setIdSiteObjeto(Integer idSiteObjeto) { this.idSiteObjeto = idSiteObjeto; }
+
+    public Integer getIdSite() { return idSite; }
+    public void setIdSite(Integer idSite) { this.idSite = idSite; }
+
+    public Integer getIdObjeto() { return idObjeto; }
+    public void setIdObjeto(Integer idObjeto) { this.idObjeto = idObjeto; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SiteObjeto that = (SiteObjeto) o;
+        return Objects.equals(idSiteObjeto, that.idSiteObjeto);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idSiteObjeto);
+    }
+
+    @Override
+    public String toString() {
+        return "SiteObjeto{" +
+                "idSiteObjeto=" + idSiteObjeto +
+                ", idSite=" + idSite +
+                ", idObjeto=" + idObjeto
+                '}';
+    }
+}

--- a/src/main/java/model/TreinoExercicio.java
+++ b/src/main/java/model/TreinoExercicio.java
@@ -1,0 +1,83 @@
+package model;
+
+import jakarta.persistence.*;
+import java.util.Objects;
+
+@Entity
+@Table(name = "Treino_Exercicio")
+public class TreinoExercicio {
+    @Id
+    @Column(name = "id_treino_exercicio")
+    private Integer idTreinoExercicio;
+
+    
+    @Column(name = "qtd_repeticao")
+    private Integer qtdRepeticao;
+
+    
+    @Column(name = "tempo_descanso")
+    private String tempoDescanso;
+
+    
+    @Column(name = "ordem")
+    private Integer ordem;
+
+    
+    @Column(name = "feito")
+    private Boolean feito;
+
+    
+    @Column(name = "id_exercicio")
+    private Integer idExercicio;
+
+    
+    @Column(name = "id_treino")
+    private Integer idTreino;
+
+    public Integer getIdTreinoExercicio() { return idTreinoExercicio; }
+    public void setIdTreinoExercicio(Integer idTreinoExercicio) { this.idTreinoExercicio = idTreinoExercicio; }
+
+    public Integer getQtdRepeticao() { return qtdRepeticao; }
+    public void setQtdRepeticao(Integer qtdRepeticao) { this.qtdRepeticao = qtdRepeticao; }
+
+    public String getTempoDescanso() { return tempoDescanso; }
+    public void setTempoDescanso(String tempoDescanso) { this.tempoDescanso = tempoDescanso; }
+
+    public Integer getOrdem() { return ordem; }
+    public void setOrdem(Integer ordem) { this.ordem = ordem; }
+
+    public Boolean getFeito() { return feito; }
+    public void setFeito(Boolean feito) { this.feito = feito; }
+
+    public Integer getIdExercicio() { return idExercicio; }
+    public void setIdExercicio(Integer idExercicio) { this.idExercicio = idExercicio; }
+
+    public Integer getIdTreino() { return idTreino; }
+    public void setIdTreino(Integer idTreino) { this.idTreino = idTreino; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TreinoExercicio that = (TreinoExercicio) o;
+        return Objects.equals(idTreinoExercicio, that.idTreinoExercicio);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idTreinoExercicio);
+    }
+
+    @Override
+    public String toString() {
+        return "TreinoExercicio{" +
+                "idTreinoExercicio=" + idTreinoExercicio +
+                ", qtdRepeticao=" + qtdRepeticao +
+                ", tempoDescanso=" + tempoDescanso +
+                ", ordem=" + ordem +
+                ", feito=" + feito +
+                ", idExercicio=" + idExercicio +
+                ", idTreino=" + idTreino
+                '}';
+    }
+}

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,14 @@
+<!-- path: src/main/resources/META-INF/persistence.xml -->
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence" version="3.0">
+    <persistence-unit name="rotinamaisPU">
+        <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+        <properties>
+            <property name="jakarta.persistence.jdbc.driver" value="org.postgresql.Driver"/>
+            <property name="jakarta.persistence.jdbc.url" value="jdbc:postgresql://localhost:5432/rotinamais"/>
+            <property name="jakarta.persistence.jdbc.user" value="postgres"/>
+            <property name="jakarta.persistence.jdbc.password" value="postgres"/>
+            <property name="hibernate.dialect" value="org.hibernate.dialect.PostgreSQLDialect"/>
+            <property name="hibernate.hbm2ddl.auto" value="none"/>
+        </properties>
+    </persistence-unit>
+</persistence>


### PR DESCRIPTION
## Summary
- add JPA models, native DAO layers and controllers for TreinoExercicio, RotinaPeriodo, AlimentacaoIngrediente, IngredienteFornecedor, SiteObjeto, MonitoramentoObjeto, Papel, Carteira and Operacao
- document new examples in README

## Testing
- `mvn -q -DskipTests package` *(fails: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf64cd49288325890fe7732235f5da