### PR TITLE
Atualiza testes com relações via dados existentes

### DIFF
--- a/src/main/java/test/AlimentacaoIngredienteControllerTest.java
+++ b/src/main/java/test/AlimentacaoIngredienteControllerTest.java
@@ -3,6 +3,10 @@ package test;
 import controller.AlimentacaoIngredienteController;
 import dao.impl.AlimentacaoIngredienteDaoNativeImpl;
 import model.AlimentacaoIngrediente;
+import controller.AlimentacaoController;
+import controller.IngredienteController;
+import dao.impl.AlimentacaoDaoNativeImpl;
+import dao.impl.IngredienteDaoNativeImpl;
 
 import java.util.List;
 
@@ -13,8 +17,10 @@ public class AlimentacaoIngredienteControllerTest {
 
         AlimentacaoIngrediente ai = new AlimentacaoIngrediente();
         ai.setQuantidade(1);
-        ai.setIdAlimentacao(1);
-        ai.setIdIngrediente(1);
+        AlimentacaoController alimentacaoController = new AlimentacaoController(new AlimentacaoDaoNativeImpl());
+        IngredienteController ingredienteController = new IngredienteController(new IngredienteDaoNativeImpl());
+        ai.setIdAlimentacao(TestUtils.getRandom(alimentacaoController.listar()).getIdAlimentacao());
+        ai.setIdIngrediente(TestUtils.getRandom(ingredienteController.listar()).getIdIngrediente());
         controller.criar(ai);
 
         List<AlimentacaoIngrediente> list = controller.listar();

--- a/src/main/java/test/CarteiraControllerTest.java
+++ b/src/main/java/test/CarteiraControllerTest.java
@@ -3,6 +3,8 @@ package test;
 import controller.CarteiraController;
 import dao.impl.CarteiraDaoNativeImpl;
 import model.Carteira;
+import controller.UsuarioController;
+import dao.impl.UsuarioDaoNativeImpl;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -16,7 +18,8 @@ public class CarteiraControllerTest {
         carteira.setNome("Carteira Exemplo");
         carteira.setTipo("T");
         carteira.setDataInicio(LocalDate.now());
-        carteira.setIdUsuario(1);
+        UsuarioController usuarioController = new UsuarioController(new UsuarioDaoNativeImpl());
+        carteira.setIdUsuario(TestUtils.getRandom(usuarioController.listar()).getIdUsuario());
         controller.criar(carteira);
 
         List<Carteira> list = controller.listar();

--- a/src/main/java/test/IngredienteFornecedorControllerTest.java
+++ b/src/main/java/test/IngredienteFornecedorControllerTest.java
@@ -3,6 +3,10 @@ package test;
 import controller.IngredienteFornecedorController;
 import dao.impl.IngredienteFornecedorDaoNativeImpl;
 import model.IngredienteFornecedor;
+import controller.FornecedorController;
+import controller.IngredienteController;
+import dao.impl.FornecedorDaoNativeImpl;
+import dao.impl.IngredienteDaoNativeImpl;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -16,8 +20,10 @@ public class IngredienteFornecedorControllerTest {
         IngredienteFornecedor rel = new IngredienteFornecedor();
         rel.setValor(BigDecimal.ONE);
         rel.setData(LocalDate.now());
-        rel.setIdFornecedor(1);
-        rel.setIdIngrediente(1);
+        FornecedorController fornecedorController = new FornecedorController(new FornecedorDaoNativeImpl());
+        IngredienteController ingredienteController = new IngredienteController(new IngredienteDaoNativeImpl());
+        rel.setIdFornecedor(TestUtils.getRandom(fornecedorController.listar()).getIdFornecedor());
+        rel.setIdIngrediente(TestUtils.getRandom(ingredienteController.listar()).getIdIngrediente());
         controller.criar(rel);
 
         List<IngredienteFornecedor> list = controller.listar();

--- a/src/main/java/test/LancamentoControllerTest.java
+++ b/src/main/java/test/LancamentoControllerTest.java
@@ -3,7 +3,8 @@ package test;
 import controller.LancamentoController;
 import dao.impl.LancamentoDaoNativeImpl;
 import model.Lancamento;
-import model.Evento;
+import controller.EventoController;
+import dao.impl.EventoDaoNativeImpl;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -16,9 +17,8 @@ public class LancamentoControllerTest {
 
         Lancamento lancamento = new Lancamento();
         lancamento.setValor(BigDecimal.ONE);
-        Evento evento = new Evento();
-        evento.setIdEvento(1);
-        lancamento.setEvento(evento);
+        EventoController eventoController = new EventoController(new EventoDaoNativeImpl());
+        lancamento.setEvento(TestUtils.getRandom(eventoController.listar()));
         lancamento.setFixo(Boolean.FALSE);
         lancamento.setDataPagamento(LocalDate.now());
         controller.criar(lancamento);

--- a/src/main/java/test/MonitoramentoObjetoControllerTest.java
+++ b/src/main/java/test/MonitoramentoObjetoControllerTest.java
@@ -3,6 +3,10 @@ package test;
 import controller.MonitoramentoObjetoController;
 import dao.impl.MonitoramentoObjetoDaoNativeImpl;
 import model.MonitoramentoObjeto;
+import controller.MonitoramentoController;
+import controller.ObjetoController;
+import dao.impl.MonitoramentoDaoNativeImpl;
+import dao.impl.ObjetoDaoNativeImpl;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -14,8 +18,10 @@ public class MonitoramentoObjetoControllerTest {
 
         MonitoramentoObjeto mo = new MonitoramentoObjeto();
         mo.setData(LocalDate.now());
-        mo.setIdMonitoramento(1);
-        mo.setIdObjeto(1);
+        MonitoramentoController monitoramentoController = new MonitoramentoController(new MonitoramentoDaoNativeImpl());
+        ObjetoController objetoController = new ObjetoController(new ObjetoDaoNativeImpl());
+        mo.setIdMonitoramento(TestUtils.getRandom(monitoramentoController.listar()).getIdMonitoramento());
+        mo.setIdObjeto(TestUtils.getRandom(objetoController.listar()).getIdObjeto());
         controller.criar(mo);
 
         List<MonitoramentoObjeto> list = controller.listar();

--- a/src/main/java/test/MovimentacaoControllerTest.java
+++ b/src/main/java/test/MovimentacaoControllerTest.java
@@ -3,6 +3,12 @@ package test;
 import controller.MovimentacaoController;
 import dao.impl.MovimentacaoDaoNativeImpl;
 import model.Movimentacao;
+import controller.UsuarioController;
+import controller.CaixaController;
+import controller.PeriodoController;
+import dao.impl.UsuarioDaoNativeImpl;
+import dao.impl.CaixaDaoNativeImpl;
+import dao.impl.PeriodoDaoNativeImpl;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -25,6 +31,12 @@ public class MovimentacaoControllerTest {
         mov.setLiquido(new BigDecimal("100.0"));
         mov.setStatus(1);
         mov.setPonto(10);
+        UsuarioController usuarioController = new UsuarioController(new UsuarioDaoNativeImpl());
+        CaixaController caixaController = new CaixaController(new CaixaDaoNativeImpl());
+        PeriodoController periodoController = new PeriodoController(new PeriodoDaoNativeImpl());
+        mov.setUsuario(TestUtils.getRandom(usuarioController.listar()));
+        mov.setCaixa(TestUtils.getRandom(caixaController.listar()));
+        mov.setPeriodo(TestUtils.getRandom(periodoController.listar()));
         controller.criar(mov);
 
         // Recuperar movimentação persistida e atualizar
@@ -42,9 +54,9 @@ public class MovimentacaoControllerTest {
         controller.buscarPorTipo(1);
         controller.buscarPorStatus(1);
         controller.buscarPorPonto(10);
-        controller.buscarPorIdUsuario(1);
-        controller.buscarPorIdCaixa(1);
-        controller.buscarPorIdPeriodo(1);
+        controller.buscarPorIdUsuario(mov.getUsuario().getIdUsuario());
+        controller.buscarPorIdCaixa(mov.getCaixa().getIdCaixa());
+        controller.buscarPorIdPeriodo(mov.getPeriodo().getIdPeriodo());
         controller.pesquisar(mov);
         controller.pesquisar(mov, 0, 10);
 

--- a/src/main/java/test/OperacaoControllerTest.java
+++ b/src/main/java/test/OperacaoControllerTest.java
@@ -3,6 +3,10 @@ package test;
 import controller.OperacaoController;
 import dao.impl.OperacaoDaoNativeImpl;
 import model.Operacao;
+import controller.CarteiraController;
+import controller.PapelController;
+import dao.impl.CarteiraDaoNativeImpl;
+import dao.impl.PapelDaoNativeImpl;
 
 import java.math.BigDecimal;
 import java.time.LocalTime;
@@ -31,8 +35,10 @@ public class OperacaoControllerTest {
         op.setPerdaMax(BigDecimal.ONE);
         op.setTet("tet");
         op.setTotal(BigDecimal.ONE);
-        op.setIdCarteira(1);
-        op.setIdPapel(1);
+        CarteiraController carteiraController = new CarteiraController(new CarteiraDaoNativeImpl());
+        PapelController papelController = new PapelController(new PapelDaoNativeImpl());
+        op.setIdCarteira(TestUtils.getRandom(carteiraController.listar()).getIdCarteira());
+        op.setIdPapel(TestUtils.getRandom(papelController.listar()).getIdPapel());
         controller.criar(op);
 
         List<Operacao> list = controller.listar();

--- a/src/main/java/test/RotinaPeriodoControllerTest.java
+++ b/src/main/java/test/RotinaPeriodoControllerTest.java
@@ -3,6 +3,10 @@ package test;
 import controller.RotinaPeriodoController;
 import dao.impl.RotinaPeriodoDaoNativeImpl;
 import model.RotinaPeriodo;
+import controller.RotinaController;
+import controller.PeriodoController;
+import dao.impl.RotinaDaoNativeImpl;
+import dao.impl.PeriodoDaoNativeImpl;
 
 import java.util.List;
 
@@ -12,8 +16,10 @@ public class RotinaPeriodoControllerTest {
         RotinaPeriodoController controller = new RotinaPeriodoController(dao);
 
         RotinaPeriodo rp = new RotinaPeriodo();
-        rp.setIdRotina(1);
-        rp.setIdPeriodo(1);
+        RotinaController rotinaController = new RotinaController(new RotinaDaoNativeImpl());
+        PeriodoController periodoController = new PeriodoController(new PeriodoDaoNativeImpl());
+        rp.setIdRotina(TestUtils.getRandom(rotinaController.listar()).getIdRotina());
+        rp.setIdPeriodo(TestUtils.getRandom(periodoController.listar()).getIdPeriodo());
         controller.criar(rp);
 
         List<RotinaPeriodo> list = controller.listar();

--- a/src/main/java/test/SiteObjetoControllerTest.java
+++ b/src/main/java/test/SiteObjetoControllerTest.java
@@ -3,6 +3,10 @@ package test;
 import controller.SiteObjetoController;
 import dao.impl.SiteObjetoDaoNativeImpl;
 import model.SiteObjeto;
+import controller.SiteController;
+import controller.ObjetoController;
+import dao.impl.SiteDaoNativeImpl;
+import dao.impl.ObjetoDaoNativeImpl;
 
 import java.util.List;
 
@@ -12,8 +16,10 @@ public class SiteObjetoControllerTest {
         SiteObjetoController controller = new SiteObjetoController(dao);
 
         SiteObjeto so = new SiteObjeto();
-        so.setIdSite(1);
-        so.setIdObjeto(1);
+        SiteController siteController = new SiteController(new SiteDaoNativeImpl());
+        ObjetoController objetoController = new ObjetoController(new ObjetoDaoNativeImpl());
+        so.setIdSite(TestUtils.getRandom(siteController.listar()).getIdSite());
+        so.setIdObjeto(TestUtils.getRandom(objetoController.listar()).getIdObjeto());
         controller.criar(so);
 
         List<SiteObjeto> list = controller.listar();

--- a/src/main/java/test/TestUtils.java
+++ b/src/main/java/test/TestUtils.java
@@ -1,0 +1,28 @@
+package test;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Utility methods for test classes.
+ */
+public final class TestUtils {
+    private TestUtils() {
+    }
+
+    /**
+     * Returns a random element from the given list.
+     *
+     * @param list list of elements
+     * @param <T>  element type
+     * @return a random element from list
+     * @throws IllegalStateException if list is null or empty
+     */
+    public static <T> T getRandom(List<T> list) {
+        if (list == null || list.isEmpty()) {
+            throw new IllegalStateException("Lista vazia");
+        }
+        int index = ThreadLocalRandom.current().nextInt(list.size());
+        return list.get(index);
+    }
+}

--- a/src/main/java/test/TreinoControllerTest.java
+++ b/src/main/java/test/TreinoControllerTest.java
@@ -3,6 +3,8 @@ package test;
 import controller.TreinoController;
 import dao.impl.TreinoDaoNativeImpl;
 import model.Treino;
+import controller.RotinaController;
+import dao.impl.RotinaDaoNativeImpl;
 
 import java.util.List;
 
@@ -20,7 +22,8 @@ public class TreinoControllerTest {
         Treino treino = new Treino();
         treino.setNome("Treino A");
         treino.setClasse("Força");
-        treino.setIdRotina(1);
+        RotinaController rotinaController = new RotinaController(new RotinaDaoNativeImpl());
+        treino.setIdRotina(TestUtils.getRandom(rotinaController.listar()).getIdRotina());
         controller.criar(treino);
 
         // Recuperar treino persistido e atualizar
@@ -34,7 +37,7 @@ public class TreinoControllerTest {
         controller.listar(0, 10);
         controller.buscarPorNome("Treino");
         controller.buscarPorClasse("Força");
-        controller.buscarPorIdRotina(1);
+        controller.buscarPorIdRotina(treino.getIdRotina());
         controller.pesquisar(treino);
         controller.pesquisar(treino, 0, 10);
 

--- a/src/main/java/test/TreinoExercicioControllerTest.java
+++ b/src/main/java/test/TreinoExercicioControllerTest.java
@@ -3,6 +3,10 @@ package test;
 import controller.TreinoExercicioController;
 import dao.impl.TreinoExercicioDaoNativeImpl;
 import model.TreinoExercicio;
+import controller.ExercicioController;
+import controller.TreinoController;
+import dao.impl.ExercicioDaoNativeImpl;
+import dao.impl.TreinoDaoNativeImpl;
 
 import java.util.List;
 
@@ -16,8 +20,10 @@ public class TreinoExercicioControllerTest {
         te.setTempoDescanso("1m");
         te.setOrdem(1);
         te.setFeito(Boolean.FALSE);
-        te.setIdExercicio(1);
-        te.setIdTreino(1);
+        ExercicioController exercicioController = new ExercicioController(new ExercicioDaoNativeImpl());
+        TreinoController treinoController = new TreinoController(new TreinoDaoNativeImpl());
+        te.setIdExercicio(TestUtils.getRandom(exercicioController.listar()).getIdExercicio());
+        te.setIdTreino(TestUtils.getRandom(treinoController.listar()).getIdTreino());
         controller.criar(te);
 
         List<TreinoExercicio> list = controller.listar();


### PR DESCRIPTION
## Summary
- adiciona utilitário TestUtils para obter registros aleatórios
- atualiza testes com relacionamentos para buscar entidades existentes antes de criar

## Testing
- `mvn -q -e -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c0723d61248325af44758207ae694b