### PR TITLE
Reset entity ids before persisting to avoid detached entity errors

### DIFF
--- a/src/main/java/dao/impl/AlimentacaoIngredienteDaoNativeImpl.java
+++ b/src/main/java/dao/impl/AlimentacaoIngredienteDaoNativeImpl.java
@@ -17,6 +17,7 @@ public class AlimentacaoIngredienteDaoNativeImpl implements AlimentacaoIngredien
     public void create(AlimentacaoIngrediente e) {
         Logger.info("AlimentacaoIngredienteDaoNativeImpl.create");
         em.getTransaction().begin();
+        e.setIdAlimentacaoIngrediente(null);
         em.persist(e);
         em.getTransaction().commit();
     }

--- a/src/main/java/dao/impl/CarteiraDaoNativeImpl.java
+++ b/src/main/java/dao/impl/CarteiraDaoNativeImpl.java
@@ -18,6 +18,7 @@ public class CarteiraDaoNativeImpl implements CarteiraDao {
     public void create(Carteira e) {
         Logger.info("CarteiraDaoNativeImpl.create");
         em.getTransaction().begin();
+        e.setIdCarteira(null);
         em.persist(e);
         em.getTransaction().commit();
     }

--- a/src/main/java/dao/impl/CofreDaoNativeImpl.java
+++ b/src/main/java/dao/impl/CofreDaoNativeImpl.java
@@ -17,6 +17,7 @@ public class CofreDaoNativeImpl implements CofreDao {
     public void create(Cofre c) {
         Logger.info("CofreDao.create");
         em.getTransaction().begin();
+        c.setIdCofre(null);
         em.persist(c);
         em.getTransaction().commit();
     }

--- a/src/main/java/dao/impl/IngredienteFornecedorDaoNativeImpl.java
+++ b/src/main/java/dao/impl/IngredienteFornecedorDaoNativeImpl.java
@@ -19,6 +19,7 @@ public class IngredienteFornecedorDaoNativeImpl implements IngredienteFornecedor
     public void create(IngredienteFornecedor e) {
         Logger.info("IngredienteFornecedorDaoNativeImpl.create");
         em.getTransaction().begin();
+        e.setIdFornecedorIngrediente(null);
         em.persist(e);
         em.getTransaction().commit();
     }

--- a/src/main/java/dao/impl/MetaDaoNativeImpl.java
+++ b/src/main/java/dao/impl/MetaDaoNativeImpl.java
@@ -17,6 +17,7 @@ public class MetaDaoNativeImpl implements MetaDao {
     public void create(Meta meta) {
         Logger.info("MetaDao.create");
         em.getTransaction().begin();
+        meta.setIdMeta(null);
         em.persist(meta);
         em.getTransaction().commit();
     }

--- a/src/main/java/dao/impl/MonitoramentoObjetoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/MonitoramentoObjetoDaoNativeImpl.java
@@ -18,6 +18,7 @@ public class MonitoramentoObjetoDaoNativeImpl implements MonitoramentoObjetoDao 
     public void create(MonitoramentoObjeto e) {
         Logger.info("MonitoramentoObjetoDaoNativeImpl.create");
         em.getTransaction().begin();
+        e.setIdMonitoramentoObjeto(null);
         em.persist(e);
         em.getTransaction().commit();
     }

--- a/src/main/java/dao/impl/OperacaoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/OperacaoDaoNativeImpl.java
@@ -19,6 +19,7 @@ public class OperacaoDaoNativeImpl implements OperacaoDao {
     public void create(Operacao e) {
         Logger.info("OperacaoDaoNativeImpl.create");
         em.getTransaction().begin();
+        e.setIdOperacao(null);
         em.persist(e);
         em.getTransaction().commit();
     }

--- a/src/main/java/dao/impl/PapelDaoNativeImpl.java
+++ b/src/main/java/dao/impl/PapelDaoNativeImpl.java
@@ -18,6 +18,7 @@ public class PapelDaoNativeImpl implements PapelDao {
     public void create(Papel e) {
         Logger.info("PapelDaoNativeImpl.create");
         em.getTransaction().begin();
+        e.setIdPapel(null);
         em.persist(e);
         em.getTransaction().commit();
     }

--- a/src/main/java/dao/impl/RotinaPeriodoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/RotinaPeriodoDaoNativeImpl.java
@@ -17,6 +17,7 @@ public class RotinaPeriodoDaoNativeImpl implements RotinaPeriodoDao {
     public void create(RotinaPeriodo e) {
         Logger.info("RotinaPeriodoDaoNativeImpl.create");
         em.getTransaction().begin();
+        e.setIdRotinaPeriodo(null);
         em.persist(e);
         em.getTransaction().commit();
     }

--- a/src/main/java/dao/impl/SiteObjetoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/SiteObjetoDaoNativeImpl.java
@@ -17,6 +17,7 @@ public class SiteObjetoDaoNativeImpl implements SiteObjetoDao {
     public void create(SiteObjeto e) {
         Logger.info("SiteObjetoDaoNativeImpl.create");
         em.getTransaction().begin();
+        e.setIdSiteObjeto(null);
         em.persist(e);
         em.getTransaction().commit();
     }

--- a/src/main/java/dao/impl/TreinoExercicioDaoNativeImpl.java
+++ b/src/main/java/dao/impl/TreinoExercicioDaoNativeImpl.java
@@ -17,6 +17,7 @@ public class TreinoExercicioDaoNativeImpl implements TreinoExercicioDao {
     public void create(TreinoExercicio e) {
         Logger.info("TreinoExercicioDaoNativeImpl.create");
         em.getTransaction().begin();
+        e.setIdTreinoExercicio(null);
         em.persist(e);
         em.getTransaction().commit();
     }


### PR DESCRIPTION
## Summary
- Clear entity identifiers in all JPA DAO `create` methods before calling `persist`
- Prevents `detached entity passed to persist` when reusing domain objects after deletion

## Testing
- `mvn -q -e compile` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68c07447a40c8325a19014a4632e9dfa