### PR TITLE
Remover necessidade de ID nas criações de DAO

### DIFF
--- a/src/main/java/dao/impl/AlimentacaoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/AlimentacaoDaoNativeImpl.java
@@ -21,10 +21,9 @@ public class AlimentacaoDaoNativeImpl implements AlimentacaoDao {
         EntityManager em = EntityManagerUtil.getEntityManager();
         try {
             em.getTransaction().begin();
-            String sql = "INSERT INTO Alimentacao (id_alimentacao, status, nome, link, video, preparo, id_rotina) " +
-                    "VALUES (:id, :status, :nome, :link, :video, :preparo, :idRotina)";
+            String sql = "INSERT INTO Alimentacao (status, nome, link, video, preparo, id_rotina) " +
+                    "VALUES (:status, :nome, :link, :video, :preparo, :idRotina)";
             Query query = em.createNativeQuery(sql);
-            query.setParameter("id", alimentacao.getIdAlimentacao());
             query.setParameter("status", alimentacao.getStatus());
             query.setParameter("nome", alimentacao.getNome());
             query.setParameter("link", alimentacao.getLink());

--- a/src/main/java/dao/impl/CaixaDaoNativeImpl.java
+++ b/src/main/java/dao/impl/CaixaDaoNativeImpl.java
@@ -22,9 +22,8 @@ public class CaixaDaoNativeImpl implements CaixaDao {
         EntityManager em = EntityManagerUtil.getEntityManager();
         try {
             em.getTransaction().begin();
-            String sql = "INSERT INTO Caixa (id_caixa, nome, reserva_emergencia, salario_medio, valor_total, id_usuario) VALUES (:id, :nome, :reserva, :salario, :valor, :idUsuario)";
+            String sql = "INSERT INTO Caixa (nome, reserva_emergencia, salario_medio, valor_total, id_usuario) VALUES (:nome, :reserva, :salario, :valor, :idUsuario)";
             Query query = em.createNativeQuery(sql);
-            query.setParameter("id", caixa.getIdCaixa());
             query.setParameter("nome", caixa.getNome());
             query.setParameter("reserva", caixa.getReservaEmergencia());
             query.setParameter("salario", caixa.getSalarioMedio());

--- a/src/main/java/dao/impl/CategoriaDaoNativeImpl.java
+++ b/src/main/java/dao/impl/CategoriaDaoNativeImpl.java
@@ -22,10 +22,9 @@ public class CategoriaDaoNativeImpl implements CategoriaDao {
         EntityManager em = EntityManagerUtil.getEntityManager();
         try {
             em.getTransaction().begin();
-            String sql = "INSERT INTO Categoria (id_categoria, nome, descricao, foto, data_criacao) " +
-                    "VALUES (:id, :nome, :descricao, :foto, :dataCriacao)";
+            String sql = "INSERT INTO Categoria (nome, descricao, foto, data_criacao) " +
+                    "VALUES (:nome, :descricao, :foto, :dataCriacao)";
             Query query = em.createNativeQuery(sql);
-            query.setParameter("id", categoria.getIdCategoria());
             query.setParameter("nome", categoria.getNome());
             query.setParameter("descricao", categoria.getDescricao());
             query.setParameter("foto", categoria.getFoto());

--- a/src/main/java/dao/impl/DocumentoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/DocumentoDaoNativeImpl.java
@@ -21,10 +21,9 @@ public class DocumentoDaoNativeImpl implements DocumentoDao {
         EntityManager em = EntityManagerUtil.getEntityManager();
         try {
             em.getTransaction().begin();
-            String sql = "INSERT INTO Documento (id_documento, nome, arquivo, foto, video, data, id_usuario) " +
-                    "VALUES (:id, :nome, :arquivo, :foto, :video, :data, :idUsuario)";
+            String sql = "INSERT INTO Documento (nome, arquivo, foto, video, data, id_usuario) " +
+                    "VALUES (:nome, :arquivo, :foto, :video, :data, :idUsuario)";
             Query query = em.createNativeQuery(sql);
-            query.setParameter("id", documento.getIdDocumento());
             query.setParameter("nome", documento.getNome());
             query.setParameter("arquivo", documento.getArquivo());
             query.setParameter("foto", documento.getFoto());

--- a/src/main/java/dao/impl/EventoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/EventoDaoNativeImpl.java
@@ -21,10 +21,9 @@ public class EventoDaoNativeImpl implements EventoDao {
         EntityManager em = EntityManagerUtil.getEntityManager();
         try {
             em.getTransaction().begin();
-            String sql = "INSERT INTO Evento (id_evento, vantagem, foto, nome, descricao, data_criacao, id_categoria) " +
-                    "VALUES (:id, :vantagem, :foto, :nome, :descricao, :dataCriacao, :idCategoria)";
+            String sql = "INSERT INTO Evento (vantagem, foto, nome, descricao, data_criacao, id_categoria) " +
+                    "VALUES (:vantagem, :foto, :nome, :descricao, :dataCriacao, :idCategoria)";
             Query query = em.createNativeQuery(sql);
-            query.setParameter("id", evento.getIdEvento());
             query.setParameter("vantagem", evento.getVantagem());
             query.setParameter("foto", evento.getFoto());
             query.setParameter("nome", evento.getNome());

--- a/src/main/java/dao/impl/ExercicioDaoNativeImpl.java
+++ b/src/main/java/dao/impl/ExercicioDaoNativeImpl.java
@@ -21,10 +21,9 @@ public class ExercicioDaoNativeImpl implements ExercicioDao {
         EntityManager em = EntityManagerUtil.getEntityManager();
         try {
             em.getTransaction().begin();
-            String sql = "INSERT INTO Exercicio (id_exercicio, nome, carga_leve, carga_media, carga_maxima) " +
-                    "VALUES (:id, :nome, :cargaLeve, :cargaMedia, :cargaMaxima)";
+            String sql = "INSERT INTO Exercicio (nome, carga_leve, carga_media, carga_maxima) " +
+                    "VALUES (:nome, :cargaLeve, :cargaMedia, :cargaMaxima)";
             Query query = em.createNativeQuery(sql);
-            query.setParameter("id", exercicio.getIdExercicio());
             query.setParameter("nome", exercicio.getNome());
             query.setParameter("cargaLeve", exercicio.getCargaLeve());
             query.setParameter("cargaMedia", exercicio.getCargaMedia());

--- a/src/main/java/dao/impl/FornecedorDaoNativeImpl.java
+++ b/src/main/java/dao/impl/FornecedorDaoNativeImpl.java
@@ -21,10 +21,9 @@ public class FornecedorDaoNativeImpl implements FornecedorDao {
         EntityManager em = EntityManagerUtil.getEntityManager();
         try {
             em.getTransaction().begin();
-            String sql = "INSERT INTO Fornecedor (id_fornecedor, nome, foto, endereco, online) " +
-                    "VALUES (:id, :nome, :foto, :endereco, :online)";
+            String sql = "INSERT INTO Fornecedor (nome, foto, endereco, online) " +
+                    "VALUES (:nome, :foto, :endereco, :online)";
             Query query = em.createNativeQuery(sql);
-            query.setParameter("id", fornecedor.getIdFornecedor());
             query.setParameter("nome", fornecedor.getNome());
             query.setParameter("foto", fornecedor.getFoto());
             query.setParameter("endereco", fornecedor.getEndereco());

--- a/src/main/java/dao/impl/IngredienteDaoNativeImpl.java
+++ b/src/main/java/dao/impl/IngredienteDaoNativeImpl.java
@@ -21,10 +21,9 @@ public class IngredienteDaoNativeImpl implements IngredienteDao {
         EntityManager em = EntityManagerUtil.getEntityManager();
         try {
             em.getTransaction().begin();
-            String sql = "INSERT INTO Ingrediente (id_ingrediente, nome, descricao, foto) " +
-                    "VALUES (:id, :nome, :descricao, :foto)";
+            String sql = "INSERT INTO Ingrediente (nome, descricao, foto) " +
+                    "VALUES (:nome, :descricao, :foto)";
             Query query = em.createNativeQuery(sql);
-            query.setParameter("id", ingrediente.getIdIngrediente());
             query.setParameter("nome", ingrediente.getNome());
             query.setParameter("descricao", ingrediente.getDescricao());
             query.setParameter("foto", ingrediente.getFoto());

--- a/src/main/java/dao/impl/LancamentoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/LancamentoDaoNativeImpl.java
@@ -21,10 +21,9 @@ public class LancamentoDaoNativeImpl implements LancamentoDao {
         EntityManager em = EntityManagerUtil.getEntityManager();
         try {
             em.getTransaction().begin();
-            String sql = "INSERT INTO Lancamento (id_lancamento, valor, fixo, data_pagamento, status, id_movimentacao, id_evento) " +
-                    "VALUES (:id, :valor, :fixo, :dataPagamento, :status, :idMovimentacao, :idEvento)";
+            String sql = "INSERT INTO Lancamento (valor, fixo, data_pagamento, status, id_movimentacao, id_evento) " +
+                    "VALUES (:valor, :fixo, :dataPagamento, :status, :idMovimentacao, :idEvento)";
             Query query = em.createNativeQuery(sql);
-            query.setParameter("id", lancamento.getIdLancamento());
             query.setParameter("valor", lancamento.getValor());
             query.setParameter("fixo", lancamento.getFixo());
             query.setParameter("dataPagamento", lancamento.getDataPagamento());

--- a/src/main/java/dao/impl/MonitoramentoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/MonitoramentoDaoNativeImpl.java
@@ -21,10 +21,9 @@ public class MonitoramentoDaoNativeImpl implements MonitoramentoDao {
         EntityManager em = EntityManagerUtil.getEntityManager();
         try {
             em.getTransaction().begin();
-            String sql = "INSERT INTO Monitoramento (id_monitoramento, status, nome, descricao, foto, id_periodo) " +
-                    "VALUES (:id, :status, :nome, :descricao, :foto, :idPeriodo)";
+            String sql = "INSERT INTO Monitoramento (status, nome, descricao, foto, id_periodo) " +
+                    "VALUES (:status, :nome, :descricao, :foto, :idPeriodo)";
             Query query = em.createNativeQuery(sql);
-            query.setParameter("id", monitoramento.getIdMonitoramento());
             query.setParameter("status", monitoramento.getStatus());
             query.setParameter("nome", monitoramento.getNome());
             query.setParameter("descricao", monitoramento.getDescricao());

--- a/src/main/java/dao/impl/MovimentacaoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/MovimentacaoDaoNativeImpl.java
@@ -22,10 +22,9 @@ public class MovimentacaoDaoNativeImpl implements MovimentacaoDao {
         EntityManager em = EntityManagerUtil.getEntityManager();
         try {
             em.getTransaction().begin();
-            String sql = "INSERT INTO Movimentacao (id_movimentacao, desconto, vantagem, liquido, tipo, status, ponto, id_usuario, id_caixa, id_periodo) " +
-                    "VALUES (:id, :desconto, :vantagem, :liquido, :tipo, :status, :ponto, :idUsuario, :idCaixa, :idPeriodo)";
+            String sql = "INSERT INTO Movimentacao (desconto, vantagem, liquido, tipo, status, ponto, id_usuario, id_caixa, id_periodo) " +
+                    "VALUES (:desconto, :vantagem, :liquido, :tipo, :status, :ponto, :idUsuario, :idCaixa, :idPeriodo)";
             Query query = em.createNativeQuery(sql);
-            query.setParameter("id", movimentacao.getIdMovimentacao());
             query.setParameter("desconto", movimentacao.getDesconto());
             query.setParameter("vantagem", movimentacao.getVantagem());
             query.setParameter("liquido", movimentacao.getLiquido());

--- a/src/main/java/dao/impl/ObjetoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/ObjetoDaoNativeImpl.java
@@ -22,9 +22,8 @@ public class ObjetoDaoNativeImpl implements ObjetoDao {
         EntityManager em = EntityManagerUtil.getEntityManager();
         try {
             em.getTransaction().begin();
-            String sql = "INSERT INTO Objeto (id_objeto, nome, tipo, valor, descricao, foto) VALUES (:id, :nome, :tipo, :valor, :descricao, :foto)";
+            String sql = "INSERT INTO Objeto (nome, tipo, valor, descricao, foto) VALUES (:nome, :tipo, :valor, :descricao, :foto)";
             Query query = em.createNativeQuery(sql);
-            query.setParameter("id", objeto.getIdObjeto());
             query.setParameter("nome", objeto.getNome());
             query.setParameter("tipo", objeto.getTipo());
             query.setParameter("valor", objeto.getValor());

--- a/src/main/java/dao/impl/PeriodoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/PeriodoDaoNativeImpl.java
@@ -21,9 +21,8 @@ public class PeriodoDaoNativeImpl implements PeriodoDao {
         EntityManager em = EntityManagerUtil.getEntityManager();
         try {
             em.getTransaction().begin();
-            String sql = "INSERT INTO Periodo (id_periodo, ano, mes) VALUES (:id, :ano, :mes)";
+            String sql = "INSERT INTO Periodo (ano, mes) VALUES (:ano, :mes)";
             Query query = em.createNativeQuery(sql);
-            query.setParameter("id", periodo.getIdPeriodo());
             query.setParameter("ano", periodo.getAno());
             query.setParameter("mes", periodo.getMes());
             query.executeUpdate();

--- a/src/main/java/dao/impl/RotinaDaoNativeImpl.java
+++ b/src/main/java/dao/impl/RotinaDaoNativeImpl.java
@@ -22,10 +22,9 @@ public class RotinaDaoNativeImpl implements RotinaDao {
         EntityManager em = EntityManagerUtil.getEntityManager();
         try {
             em.getTransaction().begin();
-            String sql = "INSERT INTO Rotina (id_rotina, nome, inicio, fim, descricao, status, ponto, id_usuario) " +
-                    "VALUES (:id, :nome, :inicio, :fim, :descricao, :status, :ponto, :idUsuario)";
+            String sql = "INSERT INTO Rotina (nome, inicio, fim, descricao, status, ponto, id_usuario) " +
+                    "VALUES (:nome, :inicio, :fim, :descricao, :status, :ponto, :idUsuario)";
             Query query = em.createNativeQuery(sql);
-            query.setParameter("id", rotina.getIdRotina());
             query.setParameter("nome", rotina.getNome());
             query.setParameter("inicio", rotina.getInicio());
             query.setParameter("fim", rotina.getFim());

--- a/src/main/java/dao/impl/SiteDaoNativeImpl.java
+++ b/src/main/java/dao/impl/SiteDaoNativeImpl.java
@@ -21,9 +21,8 @@ public class SiteDaoNativeImpl implements SiteDao {
         EntityManager em = EntityManagerUtil.getEntityManager();
         try {
             em.getTransaction().begin();
-            String sql = "INSERT INTO Site (id_site, url, ativo, logo) VALUES (:id, :url, :ativo, :logo)";
+            String sql = "INSERT INTO Site (url, ativo, logo) VALUES (:url, :ativo, :logo)";
             Query query = em.createNativeQuery(sql);
-            query.setParameter("id", site.getIdSite());
             query.setParameter("url", site.getUrl());
             query.setParameter("ativo", site.getAtivo());
             query.setParameter("logo", site.getLogo());

--- a/src/main/java/dao/impl/TreinoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/TreinoDaoNativeImpl.java
@@ -21,9 +21,8 @@ public class TreinoDaoNativeImpl implements TreinoDao {
         EntityManager em = EntityManagerUtil.getEntityManager();
         try {
             em.getTransaction().begin();
-            String sql = "INSERT INTO Treino (id_treino, nome, classe, id_rotina) VALUES (:id, :nome, :classe, :idRotina)";
+            String sql = "INSERT INTO Treino (nome, classe, id_rotina) VALUES (:nome, :classe, :idRotina)";
             Query query = em.createNativeQuery(sql);
-            query.setParameter("id", treino.getIdTreino());
             query.setParameter("nome", treino.getNome());
             query.setParameter("classe", treino.getClasse());
             query.setParameter("idRotina", treino.getIdRotina());

--- a/src/main/java/dao/impl/UsuarioDaoNativeImpl.java
+++ b/src/main/java/dao/impl/UsuarioDaoNativeImpl.java
@@ -30,17 +30,16 @@ public class UsuarioDaoNativeImpl implements UsuarioDao {
     @Override
     public void create(Usuario usuario) throws UsuarioException {
         Logger.info("UsuarioDaoNativeImpl.create - inicio");
-        String sql = "INSERT INTO Usuario (id_usuario, nome, senha, foto, email) VALUES (?,?,?,?,?)";
+        String sql = "INSERT INTO Usuario (nome, senha, foto, email) VALUES (?,?,?,?)";
         Connection conn = null;
         try {
             conn = ConnectionFactory.getConnection();
             conn.setAutoCommit(false);
             try (PreparedStatement ps = conn.prepareStatement(sql)) {
-                ps.setInt(1, usuario.getIdUsuario());
-                ps.setString(2, usuario.getNome());
-                ps.setString(3, usuario.getSenha());
-                ps.setBytes(4, usuario.getFoto());
-                ps.setString(5, usuario.getEmail());
+                ps.setString(1, usuario.getNome());
+                ps.setString(2, usuario.getSenha());
+                ps.setBytes(3, usuario.getFoto());
+                ps.setString(4, usuario.getEmail());
                 ps.executeUpdate();
             }
             conn.commit();


### PR DESCRIPTION
## Summary
- Ajusta operações de criação nas classes DAO para não requerer ID manual
- Simplifica inserções SQL usando IDs gerados automaticamente

## Testing
- `mvn -q test` *(falhou: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c06a2c435883258b164a79634f4d90