### PR TITLE
fix: require Java 17

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,5 +1,7 @@
 RotinaMaisDesktop (estrutura completa)
 =====================================
+Requer **Java 17** ou superior para compilar e executar, devido às
+dependências Jakarta Persistence 3.x e Hibernate 6.x.
 - Código refatorado em PT-BR (component, swing, evento, model, dialog, form, main).
 - Utilitário de ícones: swing.icon.Icones (PNG/JPG em /resources/icon + fallback Material Icons).
 - Coloque seus PNGs/JPGs de ícones em: src/main/resources/icon/

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
   <name>RotinaMaisDesktop</name>
 
   <properties>
-    <!-- Java 8 conforme seu JRE no projeto -->
-    <maven.compiler.release>8</maven.compiler.release>
+    <!-- Compilar com Java 17 para compatibilidade com dependências -->
+    <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
        <!-- versões estáveis -->
     <jakarta.persistence.version>3.1.0</jakarta.persistence.version>
@@ -52,6 +52,14 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.11.0</version>
+        <configuration>
+          <release>${maven.compiler.release}</release>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>

--- a/src/main/java/infra/EntityManagerUtil.java
+++ b/src/main/java/infra/EntityManagerUtil.java
@@ -6,7 +6,8 @@ import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.Persistence;
 
 public class EntityManagerUtil {
-    private static final EntityManagerFactory emf = Persistence.createEntityManagerFactory("rotinamaisPU");
+    private static final EntityManagerFactory emf =
+            Persistence.createEntityManagerFactory("rotinamais");
 
     private EntityManagerUtil() {
     }


### PR DESCRIPTION
## Summary
- compile and run with Java 17 and add compiler plugin
- fix JPA entity manager factory name
- document Java 17 requirement

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c02a45fa98832589dd501f59c87ac8