### PR TITLE
Use javax.persistence with Hibernate 5 for Java 8 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,12 @@
   <name>RotinaMaisDesktop</name>
 
   <properties>
-    <!-- Compilar com Java 17 para compatibilidade com dependências -->
-    <maven.compiler.release>17</maven.compiler.release>
+    <!-- Compilar com Java 8 para garantir compatibilidade com as bibliotecas -->
+    <maven.compiler.release>8</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-       <!-- versões estáveis -->
-    <jakarta.persistence.version>3.1.0</jakarta.persistence.version>
-    <hibernate.version>6.6.6.Final</hibernate.version>
+    <!-- versões estáveis compatíveis com Java 8 -->
+    <jpa.version>2.2</jpa.version>
+    <hibernate.version>5.6.15.Final</hibernate.version>
     <postgres.version>42.7.7</postgres.version>
   </properties>
 
@@ -26,16 +26,16 @@
       <version>5.3</version>
     </dependency>
 
-  <!-- API JPA (Jakarta) -->
+    <!-- API JPA -->
     <dependency>
-      <groupId>jakarta.persistence</groupId>
-      <artifactId>jakarta.persistence-api</artifactId>
-      <version>${jakarta.persistence.version}</version>
+      <groupId>javax.persistence</groupId>
+      <artifactId>javax.persistence-api</artifactId>
+      <version>${jpa.version}</version>
     </dependency>
 
     <!-- Implementação: Hibernate ORM -->
     <dependency>
-      <groupId>org.hibernate.orm</groupId>
+      <groupId>org.hibernate</groupId>
       <artifactId>hibernate-core</artifactId>
       <version>${hibernate.version}</version>
     </dependency>

--- a/src/main/java/conexao/ConnectionFactory.java
+++ b/src/main/java/conexao/ConnectionFactory.java
@@ -2,7 +2,7 @@ package conexao;
 
 import infra.EntityManagerUtil;
 import infra.Logger;
-import jakarta.persistence.EntityManager;
+import javax.persistence.EntityManager;
 
 import java.io.InputStream;
 import java.sql.Connection;
@@ -38,14 +38,14 @@ public final class ConnectionFactory {
         } finally {
             em.close();
         }
-        URL = (String) props.get("jakarta.persistence.jdbc.url");
-        USER = (String) props.get("jakarta.persistence.jdbc.user");
-        String pwd = (String) props.get("jakarta.persistence.jdbc.password");
+        URL = (String) props.get("javax.persistence.jdbc.url");
+        USER = (String) props.get("javax.persistence.jdbc.user");
+        String pwd = (String) props.get("javax.persistence.jdbc.password");
         if ("****".equals(pwd)) {
             pwd = loadPasswordFromPersistenceXml();
         }
         PASSWORD = pwd;
