### PR TITLE
Fix syntax in DAO implementations and controllers

### DIFF
--- a/src/main/java/controller/AlimentacaoIngredienteController.java
+++ b/src/main/java/controller/AlimentacaoIngredienteController.java
@@ -8,7 +8,7 @@ import infra.Logger;
 import model.AlimentacaoIngrediente;
 
 public class AlimentacaoIngredienteController {
-    private final {dao} dao;
+    private final AlimentacaoIngredienteDao dao;
 
     public AlimentacaoIngredienteController(AlimentacaoIngredienteDao dao) { this.dao = dao; }
 

--- a/src/main/java/controller/CarteiraController.java
+++ b/src/main/java/controller/CarteiraController.java
@@ -5,10 +5,11 @@ import exception.CarteiraException;
 import infra.Logger;
 import model.Carteira;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public class CarteiraController {
-    private final {dao} dao;
+    private final CarteiraDao dao;
 
     public CarteiraController(CarteiraDao dao) { this.dao = dao; }
 

--- a/src/main/java/controller/IngredienteFornecedorController.java
+++ b/src/main/java/controller/IngredienteFornecedorController.java
@@ -5,10 +5,12 @@ import exception.IngredienteFornecedorException;
 import infra.Logger;
 import model.IngredienteFornecedor;
 
+import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.List;
 
 public class IngredienteFornecedorController {
-    private final {dao} dao;
+    private final IngredienteFornecedorDao dao;
 
     public IngredienteFornecedorController(IngredienteFornecedorDao dao) { this.dao = dao; }
 

--- a/src/main/java/controller/MonitoramentoObjetoController.java
+++ b/src/main/java/controller/MonitoramentoObjetoController.java
@@ -5,10 +5,11 @@ import exception.MonitoramentoObjetoException;
 import infra.Logger;
 import model.MonitoramentoObjeto;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public class MonitoramentoObjetoController {
-    private final {dao} dao;
+    private final MonitoramentoObjetoDao dao;
 
     public MonitoramentoObjetoController(MonitoramentoObjetoDao dao) { this.dao = dao; }
 

--- a/src/main/java/controller/OperacaoController.java
+++ b/src/main/java/controller/OperacaoController.java
@@ -5,10 +5,12 @@ import exception.OperacaoException;
 import infra.Logger;
 import model.Operacao;
 
+import java.math.BigDecimal;
+import java.time.LocalTime;
 import java.util.List;
 
 public class OperacaoController {
-    private final {dao} dao;
+    private final OperacaoDao dao;
 
     public OperacaoController(OperacaoDao dao) { this.dao = dao; }
 

--- a/src/main/java/controller/PapelController.java
+++ b/src/main/java/controller/PapelController.java
@@ -5,10 +5,11 @@ import exception.PapelException;
 import infra.Logger;
 import model.Papel;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public class PapelController {
-    private final {dao} dao;
+    private final PapelDao dao;
 
     public PapelController(PapelDao dao) { this.dao = dao; }
 

--- a/src/main/java/controller/RotinaPeriodoController.java
+++ b/src/main/java/controller/RotinaPeriodoController.java
@@ -8,7 +8,7 @@ import model.RotinaPeriodo;
 import java.util.List;
 
 public class RotinaPeriodoController {
-    private final {dao} dao;
+    private final RotinaPeriodoDao dao;
 
     public RotinaPeriodoController(RotinaPeriodoDao dao) { this.dao = dao; }
 

--- a/src/main/java/controller/SiteObjetoController.java
+++ b/src/main/java/controller/SiteObjetoController.java
@@ -8,7 +8,7 @@ import model.SiteObjeto;
 import java.util.List;
 
 public class SiteObjetoController {
-    private final {dao} dao;
+    private final SiteObjetoDao dao;
 
     public SiteObjetoController(SiteObjetoDao dao) { this.dao = dao; }
 

--- a/src/main/java/controller/TreinoExercicioController.java
+++ b/src/main/java/controller/TreinoExercicioController.java
@@ -8,7 +8,7 @@ import model.TreinoExercicio;
 import java.util.List;
 
 public class TreinoExercicioController {
-    private final {dao} dao;
+    private final TreinoExercicioDao dao;
 
     public TreinoExercicioController(TreinoExercicioDao dao) { this.dao = dao; }
 

--- a/src/main/java/dao/impl/AlimentacaoIngredienteDaoNativeImpl.java
+++ b/src/main/java/dao/impl/AlimentacaoIngredienteDaoNativeImpl.java
@@ -41,21 +41,24 @@ public class AlimentacaoIngredienteDaoNativeImpl implements AlimentacaoIngredien
 
     @Override
     public AlimentacaoIngrediente findById(Integer id) {
-        String sql = "SELECT {select_cols} FROM {table} WHERE {e['fields'][0][2]} = :id";
-        Query q = em.createNativeQuery(sql, {cname}.class).setParameter("id", id);
-        return ({cname}) q.getSingleResult();
+        String sql = "SELECT id_alimentacao_ingrediente, quantidade, id_alimentacao, id_ingrediente FROM Alimentacao_Ingrediente WHERE id_alimentacao_ingrediente = :id";
+        Query q = em.createNativeQuery(sql, AlimentacaoIngrediente.class).setParameter("id", id);
+        return (AlimentacaoIngrediente) q.getSingleResult();
     }
 
     @Override
     public List<AlimentacaoIngrediente> findAll() {
-        String sql = "SELECT {select_cols} FROM {table}";
-        return em.createNativeQuery(sql, {cname}.class).getResultList();
+        String sql = "SELECT id_alimentacao_ingrediente, quantidade, id_alimentacao, id_ingrediente FROM Alimentacao_Ingrediente";
+        return em.createNativeQuery(sql, AlimentacaoIngrediente.class).getResultList();
     }
 
     @Override
     public List<AlimentacaoIngrediente> findAll(int page, int size) {
-        String sql = "SELECT {select_cols} FROM {table} LIMIT :size OFFSET :off";
-        return em.createNativeQuery(sql, {cname}.class).setParameter("size", size).setParameter("off", page * size).getResultList();
+        String sql = "SELECT id_alimentacao_ingrediente, quantidade, id_alimentacao, id_ingrediente FROM Alimentacao_Ingrediente LIMIT :size OFFSET :off";
+        return em.createNativeQuery(sql, AlimentacaoIngrediente.class)
+                .setParameter("size", size)
+                .setParameter("off", page * size)
+                .getResultList();
     }
 
     @Override

--- a/src/main/java/dao/impl/CarteiraDaoNativeImpl.java
+++ b/src/main/java/dao/impl/CarteiraDaoNativeImpl.java
@@ -8,6 +8,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
 import model.Carteira;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public class CarteiraDaoNativeImpl implements CarteiraDao {
@@ -41,21 +42,24 @@ public class CarteiraDaoNativeImpl implements CarteiraDao {
 
     @Override
     public Carteira findById(Integer id) {
-        String sql = "SELECT {select_cols} FROM {table} WHERE {e['fields'][0][2]} = :id";
-        Query q = em.createNativeQuery(sql, {cname}.class).setParameter("id", id);
-        return ({cname}) q.getSingleResult();
+        String sql = "SELECT id_carteira, nome, tipo, dataInicio, id_usuario FROM Carteira WHERE id_carteira = :id";
+        Query q = em.createNativeQuery(sql, Carteira.class).setParameter("id", id);
+        return (Carteira) q.getSingleResult();
     }
 
     @Override
     public List<Carteira> findAll() {
-        String sql = "SELECT {select_cols} FROM {table}";
-        return em.createNativeQuery(sql, {cname}.class).getResultList();
+        String sql = "SELECT id_carteira, nome, tipo, dataInicio, id_usuario FROM Carteira";
+        return em.createNativeQuery(sql, Carteira.class).getResultList();
     }
 
     @Override
     public List<Carteira> findAll(int page, int size) {
-        String sql = "SELECT {select_cols} FROM {table} LIMIT :size OFFSET :off";
-        return em.createNativeQuery(sql, {cname}.class).setParameter("size", size).setParameter("off", page * size).getResultList();
+        String sql = "SELECT id_carteira, nome, tipo, dataInicio, id_usuario FROM Carteira LIMIT :size OFFSET :off";
+        return em.createNativeQuery(sql, Carteira.class)
+                .setParameter("size", size)
+                .setParameter("off", page * size)
+                .getResultList();
     }
 
     @Override

--- a/src/main/java/dao/impl/IngredienteFornecedorDaoNativeImpl.java
+++ b/src/main/java/dao/impl/IngredienteFornecedorDaoNativeImpl.java
@@ -8,6 +8,8 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
 import model.IngredienteFornecedor;
 
+import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.List;
 
 public class IngredienteFornecedorDaoNativeImpl implements IngredienteFornecedorDao {
@@ -41,21 +43,24 @@ public class IngredienteFornecedorDaoNativeImpl implements IngredienteFornecedor
 
     @Override
     public IngredienteFornecedor findById(Integer id) {
-        String sql = "SELECT {select_cols} FROM {table} WHERE {e['fields'][0][2]} = :id";
-        Query q = em.createNativeQuery(sql, {cname}.class).setParameter("id", id);
-        return ({cname}) q.getSingleResult();
+        String sql = "SELECT id_fornecedor_ingrediente, valor, data, id_fornecedor, id_ingrediente FROM Ingrediente_fornecedor WHERE id_fornecedor_ingrediente = :id";
+        Query q = em.createNativeQuery(sql, IngredienteFornecedor.class).setParameter("id", id);
+        return (IngredienteFornecedor) q.getSingleResult();
     }
 
     @Override
     public List<IngredienteFornecedor> findAll() {
-        String sql = "SELECT {select_cols} FROM {table}";
-        return em.createNativeQuery(sql, {cname}.class).getResultList();
+        String sql = "SELECT id_fornecedor_ingrediente, valor, data, id_fornecedor, id_ingrediente FROM Ingrediente_fornecedor";
+        return em.createNativeQuery(sql, IngredienteFornecedor.class).getResultList();
     }
 
     @Override
     public List<IngredienteFornecedor> findAll(int page, int size) {
-        String sql = "SELECT {select_cols} FROM {table} LIMIT :size OFFSET :off";
-        return em.createNativeQuery(sql, {cname}.class).setParameter("size", size).setParameter("off", page * size).getResultList();
+        String sql = "SELECT id_fornecedor_ingrediente, valor, data, id_fornecedor, id_ingrediente FROM Ingrediente_fornecedor LIMIT :size OFFSET :off";
+        return em.createNativeQuery(sql, IngredienteFornecedor.class)
+                .setParameter("size", size)
+                .setParameter("off", page * size)
+                .getResultList();
     }
 
     @Override

--- a/src/main/java/dao/impl/MonitoramentoObjetoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/MonitoramentoObjetoDaoNativeImpl.java
@@ -8,6 +8,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
 import model.MonitoramentoObjeto;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public class MonitoramentoObjetoDaoNativeImpl implements MonitoramentoObjetoDao {
@@ -41,21 +42,24 @@ public class MonitoramentoObjetoDaoNativeImpl implements MonitoramentoObjetoDao 
 
     @Override
     public MonitoramentoObjeto findById(LocalDate id) {
-        String sql = "SELECT {select_cols} FROM {table} WHERE {e['fields'][0][2]} = :id";
-        Query q = em.createNativeQuery(sql, {cname}.class).setParameter("id", id);
-        return ({cname}) q.getSingleResult();
+        String sql = "SELECT id_monitoramento_objeto, data, id_monitoramento, id_objeto FROM Monitoramento_Objeto WHERE id_monitoramento_objeto = :id";
+        Query q = em.createNativeQuery(sql, MonitoramentoObjeto.class).setParameter("id", id);
+        return (MonitoramentoObjeto) q.getSingleResult();
     }
 
     @Override
     public List<MonitoramentoObjeto> findAll() {
-        String sql = "SELECT {select_cols} FROM {table}";
-        return em.createNativeQuery(sql, {cname}.class).getResultList();
+        String sql = "SELECT id_monitoramento_objeto, data, id_monitoramento, id_objeto FROM Monitoramento_Objeto";
+        return em.createNativeQuery(sql, MonitoramentoObjeto.class).getResultList();
     }
 
     @Override
     public List<MonitoramentoObjeto> findAll(int page, int size) {
-        String sql = "SELECT {select_cols} FROM {table} LIMIT :size OFFSET :off";
-        return em.createNativeQuery(sql, {cname}.class).setParameter("size", size).setParameter("off", page * size).getResultList();
+        String sql = "SELECT id_monitoramento_objeto, data, id_monitoramento, id_objeto FROM Monitoramento_Objeto LIMIT :size OFFSET :off";
+        return em.createNativeQuery(sql, MonitoramentoObjeto.class)
+                .setParameter("size", size)
+                .setParameter("off", page * size)
+                .getResultList();
     }
 
     @Override

--- a/src/main/java/dao/impl/OperacaoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/OperacaoDaoNativeImpl.java
@@ -8,6 +8,8 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
 import model.Operacao;
 
+import java.math.BigDecimal;
+import java.time.LocalTime;
 import java.util.List;
 
 public class OperacaoDaoNativeImpl implements OperacaoDao {
@@ -41,21 +43,24 @@ public class OperacaoDaoNativeImpl implements OperacaoDao {
 
     @Override
     public Operacao findById(Integer id) {
-        String sql = "SELECT {select_cols} FROM {table} WHERE {e['fields'][0][2]} = :id";
-        Query q = em.createNativeQuery(sql, {cname}.class).setParameter("id", id);
-        return ({cname}) q.getSingleResult();
+        String sql = "SELECT id_operacao, fechamento, tempo_operacao, qtd_compra, abertura, qtd_venda, lado, preco_compra, preco_venda, preco_medio, res_intervalo, numero_operacao, res_operacao, drawdon, ganhoMax, perdaMax, tet, total, id_carteira, id_papel FROM Operacao WHERE id_operacao = :id";
+        Query q = em.createNativeQuery(sql, Operacao.class).setParameter("id", id);
+        return (Operacao) q.getSingleResult();
     }
 
     @Override
     public List<Operacao> findAll() {
-        String sql = "SELECT {select_cols} FROM {table}";
-        return em.createNativeQuery(sql, {cname}.class).getResultList();
+        String sql = "SELECT id_operacao, fechamento, tempo_operacao, qtd_compra, abertura, qtd_venda, lado, preco_compra, preco_venda, preco_medio, res_intervalo, numero_operacao, res_operacao, drawdon, ganhoMax, perdaMax, tet, total, id_carteira, id_papel FROM Operacao";
+        return em.createNativeQuery(sql, Operacao.class).getResultList();
     }
 
     @Override
     public List<Operacao> findAll(int page, int size) {
-        String sql = "SELECT {select_cols} FROM {table} LIMIT :size OFFSET :off";
-        return em.createNativeQuery(sql, {cname}.class).setParameter("size", size).setParameter("off", page * size).getResultList();
+        String sql = "SELECT id_operacao, fechamento, tempo_operacao, qtd_compra, abertura, qtd_venda, lado, preco_compra, preco_venda, preco_medio, res_intervalo, numero_operacao, res_operacao, drawdon, ganhoMax, perdaMax, tet, total, id_carteira, id_papel FROM Operacao LIMIT :size OFFSET :off";
+        return em.createNativeQuery(sql, Operacao.class)
+                .setParameter("size", size)
+                .setParameter("off", page * size)
+                .getResultList();
     }
 
     @Override

--- a/src/main/java/dao/impl/PapelDaoNativeImpl.java
+++ b/src/main/java/dao/impl/PapelDaoNativeImpl.java
@@ -8,6 +8,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
 import model.Papel;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public class PapelDaoNativeImpl implements PapelDao {
@@ -41,21 +42,24 @@ public class PapelDaoNativeImpl implements PapelDao {
 
     @Override
     public Papel findById(Integer id) {
-        String sql = "SELECT {select_cols} FROM {table} WHERE {e['fields'][0][2]} = :id";
-        Query q = em.createNativeQuery(sql, {cname}.class).setParameter("id", id);
-        return ({cname}) q.getSingleResult();
+        String sql = "SELECT id_papel, codigo, tipo, vencimento FROM Papel WHERE id_papel = :id";
+        Query q = em.createNativeQuery(sql, Papel.class).setParameter("id", id);
+        return (Papel) q.getSingleResult();
     }
 
     @Override
     public List<Papel> findAll() {
-        String sql = "SELECT {select_cols} FROM {table}";
-        return em.createNativeQuery(sql, {cname}.class).getResultList();
+        String sql = "SELECT id_papel, codigo, tipo, vencimento FROM Papel";
+        return em.createNativeQuery(sql, Papel.class).getResultList();
     }
 
     @Override
     public List<Papel> findAll(int page, int size) {
-        String sql = "SELECT {select_cols} FROM {table} LIMIT :size OFFSET :off";
-        return em.createNativeQuery(sql, {cname}.class).setParameter("size", size).setParameter("off", page * size).getResultList();
+        String sql = "SELECT id_papel, codigo, tipo, vencimento FROM Papel LIMIT :size OFFSET :off";
+        return em.createNativeQuery(sql, Papel.class)
+                .setParameter("size", size)
+                .setParameter("off", page * size)
+                .getResultList();
     }
 
     @Override

--- a/src/main/java/dao/impl/RotinaPeriodoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/RotinaPeriodoDaoNativeImpl.java
@@ -41,21 +41,24 @@ public class RotinaPeriodoDaoNativeImpl implements RotinaPeriodoDao {
 
     @Override
     public RotinaPeriodo findById(Integer id) {
-        String sql = "SELECT {select_cols} FROM {table} WHERE {e['fields'][0][2]} = :id";
-        Query q = em.createNativeQuery(sql, {cname}.class).setParameter("id", id);
-        return ({cname}) q.getSingleResult();
+        String sql = "SELECT id_rotina_periodo, id_rotina, id_periodo FROM Rotina_Periodo WHERE id_rotina_periodo = :id";
+        Query q = em.createNativeQuery(sql, RotinaPeriodo.class).setParameter("id", id);
+        return (RotinaPeriodo) q.getSingleResult();
     }
 
     @Override
     public List<RotinaPeriodo> findAll() {
-        String sql = "SELECT {select_cols} FROM {table}";
-        return em.createNativeQuery(sql, {cname}.class).getResultList();
+        String sql = "SELECT id_rotina_periodo, id_rotina, id_periodo FROM Rotina_Periodo";
+        return em.createNativeQuery(sql, RotinaPeriodo.class).getResultList();
     }
 
     @Override
     public List<RotinaPeriodo> findAll(int page, int size) {
-        String sql = "SELECT {select_cols} FROM {table} LIMIT :size OFFSET :off";
-        return em.createNativeQuery(sql, {cname}.class).setParameter("size", size).setParameter("off", page * size).getResultList();
+        String sql = "SELECT id_rotina_periodo, id_rotina, id_periodo FROM Rotina_Periodo LIMIT :size OFFSET :off";
+        return em.createNativeQuery(sql, RotinaPeriodo.class)
+                .setParameter("size", size)
+                .setParameter("off", page * size)
+                .getResultList();
     }
 
     @Override

--- a/src/main/java/dao/impl/SiteObjetoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/SiteObjetoDaoNativeImpl.java
@@ -41,21 +41,24 @@ public class SiteObjetoDaoNativeImpl implements SiteObjetoDao {
 
     @Override
     public SiteObjeto findById(Integer id) {
-        String sql = "SELECT {select_cols} FROM {table} WHERE {e['fields'][0][2]} = :id";
-        Query q = em.createNativeQuery(sql, {cname}.class).setParameter("id", id);
-        return ({cname}) q.getSingleResult();
+        String sql = "SELECT id_site_objeto, id_site, id_objeto FROM Site_Objeto WHERE id_site_objeto = :id";
+        Query q = em.createNativeQuery(sql, SiteObjeto.class).setParameter("id", id);
+        return (SiteObjeto) q.getSingleResult();
     }
 
     @Override
     public List<SiteObjeto> findAll() {
-        String sql = "SELECT {select_cols} FROM {table}";
-        return em.createNativeQuery(sql, {cname}.class).getResultList();
+        String sql = "SELECT id_site_objeto, id_site, id_objeto FROM Site_Objeto";
+        return em.createNativeQuery(sql, SiteObjeto.class).getResultList();
     }
 
     @Override
     public List<SiteObjeto> findAll(int page, int size) {
-        String sql = "SELECT {select_cols} FROM {table} LIMIT :size OFFSET :off";
-        return em.createNativeQuery(sql, {cname}.class).setParameter("size", size).setParameter("off", page * size).getResultList();
+        String sql = "SELECT id_site_objeto, id_site, id_objeto FROM Site_Objeto LIMIT :size OFFSET :off";
+        return em.createNativeQuery(sql, SiteObjeto.class)
+                .setParameter("size", size)
+                .setParameter("off", page * size)
+                .getResultList();
     }
 
     @Override

--- a/src/main/java/dao/impl/TreinoExercicioDaoNativeImpl.java
+++ b/src/main/java/dao/impl/TreinoExercicioDaoNativeImpl.java
@@ -41,21 +41,24 @@ public class TreinoExercicioDaoNativeImpl implements TreinoExercicioDao {
 
     @Override
     public TreinoExercicio findById(Integer id) {
-        String sql = "SELECT {select_cols} FROM {table} WHERE {e['fields'][0][2]} = :id";
-        Query q = em.createNativeQuery(sql, {cname}.class).setParameter("id", id);
-        return ({cname}) q.getSingleResult();
+        String sql = "SELECT id_treino_exercicio, qtd_repeticao, tempo_descanso, ordem, feito, id_exercicio, id_treino FROM Treino_Exercicio WHERE id_treino_exercicio = :id";
+        Query q = em.createNativeQuery(sql, TreinoExercicio.class).setParameter("id", id);
+        return (TreinoExercicio) q.getSingleResult();
     }
 
     @Override
     public List<TreinoExercicio> findAll() {
-        String sql = "SELECT {select_cols} FROM {table}";
-        return em.createNativeQuery(sql, {cname}.class).getResultList();
+        String sql = "SELECT id_treino_exercicio, qtd_repeticao, tempo_descanso, ordem, feito, id_exercicio, id_treino FROM Treino_Exercicio";
+        return em.createNativeQuery(sql, TreinoExercicio.class).getResultList();
     }
 
     @Override
     public List<TreinoExercicio> findAll(int page, int size) {
-        String sql = "SELECT {select_cols} FROM {table} LIMIT :size OFFSET :off";
-        return em.createNativeQuery(sql, {cname}.class).setParameter("size", size).setParameter("off", page * size).getResultList();
+        String sql = "SELECT id_treino_exercicio, qtd_repeticao, tempo_descanso, ordem, feito, id_exercicio, id_treino FROM Treino_Exercicio LIMIT :size OFFSET :off";
+        return em.createNativeQuery(sql, TreinoExercicio.class)
+                .setParameter("size", size)
+                .setParameter("off", page * size)
+                .getResultList();
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Replace leftover templating placeholders in DAO native implementations with concrete SQL and class references
- Correct controller dependencies by replacing `{dao}` placeholders and adding missing imports

## Testing
- `javac -d /tmp $(find src/main/java -name '*.java') 2>&1 | head -n 40`
- `mvn -q -e test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:3.3.1)*

------
https://chatgpt.com/codex/tasks/task_e_68bf9ad250a88325b7b4bd0baf7065c9