### PR TITLE
fix: avoid resultset column error for binary fields

### DIFF
--- a/src/main/java/model/Alimentacao.java
+++ b/src/main/java/model/Alimentacao.java
@@ -8,7 +8,6 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
-import javax.persistence.Lob;
 import javax.persistence.Table;
 
 @Entity
@@ -29,7 +28,6 @@ public class Alimentacao {
     @Column(name = "link")
     private String link;
 
-    @Lob
     @Column(name = "video")
     private byte[] video;
 

--- a/src/main/java/model/Categoria.java
+++ b/src/main/java/model/Categoria.java
@@ -11,7 +11,6 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
-import javax.persistence.Lob;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
@@ -30,7 +29,6 @@ public class Categoria {
     @Column(name = "descricao")
     private String descricao;
 
-    @Lob
     @Column(name = "foto")
     private byte[] foto;
 

--- a/src/main/java/model/Documento.java
+++ b/src/main/java/model/Documento.java
@@ -9,7 +9,6 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
-import javax.persistence.Lob;
 import javax.persistence.Table;
 
 @Entity
@@ -24,15 +23,12 @@ public class Documento {
     @Column(name = "nome")
     private String nome;
 
-    @Lob
     @Column(name = "arquivo")
     private byte[] arquivo;
 
-    @Lob
     @Column(name = "foto")
     private byte[] foto;
 
-    @Lob
     @Column(name = "video")
     private byte[] video;
 

--- a/src/main/java/model/Evento.java
+++ b/src/main/java/model/Evento.java
@@ -13,7 +13,6 @@ import javax.persistence.Id;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.JoinColumn;
-import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
@@ -30,7 +29,6 @@ public class Evento {
     @Column(name = "vantagem")
     private Boolean vantagem;
 
-    @Lob
     @Column(name = "foto")
     private byte[] foto;
 

--- a/src/main/java/model/Fornecedor.java
+++ b/src/main/java/model/Fornecedor.java
@@ -8,7 +8,6 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
-import javax.persistence.Lob;
 import javax.persistence.Table;
 
 @Entity
@@ -23,7 +22,6 @@ public class Fornecedor {
     @Column(name = "nome")
     private String nome;
 
-    @Lob
     @Column(name = "foto")
     private byte[] foto;
 

--- a/src/main/java/model/Ingrediente.java
+++ b/src/main/java/model/Ingrediente.java
@@ -8,14 +8,12 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
-import javax.persistence.Lob;
 import javax.persistence.Table;
 
 @Entity
 @Table(name = "Ingrediente", schema = "rotinamais")
 public class Ingrediente {
 
-    @Lob
     @Column(name = "foto")
     private byte[] foto;
 

--- a/src/main/java/model/Meta.java
+++ b/src/main/java/model/Meta.java
@@ -24,7 +24,6 @@ public class Meta {
     @Column(name = "status")
     private Integer status;
 
-    @Lob
     @Column(name = "foto")
     private byte[] foto;
 

--- a/src/main/java/model/Monitoramento.java
+++ b/src/main/java/model/Monitoramento.java
@@ -8,7 +8,6 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
-import javax.persistence.Lob;
 import javax.persistence.Table;
 
 @Entity
@@ -29,7 +28,6 @@ public class Monitoramento {
     @Column(name = "descricao")
     private String descricao;
 
-    @Lob
     @Column(name = "foto")
     private byte[] foto;
 

--- a/src/main/java/model/Objeto.java
+++ b/src/main/java/model/Objeto.java
@@ -9,7 +9,6 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
-import javax.persistence.Lob;
 import javax.persistence.Table;
 
 @Entity
@@ -33,7 +32,6 @@ public class Objeto {
     @Column(name = "descricao")
     private String descricao;
 
-    @Lob
     @Column(name = "foto")
     private byte[] foto;
 

--- a/src/main/java/model/Site.java
+++ b/src/main/java/model/Site.java
@@ -8,7 +8,6 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
-import javax.persistence.Lob;
 import javax.persistence.Table;
 
 @Entity
@@ -26,7 +25,6 @@ public class Site {
     @Column(name = "ativo")
     private Boolean ativo;
 
-    @Lob
     @Column(name = "logo")
     private byte[] logo;
 

--- a/src/main/java/model/Usuario.java
+++ b/src/main/java/model/Usuario.java
@@ -10,7 +10,6 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
-import javax.persistence.Lob;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
@@ -29,7 +28,6 @@ public class Usuario {
     @Column(name = "senha")
     private String senha;
 
-    @Lob
     @Column(name = "foto")
     private byte[] foto;
 


### PR DESCRIPTION
## Summary
- remove `@Lob` annotations from all entity byte-array columns to prevent Hibernate from failing to locate unused columns

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c07d2683108325a14acba5553aa165