-        DRIVER = (String) props.get("jakarta.persistence.jdbc.driver");
+        DRIVER = (String) props.get("javax.persistence.jdbc.driver");
         try {
             Class.forName(DRIVER);
         } catch (ClassNotFoundException e) {
@@ -70,7 +70,7 @@ public final class ConnectionFactory {
             NodeList props = doc.getElementsByTagName("property");
             for (int i = 0; i < props.getLength(); i++) {
                 Element el = (Element) props.item(i);
-                if ("jakarta.persistence.jdbc.password".equals(el.getAttribute("name"))) {
+                if ("javax.persistence.jdbc.password".equals(el.getAttribute("name"))) {
                     return el.getAttribute("value");
                 }
             }

--- a/src/main/java/dao/impl/AlimentacaoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/AlimentacaoDaoNativeImpl.java
@@ -9,8 +9,8 @@ import dao.api.AlimentacaoDao;
 import exception.AlimentacaoException;
 import infra.EntityManagerUtil;
 import infra.Logger;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.Query;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
 import model.Alimentacao;
 
 public class AlimentacaoDaoNativeImpl implements AlimentacaoDao {

--- a/src/main/java/dao/impl/AlimentacaoIngredienteDaoNativeImpl.java
+++ b/src/main/java/dao/impl/AlimentacaoIngredienteDaoNativeImpl.java
@@ -4,8 +4,8 @@ import dao.api.AlimentacaoIngredienteDao;
 import exception.AlimentacaoIngredienteException;
 import infra.EntityManagerUtil;
 import infra.Logger;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.Query;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
 import model.AlimentacaoIngrediente;
 
 import java.util.List;

--- a/src/main/java/dao/impl/CaixaDaoNativeImpl.java
+++ b/src/main/java/dao/impl/CaixaDaoNativeImpl.java
@@ -10,8 +10,8 @@ import dao.api.CaixaDao;
 import exception.CaixaException;
 import infra.EntityManagerUtil;
 import infra.Logger;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.Query;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
 import model.Caixa;
 
 public class CaixaDaoNativeImpl implements CaixaDao {

--- a/src/main/java/dao/impl/CarteiraDaoNativeImpl.java
+++ b/src/main/java/dao/impl/CarteiraDaoNativeImpl.java
@@ -4,8 +4,8 @@ import dao.api.CarteiraDao;
 import exception.CarteiraException;
 import infra.EntityManagerUtil;
 import infra.Logger;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.Query;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
 import model.Carteira;
 
 import java.time.LocalDate;

--- a/src/main/java/dao/impl/CategoriaDaoNativeImpl.java
+++ b/src/main/java/dao/impl/CategoriaDaoNativeImpl.java
@@ -10,8 +10,8 @@ import dao.api.CategoriaDao;
 import exception.CategoriaException;
 import infra.EntityManagerUtil;
 import infra.Logger;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.Query;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
 import model.Categoria;
 
 public class CategoriaDaoNativeImpl implements CategoriaDao {

--- a/src/main/java/dao/impl/CofreDaoNativeImpl.java
+++ b/src/main/java/dao/impl/CofreDaoNativeImpl.java
@@ -4,8 +4,8 @@ import dao.api.CofreDao;
 import exception.CofreException;
 import infra.EntityManagerUtil;
 import infra.Logger;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.Query;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
 import model.Cofre;
 
 import java.util.List;

--- a/src/main/java/dao/impl/DocumentoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/DocumentoDaoNativeImpl.java
@@ -9,8 +9,8 @@ import dao.api.DocumentoDao;
 import exception.DocumentoException;
 import infra.EntityManagerUtil;
 import infra.Logger;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.Query;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
 import model.Documento;
 
 public class DocumentoDaoNativeImpl implements DocumentoDao {

--- a/src/main/java/dao/impl/EventoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/EventoDaoNativeImpl.java
@@ -9,8 +9,8 @@ import dao.api.EventoDao;
 import exception.EventoException;
 import infra.EntityManagerUtil;
 import infra.Logger;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.Query;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
 import model.Evento;
 
 public class EventoDaoNativeImpl implements EventoDao {

--- a/src/main/java/dao/impl/ExercicioDaoNativeImpl.java
+++ b/src/main/java/dao/impl/ExercicioDaoNativeImpl.java
@@ -9,8 +9,8 @@ import dao.api.ExercicioDao;
 import exception.ExercicioException;
 import infra.EntityManagerUtil;
 import infra.Logger;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.Query;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
 import model.Exercicio;
 
 public class ExercicioDaoNativeImpl implements ExercicioDao {

--- a/src/main/java/dao/impl/FornecedorDaoNativeImpl.java
+++ b/src/main/java/dao/impl/FornecedorDaoNativeImpl.java
@@ -9,8 +9,8 @@ import dao.api.FornecedorDao;
 import exception.FornecedorException;
 import infra.EntityManagerUtil;
 import infra.Logger;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.Query;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
 import model.Fornecedor;
 
 public class FornecedorDaoNativeImpl implements FornecedorDao {

--- a/src/main/java/dao/impl/IngredienteDaoNativeImpl.java
+++ b/src/main/java/dao/impl/IngredienteDaoNativeImpl.java
@@ -9,8 +9,8 @@ import dao.api.IngredienteDao;
 import exception.IngredienteException;
 import infra.EntityManagerUtil;
 import infra.Logger;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.Query;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
 import model.Ingrediente;
 
 public class IngredienteDaoNativeImpl implements IngredienteDao {

--- a/src/main/java/dao/impl/IngredienteFornecedorDaoNativeImpl.java
+++ b/src/main/java/dao/impl/IngredienteFornecedorDaoNativeImpl.java
@@ -4,8 +4,8 @@ import dao.api.IngredienteFornecedorDao;
 import exception.IngredienteFornecedorException;
 import infra.EntityManagerUtil;
 import infra.Logger;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.Query;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
 import model.IngredienteFornecedor;
 
 import java.math.BigDecimal;

--- a/src/main/java/dao/impl/LancamentoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/LancamentoDaoNativeImpl.java
@@ -9,8 +9,8 @@ import dao.api.LancamentoDao;
 import exception.LancamentoException;
 import infra.EntityManagerUtil;
 import infra.Logger;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.Query;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
 import model.Lancamento;
 
 public class LancamentoDaoNativeImpl implements LancamentoDao {

--- a/src/main/java/dao/impl/MetaDaoNativeImpl.java
+++ b/src/main/java/dao/impl/MetaDaoNativeImpl.java
@@ -4,8 +4,8 @@ import dao.api.MetaDao;
 import exception.MetaException;
 import infra.EntityManagerUtil;
 import infra.Logger;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.Query;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
 import model.Meta;
 
 import java.util.List;

--- a/src/main/java/dao/impl/MonitoramentoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/MonitoramentoDaoNativeImpl.java
@@ -9,8 +9,8 @@ import dao.api.MonitoramentoDao;
 import exception.MonitoramentoException;
 import infra.EntityManagerUtil;
 import infra.Logger;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.Query;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
 import model.Monitoramento;
 
 public class MonitoramentoDaoNativeImpl implements MonitoramentoDao {

--- a/src/main/java/dao/impl/MonitoramentoObjetoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/MonitoramentoObjetoDaoNativeImpl.java
@@ -4,8 +4,8 @@ import dao.api.MonitoramentoObjetoDao;
 import exception.MonitoramentoObjetoException;
 import infra.EntityManagerUtil;
 import infra.Logger;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.Query;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
 import model.MonitoramentoObjeto;
 
 import java.time.LocalDate;

--- a/src/main/java/dao/impl/MovimentacaoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/MovimentacaoDaoNativeImpl.java
@@ -10,8 +10,8 @@ import dao.api.MovimentacaoDao;
 import exception.MovimentacaoException;
 import infra.EntityManagerUtil;
 import infra.Logger;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.Query;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
 import model.Movimentacao;
 
 public class MovimentacaoDaoNativeImpl implements MovimentacaoDao {

--- a/src/main/java/dao/impl/ObjetoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/ObjetoDaoNativeImpl.java
@@ -10,8 +10,8 @@ import dao.api.ObjetoDao;
 import exception.ObjetoException;
 import infra.EntityManagerUtil;
 import infra.Logger;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.Query;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
 import model.Objeto;
 
 public class ObjetoDaoNativeImpl implements ObjetoDao {

--- a/src/main/java/dao/impl/OperacaoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/OperacaoDaoNativeImpl.java
@@ -4,8 +4,8 @@ import dao.api.OperacaoDao;
 import exception.OperacaoException;
 import infra.EntityManagerUtil;
 import infra.Logger;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.Query;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
 import model.Operacao;
 
 import java.math.BigDecimal;

--- a/src/main/java/dao/impl/PapelDaoNativeImpl.java
+++ b/src/main/java/dao/impl/PapelDaoNativeImpl.java
@@ -4,8 +4,8 @@ import dao.api.PapelDao;
 import exception.PapelException;
 import infra.EntityManagerUtil;
 import infra.Logger;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.Query;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
 import model.Papel;
 
 import java.time.LocalDate;

--- a/src/main/java/dao/impl/PeriodoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/PeriodoDaoNativeImpl.java
@@ -9,8 +9,8 @@ import dao.api.PeriodoDao;
 import exception.PeriodoException;
 import infra.EntityManagerUtil;
 import infra.Logger;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.Query;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
 import model.Periodo;
 
 public class PeriodoDaoNativeImpl implements PeriodoDao {

--- a/src/main/java/dao/impl/RotinaDaoNativeImpl.java
+++ b/src/main/java/dao/impl/RotinaDaoNativeImpl.java
@@ -10,8 +10,8 @@ import dao.api.RotinaDao;
 import exception.RotinaException;
 import infra.EntityManagerUtil;
 import infra.Logger;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.Query;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
 import model.Rotina;
 
 public class RotinaDaoNativeImpl implements RotinaDao {

--- a/src/main/java/dao/impl/RotinaPeriodoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/RotinaPeriodoDaoNativeImpl.java
@@ -4,8 +4,8 @@ import dao.api.RotinaPeriodoDao;
 import exception.RotinaPeriodoException;
 import infra.EntityManagerUtil;
 import infra.Logger;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.Query;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
 import model.RotinaPeriodo;
 
 import java.util.List;

--- a/src/main/java/dao/impl/SiteDaoNativeImpl.java
+++ b/src/main/java/dao/impl/SiteDaoNativeImpl.java
@@ -9,8 +9,8 @@ import dao.api.SiteDao;
 import exception.SiteException;
 import infra.EntityManagerUtil;
 import infra.Logger;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.Query;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
 import model.Site;
 
 public class SiteDaoNativeImpl implements SiteDao {

--- a/src/main/java/dao/impl/SiteObjetoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/SiteObjetoDaoNativeImpl.java
@@ -4,8 +4,8 @@ import dao.api.SiteObjetoDao;
 import exception.SiteObjetoException;
 import infra.EntityManagerUtil;
 import infra.Logger;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.Query;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
 import model.SiteObjeto;
 
 import java.util.List;

--- a/src/main/java/dao/impl/TreinoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/TreinoDaoNativeImpl.java
@@ -9,8 +9,8 @@ import dao.api.TreinoDao;
 import exception.TreinoException;
 import infra.EntityManagerUtil;
 import infra.Logger;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.Query;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
 import model.Treino;
 
 public class TreinoDaoNativeImpl implements TreinoDao {

--- a/src/main/java/dao/impl/TreinoExercicioDaoNativeImpl.java
+++ b/src/main/java/dao/impl/TreinoExercicioDaoNativeImpl.java
@@ -4,8 +4,8 @@ import dao.api.TreinoExercicioDao;
 import exception.TreinoExercicioException;
 import infra.EntityManagerUtil;
 import infra.Logger;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.Query;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
 import model.TreinoExercicio;
 
 import java.util.List;

--- a/src/main/java/infra/EntityManagerUtil.java
+++ b/src/main/java/infra/EntityManagerUtil.java
@@ -1,9 +1,9 @@
 // path: src/main/java/infra/EntityManagerUtil.java
 package infra;
 
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.EntityManagerFactory;
-import jakarta.persistence.Persistence;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
 
 public class EntityManagerUtil {
     private static final EntityManagerFactory emf =

--- a/src/main/java/model/Alimentacao.java
+++ b/src/main/java/model/Alimentacao.java
@@ -3,11 +3,11 @@ package model;
 
 import java.util.Objects;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Lob;
-import jakarta.persistence.Table;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import javax.persistence.Table;
 
 @Entity
 @Table(name = "Alimentacao")

--- a/src/main/java/model/AlimentacaoIngrediente.java
+++ b/src/main/java/model/AlimentacaoIngrediente.java
@@ -1,6 +1,6 @@
 package model;
 
-import jakarta.persistence.*;
+import javax.persistence.*;
 import java.util.Objects;
 
 @Entity

--- a/src/main/java/model/Caixa.java
+++ b/src/main/java/model/Caixa.java
@@ -6,14 +6,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
 
 @Entity
 @Table(name = "Caixa")

--- a/src/main/java/model/Carteira.java
+++ b/src/main/java/model/Carteira.java
@@ -1,6 +1,6 @@
 package model;
 
-import jakarta.persistence.*;
+import javax.persistence.*;
 import java.time.LocalDate;
 import java.util.Objects;
 

--- a/src/main/java/model/Categoria.java
+++ b/src/main/java/model/Categoria.java
@@ -6,12 +6,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Lob;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
 
 @Entity
 @Table(name = "Categoria")

--- a/src/main/java/model/Cofre.java
+++ b/src/main/java/model/Cofre.java
@@ -1,6 +1,6 @@
 package model;
 
-import jakarta.persistence.*;
+import javax.persistence.*;
 import java.util.Objects;
 
 @Entity

--- a/src/main/java/model/Documento.java
+++ b/src/main/java/model/Documento.java
@@ -4,11 +4,11 @@ package model;
 import java.time.LocalDate;
 import java.util.Objects;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Lob;
-import jakarta.persistence.Table;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import javax.persistence.Table;
 
 @Entity
 @Table(name = "Documento")

--- a/src/main/java/model/Evento.java
+++ b/src/main/java/model/Evento.java
@@ -6,15 +6,15 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.Lob;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
 
 @Entity
 @Table(name = "Evento")

--- a/src/main/java/model/Exercicio.java
+++ b/src/main/java/model/Exercicio.java
@@ -3,10 +3,10 @@ package model;
 
 import java.util.Objects;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
 
 @Entity
 @Table(name = "Exercicio")

--- a/src/main/java/model/Fornecedor.java
+++ b/src/main/java/model/Fornecedor.java
@@ -3,11 +3,11 @@ package model;
 
 import java.util.Objects;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Lob;
-import jakarta.persistence.Table;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import javax.persistence.Table;
 
 @Entity
 @Table(name = "Fornecedor")

--- a/src/main/java/model/Ingrediente.java
+++ b/src/main/java/model/Ingrediente.java
@@ -3,11 +3,11 @@ package model;
 
 import java.util.Objects;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Lob;
-import jakarta.persistence.Table;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import javax.persistence.Table;
 
 @Entity
 @Table(name = "Ingrediente")

--- a/src/main/java/model/IngredienteFornecedor.java
+++ b/src/main/java/model/IngredienteFornecedor.java
@@ -1,6 +1,6 @@
 package model;
 
-import jakarta.persistence.*;
+import javax.persistence.*;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Objects;

--- a/src/main/java/model/Lancamento.java
+++ b/src/main/java/model/Lancamento.java
@@ -5,13 +5,13 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Objects;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 
 @Entity
 @Table(name = "Lancamento")

--- a/src/main/java/model/Meta.java
+++ b/src/main/java/model/Meta.java
@@ -1,6 +1,6 @@
 package model;
 
-import jakarta.persistence.*;
+import javax.persistence.*;
 import java.time.LocalDate;
 import java.util.Objects;
 

--- a/src/main/java/model/Monitoramento.java
+++ b/src/main/java/model/Monitoramento.java
@@ -3,11 +3,11 @@ package model;
 
 import java.util.Objects;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Lob;
-import jakarta.persistence.Table;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import javax.persistence.Table;
 
 @Entity
 @Table(name = "Monitoramento")

--- a/src/main/java/model/MonitoramentoObjeto.java
+++ b/src/main/java/model/MonitoramentoObjeto.java
@@ -1,6 +1,6 @@
 package model;
 
-import jakarta.persistence.*;
+import javax.persistence.*;
 import java.time.LocalDate;
 import java.util.Objects;
 

--- a/src/main/java/model/Movimentacao.java
+++ b/src/main/java/model/Movimentacao.java
@@ -6,14 +6,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
 
 @Entity
 @Table(name = "Movimentacao")

--- a/src/main/java/model/Objeto.java
+++ b/src/main/java/model/Objeto.java
@@ -4,11 +4,11 @@ package model;
 import java.math.BigDecimal;
 import java.util.Objects;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Lob;
-import jakarta.persistence.Table;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import javax.persistence.Table;
 
 @Entity
 @Table(name = "Objeto")

--- a/src/main/java/model/Operacao.java
+++ b/src/main/java/model/Operacao.java
@@ -1,6 +1,6 @@
 package model;
 
-import jakarta.persistence.*;
+import javax.persistence.*;
 import java.math.BigDecimal;
 import java.time.LocalTime;
 import java.util.Objects;

--- a/src/main/java/model/Papel.java
+++ b/src/main/java/model/Papel.java
@@ -1,6 +1,6 @@
 package model;
 
-import jakarta.persistence.*;
+import javax.persistence.*;
 import java.time.LocalDate;
 import java.util.Objects;
 

--- a/src/main/java/model/Periodo.java
+++ b/src/main/java/model/Periodo.java
@@ -5,11 +5,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
 
 @Entity
 @Table(name = "Periodo")

--- a/src/main/java/model/Rotina.java
+++ b/src/main/java/model/Rotina.java
@@ -4,10 +4,10 @@ package model;
 import java.time.LocalDate;
 import java.util.Objects;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
 
 @Entity
 @Table(name = "Rotina")

--- a/src/main/java/model/RotinaPeriodo.java
+++ b/src/main/java/model/RotinaPeriodo.java
@@ -1,6 +1,6 @@
 package model;
 
-import jakarta.persistence.*;
+import javax.persistence.*;
 import java.util.Objects;
 
 @Entity

--- a/src/main/java/model/Site.java
+++ b/src/main/java/model/Site.java
@@ -3,11 +3,11 @@ package model;
 
 import java.util.Objects;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Lob;
-import jakarta.persistence.Table;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import javax.persistence.Table;
 
 @Entity
 @Table(name = "Site")

--- a/src/main/java/model/SiteObjeto.java
+++ b/src/main/java/model/SiteObjeto.java
@@ -1,6 +1,6 @@
 package model;
 
-import jakarta.persistence.*;
+import javax.persistence.*;
 import java.util.Objects;
 
 @Entity

--- a/src/main/java/model/Treino.java
+++ b/src/main/java/model/Treino.java
@@ -3,10 +3,10 @@ package model;
 
 import java.util.Objects;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
 
 @Entity
 @Table(name = "Treino")

--- a/src/main/java/model/TreinoExercicio.java
+++ b/src/main/java/model/TreinoExercicio.java
@@ -1,6 +1,6 @@
 package model;
 
-import jakarta.persistence.*;
+import javax.persistence.*;
 import java.util.Objects;
 
 @Entity

--- a/src/main/java/model/Usuario.java
+++ b/src/main/java/model/Usuario.java
@@ -5,12 +5,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Lob;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
 
 @Entity
 @Table(name = "Usuario")

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -1,12 +1,12 @@
 <!-- path: src/main/resources/META-INF/persistence.xml -->
-<persistence xmlns="https://jakarta.ee/xml/ns/persistence" version="3.0">
+<persistence xmlns="http://xmlns.jcp.org/xml/ns/persistence" version="2.2">
     <persistence-unit name="rotinamais">
         <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
         <properties>
-            <property name="jakarta.persistence.jdbc.driver" value="org.postgresql.Driver"/>
-            <property name="jakarta.persistence.jdbc.url" value="jdbc:postgresql://localhost:5432/rotinamais"/>
-            <property name="jakarta.persistence.jdbc.user" value="kadu"/>
-            <property name="jakarta.persistence.jdbc.password" value="123"/>
+            <property name="javax.persistence.jdbc.driver" value="org.postgresql.Driver"/>
+            <property name="javax.persistence.jdbc.url" value="jdbc:postgresql://localhost:5432/rotinamais"/>
+            <property name="javax.persistence.jdbc.user" value="kadu"/>
+            <property name="javax.persistence.jdbc.password" value="123"/>
             <property name="hibernate.dialect" value="org.hibernate.dialect.PostgreSQLDialect"/>
             <property name="hibernate.hbm2ddl.auto" value="none"/>
         </properties>


### PR DESCRIPTION
## Summary
- Switch Maven project to Java 8 and replace Jakarta Persistence with javax.persistence 2.2
- Downgrade Hibernate to 5.6 and adjust JDBC property names in ConnectionFactory and persistence.xml

## Testing
- `mvn -q -e compile` *(fails: Network is unreachable)*
- `mvn -q -e -o test` *(fails: artifact org.apache.maven.plugins:maven-resources-plugin not downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_68c038acb8f08325917f3dfe8cee71d6