### PR TITLE
Bind nullable foreign keys as INTEGER in native queries

### DIFF
--- a/src/main/java/dao/impl/AlimentacaoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/AlimentacaoDaoNativeImpl.java
@@ -12,6 +12,8 @@ import infra.Logger;
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
 import model.Alimentacao;
+import org.hibernate.query.NativeQuery;
+import org.hibernate.type.StandardBasicTypes;
 
 public class AlimentacaoDaoNativeImpl implements AlimentacaoDao {
 
@@ -23,13 +25,14 @@ public class AlimentacaoDaoNativeImpl implements AlimentacaoDao {
             em.getTransaction().begin();
             String sql = "INSERT INTO Alimentacao (status, nome, link, video, preparo, id_rotina) " +
                     "VALUES (:status, :nome, :link, :video, :preparo, CAST(:idRotina AS INTEGER))";
-            Query query = em.createNativeQuery(sql);
+            NativeQuery<?> query = (NativeQuery<?>) em.createNativeQuery(sql);
             query.setParameter("status", alimentacao.getStatus());
             query.setParameter("nome", alimentacao.getNome());
             query.setParameter("link", alimentacao.getLink());
             query.setParameter("video", alimentacao.getVideo());
             query.setParameter("preparo", alimentacao.getPreparo());
-            query.setParameter("idRotina", alimentacao.getIdRotina());
+            Integer idRotina = alimentacao.getIdRotina();
+            query.setParameter("idRotina", idRotina, StandardBasicTypes.INTEGER);
             query.executeUpdate();
             em.getTransaction().commit();
             Logger.info("AlimentacaoDaoNativeImpl.create - sucesso");
@@ -49,13 +52,14 @@ public class AlimentacaoDaoNativeImpl implements AlimentacaoDao {
         try {
             em.getTransaction().begin();
             String sql = "UPDATE Alimentacao SET status=:status, nome=:nome, link=:link, video=:video, preparo=:preparo, id_rotina=CAST(:idRotina AS INTEGER) WHERE id_alimentacao=:id";
-            Query query = em.createNativeQuery(sql);
+            NativeQuery<?> query = (NativeQuery<?>) em.createNativeQuery(sql);
             query.setParameter("status", alimentacao.getStatus());
             query.setParameter("nome", alimentacao.getNome());
             query.setParameter("link", alimentacao.getLink());
             query.setParameter("video", alimentacao.getVideo());
             query.setParameter("preparo", alimentacao.getPreparo());
-            query.setParameter("idRotina", alimentacao.getIdRotina());
+            Integer idRotina = alimentacao.getIdRotina();
+            query.setParameter("idRotina", idRotina, StandardBasicTypes.INTEGER);
             query.setParameter("id", alimentacao.getIdAlimentacao());
             int updated = query.executeUpdate();
             if (updated == 0) {

--- a/src/main/java/dao/impl/CaixaDaoNativeImpl.java
+++ b/src/main/java/dao/impl/CaixaDaoNativeImpl.java
@@ -13,6 +13,8 @@ import infra.Logger;
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
 import model.Caixa;
+import org.hibernate.query.NativeQuery;
+import org.hibernate.type.StandardBasicTypes;
 
 public class CaixaDaoNativeImpl implements CaixaDao {
 
@@ -26,12 +28,13 @@ public class CaixaDaoNativeImpl implements CaixaDao {
             // Ao efetuar o CAST para INTEGER garantimos que o JDBC defina o tipo correto
             // mesmo quando o id do usuário for nulo, evitando o erro "column is of type integer but expression is of type bytea".
             String sql = "INSERT INTO Caixa (nome, reserva_emergencia, salario_medio, valor_total, id_usuario) VALUES (:nome, :reserva, :salario, :valor, CAST(:idUsuario AS INTEGER))";
-            Query query = em.createNativeQuery(sql);
+            NativeQuery<?> query = (NativeQuery<?>) em.createNativeQuery(sql);
             query.setParameter("nome", caixa.getNome());
             query.setParameter("reserva", caixa.getReservaEmergencia());
             query.setParameter("salario", caixa.getSalarioMedio());
             query.setParameter("valor", caixa.getValorTotal());
-            query.setParameter("idUsuario", caixa.getUsuario() != null ? caixa.getUsuario().getIdUsuario() : null);
+            Integer idUsuario = caixa.getUsuario() != null ? caixa.getUsuario().getIdUsuario() : null;
+            query.setParameter("idUsuario", idUsuario, StandardBasicTypes.INTEGER);
             query.executeUpdate();
             em.getTransaction().commit();
             Logger.info("CaixaDaoNativeImpl.create - sucesso");
@@ -52,12 +55,13 @@ public class CaixaDaoNativeImpl implements CaixaDao {
             em.getTransaction().begin();
             // Aplicar o mesmo CAST na atualização para evitar problemas de tipagem quando o usuário for nulo
             String sql = "UPDATE Caixa SET nome=:nome, reserva_emergencia=:reserva, salario_medio=:salario, valor_total=:valor, id_usuario=CAST(:idUsuario AS INTEGER) WHERE id_caixa=:id";
-            Query query = em.createNativeQuery(sql);
+            NativeQuery<?> query = (NativeQuery<?>) em.createNativeQuery(sql);
             query.setParameter("nome", caixa.getNome());
             query.setParameter("reserva", caixa.getReservaEmergencia());
             query.setParameter("salario", caixa.getSalarioMedio());
             query.setParameter("valor", caixa.getValorTotal());
-            query.setParameter("idUsuario", caixa.getUsuario() != null ? caixa.getUsuario().getIdUsuario() : null);
+            Integer idUsuario = caixa.getUsuario() != null ? caixa.getUsuario().getIdUsuario() : null;
+            query.setParameter("idUsuario", idUsuario, StandardBasicTypes.INTEGER);
             query.setParameter("id", caixa.getIdCaixa());
             int updated = query.executeUpdate();
             if (updated == 0) {

--- a/src/main/java/dao/impl/DocumentoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/DocumentoDaoNativeImpl.java
@@ -12,6 +12,8 @@ import infra.Logger;
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
 import model.Documento;
+import org.hibernate.query.NativeQuery;
+import org.hibernate.type.StandardBasicTypes;
 
 public class DocumentoDaoNativeImpl implements DocumentoDao {
 
@@ -23,13 +25,14 @@ public class DocumentoDaoNativeImpl implements DocumentoDao {
             em.getTransaction().begin();
             String sql = "INSERT INTO Documento (nome, arquivo, foto, video, data, id_usuario) " +
                     "VALUES (:nome, :arquivo, :foto, :video, :data, CAST(:idUsuario AS INTEGER))";
-            Query query = em.createNativeQuery(sql);
+            NativeQuery<?> query = (NativeQuery<?>) em.createNativeQuery(sql);
             query.setParameter("nome", documento.getNome());
             query.setParameter("arquivo", documento.getArquivo());
             query.setParameter("foto", documento.getFoto());
             query.setParameter("video", documento.getVideo());
             query.setParameter("data", documento.getData());
-            query.setParameter("idUsuario", documento.getIdUsuario());
+            Integer idUsuario = documento.getIdUsuario();
+            query.setParameter("idUsuario", idUsuario, StandardBasicTypes.INTEGER);
             query.executeUpdate();
             em.getTransaction().commit();
             Logger.info("DocumentoDaoNativeImpl.create - sucesso");
@@ -49,13 +52,14 @@ public class DocumentoDaoNativeImpl implements DocumentoDao {
         try {
             em.getTransaction().begin();
             String sql = "UPDATE Documento SET nome=:nome, arquivo=:arquivo, foto=:foto, video=:video, data=:data, id_usuario=CAST(:idUsuario AS INTEGER) WHERE id_documento=:id";
-            Query query = em.createNativeQuery(sql);
+            NativeQuery<?> query = (NativeQuery<?>) em.createNativeQuery(sql);
             query.setParameter("nome", documento.getNome());
             query.setParameter("arquivo", documento.getArquivo());
             query.setParameter("foto", documento.getFoto());
             query.setParameter("video", documento.getVideo());
             query.setParameter("data", documento.getData());
-            query.setParameter("idUsuario", documento.getIdUsuario());
+            Integer idUsuario = documento.getIdUsuario();
+            query.setParameter("idUsuario", idUsuario, StandardBasicTypes.INTEGER);
             query.setParameter("id", documento.getIdDocumento());
             int updated = query.executeUpdate();
             if (updated == 0) {

--- a/src/main/java/dao/impl/EventoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/EventoDaoNativeImpl.java
@@ -12,6 +12,8 @@ import infra.Logger;
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
 import model.Evento;
+import org.hibernate.query.NativeQuery;
+import org.hibernate.type.StandardBasicTypes;
 
 public class EventoDaoNativeImpl implements EventoDao {
 
@@ -23,13 +25,14 @@ public class EventoDaoNativeImpl implements EventoDao {
             em.getTransaction().begin();
             String sql = "INSERT INTO Evento (vantagem, foto, nome, descricao, data_criacao, id_categoria) " +
                     "VALUES (:vantagem, :foto, :nome, :descricao, :dataCriacao, CAST(:idCategoria AS INTEGER))";
-            Query query = em.createNativeQuery(sql);
+            NativeQuery<?> query = (NativeQuery<?>) em.createNativeQuery(sql);
             query.setParameter("vantagem", evento.getVantagem());
             query.setParameter("foto", evento.getFoto());
             query.setParameter("nome", evento.getNome());
             query.setParameter("descricao", evento.getDescricao());
             query.setParameter("dataCriacao", evento.getDataCriacao());
-            query.setParameter("idCategoria", evento.getCategoria() != null ? evento.getCategoria().getIdCategoria() : null);
+            Integer idCategoria = evento.getCategoria() != null ? evento.getCategoria().getIdCategoria() : null;
+            query.setParameter("idCategoria", idCategoria, StandardBasicTypes.INTEGER);
             query.executeUpdate();
             em.getTransaction().commit();
             Logger.info("EventoDaoNativeImpl.create - sucesso");
@@ -50,13 +53,14 @@ public class EventoDaoNativeImpl implements EventoDao {
             em.getTransaction().begin();
             String sql = "UPDATE Evento SET vantagem=:vantagem, foto=:foto, nome=:nome, descricao=:descricao, " +
                     "data_criacao=:dataCriacao, id_categoria=CAST(:idCategoria AS INTEGER) WHERE id_evento=:id";
-            Query query = em.createNativeQuery(sql);
+            NativeQuery<?> query = (NativeQuery<?>) em.createNativeQuery(sql);
             query.setParameter("vantagem", evento.getVantagem());
             query.setParameter("foto", evento.getFoto());
             query.setParameter("nome", evento.getNome());
             query.setParameter("descricao", evento.getDescricao());
             query.setParameter("dataCriacao", evento.getDataCriacao());
-            query.setParameter("idCategoria", evento.getCategoria() != null ? evento.getCategoria().getIdCategoria() : null);
+            Integer idCategoria = evento.getCategoria() != null ? evento.getCategoria().getIdCategoria() : null;
+            query.setParameter("idCategoria", idCategoria, StandardBasicTypes.INTEGER);
             query.setParameter("id", evento.getIdEvento());
             int updated = query.executeUpdate();
             if (updated == 0) {

--- a/src/main/java/dao/impl/LancamentoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/LancamentoDaoNativeImpl.java
@@ -12,6 +12,8 @@ import infra.Logger;
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
 import model.Lancamento;
+import org.hibernate.query.NativeQuery;
+import org.hibernate.type.StandardBasicTypes;
 
 public class LancamentoDaoNativeImpl implements LancamentoDao {
 
@@ -23,13 +25,15 @@ public class LancamentoDaoNativeImpl implements LancamentoDao {
             em.getTransaction().begin();
             String sql = "INSERT INTO Lancamento (valor, fixo, data_pagamento, status, id_movimentacao, id_evento) " +
                     "VALUES (:valor, :fixo, :dataPagamento, :status, CAST(:idMovimentacao AS INTEGER), CAST(:idEvento AS INTEGER))";
-            Query query = em.createNativeQuery(sql);
+            NativeQuery<?> query = (NativeQuery<?>) em.createNativeQuery(sql);
             query.setParameter("valor", lancamento.getValor());
             query.setParameter("fixo", lancamento.getFixo());
             query.setParameter("dataPagamento", lancamento.getDataPagamento());
             query.setParameter("status", lancamento.getStatus());
-            query.setParameter("idMovimentacao", lancamento.getMovimentacao() != null ? lancamento.getMovimentacao().getIdMovimentacao() : null);
-            query.setParameter("idEvento", lancamento.getEvento() != null ? lancamento.getEvento().getIdEvento() : null);
+            Integer idMovimentacao = lancamento.getMovimentacao() != null ? lancamento.getMovimentacao().getIdMovimentacao() : null;
+            Integer idEvento = lancamento.getEvento() != null ? lancamento.getEvento().getIdEvento() : null;
+            query.setParameter("idMovimentacao", idMovimentacao, StandardBasicTypes.INTEGER);
+            query.setParameter("idEvento", idEvento, StandardBasicTypes.INTEGER);
             query.executeUpdate();
             em.getTransaction().commit();
             Logger.info("LancamentoDaoNativeImpl.create - sucesso");
@@ -50,13 +54,15 @@ public class LancamentoDaoNativeImpl implements LancamentoDao {
             em.getTransaction().begin();
             String sql = "UPDATE Lancamento SET valor=:valor, fixo=:fixo, data_pagamento=:dataPagamento, status=:status, " +
                     "id_movimentacao=CAST(:idMovimentacao AS INTEGER), id_evento=CAST(:idEvento AS INTEGER) WHERE id_lancamento=:id";
-            Query query = em.createNativeQuery(sql);
+            NativeQuery<?> query = (NativeQuery<?>) em.createNativeQuery(sql);
             query.setParameter("valor", lancamento.getValor());
             query.setParameter("fixo", lancamento.getFixo());
             query.setParameter("dataPagamento", lancamento.getDataPagamento());
             query.setParameter("status", lancamento.getStatus());
-            query.setParameter("idMovimentacao", lancamento.getMovimentacao() != null ? lancamento.getMovimentacao().getIdMovimentacao() : null);
-            query.setParameter("idEvento", lancamento.getEvento() != null ? lancamento.getEvento().getIdEvento() : null);
+            Integer idMovimentacao = lancamento.getMovimentacao() != null ? lancamento.getMovimentacao().getIdMovimentacao() : null;
+            Integer idEvento = lancamento.getEvento() != null ? lancamento.getEvento().getIdEvento() : null;
+            query.setParameter("idMovimentacao", idMovimentacao, StandardBasicTypes.INTEGER);
+            query.setParameter("idEvento", idEvento, StandardBasicTypes.INTEGER);
             query.setParameter("id", lancamento.getIdLancamento());
             int updated = query.executeUpdate();
             if (updated == 0) {

--- a/src/main/java/dao/impl/MonitoramentoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/MonitoramentoDaoNativeImpl.java
@@ -12,6 +12,8 @@ import infra.Logger;
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
 import model.Monitoramento;
+import org.hibernate.query.NativeQuery;
+import org.hibernate.type.StandardBasicTypes;
 
 public class MonitoramentoDaoNativeImpl implements MonitoramentoDao {
 
@@ -23,12 +25,13 @@ public class MonitoramentoDaoNativeImpl implements MonitoramentoDao {
             em.getTransaction().begin();
             String sql = "INSERT INTO Monitoramento (status, nome, descricao, foto, id_periodo) " +
                     "VALUES (:status, :nome, :descricao, :foto, CAST(:idPeriodo AS INTEGER))";
-            Query query = em.createNativeQuery(sql);
+            NativeQuery<?> query = (NativeQuery<?>) em.createNativeQuery(sql);
             query.setParameter("status", monitoramento.getStatus());
             query.setParameter("nome", monitoramento.getNome());
             query.setParameter("descricao", monitoramento.getDescricao());
             query.setParameter("foto", monitoramento.getFoto());
-            query.setParameter("idPeriodo", monitoramento.getIdPeriodo());
+            Integer idPeriodo = monitoramento.getIdPeriodo();
+            query.setParameter("idPeriodo", idPeriodo, StandardBasicTypes.INTEGER);
             query.executeUpdate();
             em.getTransaction().commit();
             Logger.info("MonitoramentoDaoNativeImpl.create - sucesso");
@@ -48,12 +51,13 @@ public class MonitoramentoDaoNativeImpl implements MonitoramentoDao {
         try {
             em.getTransaction().begin();
             String sql = "UPDATE Monitoramento SET status=:status, nome=:nome, descricao=:descricao, foto=:foto, id_periodo=CAST(:idPeriodo AS INTEGER) WHERE id_monitoramento=:id";
-            Query query = em.createNativeQuery(sql);
+            NativeQuery<?> query = (NativeQuery<?>) em.createNativeQuery(sql);
             query.setParameter("status", monitoramento.getStatus());
             query.setParameter("nome", monitoramento.getNome());
             query.setParameter("descricao", monitoramento.getDescricao());
             query.setParameter("foto", monitoramento.getFoto());
-            query.setParameter("idPeriodo", monitoramento.getIdPeriodo());
+            Integer idPeriodo = monitoramento.getIdPeriodo();
+            query.setParameter("idPeriodo", idPeriodo, StandardBasicTypes.INTEGER);
             query.setParameter("id", monitoramento.getIdMonitoramento());
             int updated = query.executeUpdate();
             if (updated == 0) {

--- a/src/main/java/dao/impl/MovimentacaoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/MovimentacaoDaoNativeImpl.java
@@ -13,6 +13,8 @@ import infra.Logger;
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
 import model.Movimentacao;
+import org.hibernate.query.NativeQuery;
+import org.hibernate.type.StandardBasicTypes;
 
 public class MovimentacaoDaoNativeImpl implements MovimentacaoDao {
 
@@ -24,16 +26,19 @@ public class MovimentacaoDaoNativeImpl implements MovimentacaoDao {
             em.getTransaction().begin();
             String sql = "INSERT INTO Movimentacao (desconto, vantagem, liquido, tipo, status, ponto, id_usuario, id_caixa, id_periodo) " +
                     "VALUES (:desconto, :vantagem, :liquido, :tipo, :status, :ponto, CAST(:idUsuario AS INTEGER), CAST(:idCaixa AS INTEGER), CAST(:idPeriodo AS INTEGER))";
-            Query query = em.createNativeQuery(sql);
+            NativeQuery<?> query = (NativeQuery<?>) em.createNativeQuery(sql);
             query.setParameter("desconto", movimentacao.getDesconto());
             query.setParameter("vantagem", movimentacao.getVantagem());
             query.setParameter("liquido", movimentacao.getLiquido());
             query.setParameter("tipo", movimentacao.getTipo());
             query.setParameter("status", movimentacao.getStatus());
             query.setParameter("ponto", movimentacao.getPonto());
-            query.setParameter("idUsuario", movimentacao.getUsuario() != null ? movimentacao.getUsuario().getIdUsuario() : null);
-            query.setParameter("idCaixa", movimentacao.getCaixa() != null ? movimentacao.getCaixa().getIdCaixa() : null);
-            query.setParameter("idPeriodo", movimentacao.getPeriodo() != null ? movimentacao.getPeriodo().getIdPeriodo() : null);
+            Integer idUsuario = movimentacao.getUsuario() != null ? movimentacao.getUsuario().getIdUsuario() : null;
+            Integer idCaixa = movimentacao.getCaixa() != null ? movimentacao.getCaixa().getIdCaixa() : null;
+            Integer idPeriodo = movimentacao.getPeriodo() != null ? movimentacao.getPeriodo().getIdPeriodo() : null;
+            query.setParameter("idUsuario", idUsuario, StandardBasicTypes.INTEGER);
+            query.setParameter("idCaixa", idCaixa, StandardBasicTypes.INTEGER);
+            query.setParameter("idPeriodo", idPeriodo, StandardBasicTypes.INTEGER);
             query.executeUpdate();
             em.getTransaction().commit();
             Logger.info("MovimentacaoDaoNativeImpl.create - sucesso");
@@ -53,16 +58,19 @@ public class MovimentacaoDaoNativeImpl implements MovimentacaoDao {
         try {
             em.getTransaction().begin();
             String sql = "UPDATE Movimentacao SET desconto=:desconto, vantagem=:vantagem, liquido=:liquido, tipo=:tipo, status=:status, ponto=:ponto, id_usuario=CAST(:idUsuario AS INTEGER), id_caixa=CAST(:idCaixa AS INTEGER), id_periodo=CAST(:idPeriodo AS INTEGER) WHERE id_movimentacao=:id";
-            Query query = em.createNativeQuery(sql);
+            NativeQuery<?> query = (NativeQuery<?>) em.createNativeQuery(sql);
             query.setParameter("desconto", movimentacao.getDesconto());
             query.setParameter("vantagem", movimentacao.getVantagem());
             query.setParameter("liquido", movimentacao.getLiquido());
             query.setParameter("tipo", movimentacao.getTipo());
             query.setParameter("status", movimentacao.getStatus());
             query.setParameter("ponto", movimentacao.getPonto());
-            query.setParameter("idUsuario", movimentacao.getUsuario() != null ? movimentacao.getUsuario().getIdUsuario() : null);
-            query.setParameter("idCaixa", movimentacao.getCaixa() != null ? movimentacao.getCaixa().getIdCaixa() : null);
-            query.setParameter("idPeriodo", movimentacao.getPeriodo() != null ? movimentacao.getPeriodo().getIdPeriodo() : null);
+            Integer idUsuario = movimentacao.getUsuario() != null ? movimentacao.getUsuario().getIdUsuario() : null;
+            Integer idCaixa = movimentacao.getCaixa() != null ? movimentacao.getCaixa().getIdCaixa() : null;
+            Integer idPeriodo = movimentacao.getPeriodo() != null ? movimentacao.getPeriodo().getIdPeriodo() : null;
+            query.setParameter("idUsuario", idUsuario, StandardBasicTypes.INTEGER);
+            query.setParameter("idCaixa", idCaixa, StandardBasicTypes.INTEGER);
+            query.setParameter("idPeriodo", idPeriodo, StandardBasicTypes.INTEGER);
             query.setParameter("id", movimentacao.getIdMovimentacao());
             int updated = query.executeUpdate();
             if (updated == 0) {

--- a/src/main/java/dao/impl/RotinaDaoNativeImpl.java
+++ b/src/main/java/dao/impl/RotinaDaoNativeImpl.java
@@ -13,6 +13,8 @@ import infra.Logger;
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
 import model.Rotina;
+import org.hibernate.query.NativeQuery;
+import org.hibernate.type.StandardBasicTypes;
 
 public class RotinaDaoNativeImpl implements RotinaDao {
 
@@ -24,14 +26,15 @@ public class RotinaDaoNativeImpl implements RotinaDao {
             em.getTransaction().begin();
             String sql = "INSERT INTO Rotina (nome, inicio, fim, descricao, status, ponto, id_usuario) " +
                     "VALUES (:nome, :inicio, :fim, :descricao, :status, :ponto, CAST(:idUsuario AS INTEGER))";
-            Query query = em.createNativeQuery(sql);
+            NativeQuery<?> query = (NativeQuery<?>) em.createNativeQuery(sql);
             query.setParameter("nome", rotina.getNome());
             query.setParameter("inicio", rotina.getInicio());
             query.setParameter("fim", rotina.getFim());
             query.setParameter("descricao", rotina.getDescricao());
             query.setParameter("status", rotina.getStatus());
             query.setParameter("ponto", rotina.getPonto());
-            query.setParameter("idUsuario", rotina.getIdUsuario());
+            Integer idUsuario = rotina.getIdUsuario();
+            query.setParameter("idUsuario", idUsuario, StandardBasicTypes.INTEGER);
             query.executeUpdate();
             em.getTransaction().commit();
             Logger.info("RotinaDaoNativeImpl.create - sucesso");
@@ -51,14 +54,15 @@ public class RotinaDaoNativeImpl implements RotinaDao {
         try {
             em.getTransaction().begin();
             String sql = "UPDATE Rotina SET nome=:nome, inicio=:inicio, fim=:fim, descricao=:descricao, status=:status, ponto=:ponto, id_usuario=CAST(:idUsuario AS INTEGER) WHERE id_rotina=:id";
-            Query query = em.createNativeQuery(sql);
+            NativeQuery<?> query = (NativeQuery<?>) em.createNativeQuery(sql);
             query.setParameter("nome", rotina.getNome());
             query.setParameter("inicio", rotina.getInicio());
             query.setParameter("fim", rotina.getFim());
             query.setParameter("descricao", rotina.getDescricao());
             query.setParameter("status", rotina.getStatus());
             query.setParameter("ponto", rotina.getPonto());
-            query.setParameter("idUsuario", rotina.getIdUsuario());
+            Integer idUsuario = rotina.getIdUsuario();
+            query.setParameter("idUsuario", idUsuario, StandardBasicTypes.INTEGER);
             query.setParameter("id", rotina.getIdRotina());
             int updated = query.executeUpdate();
             if (updated == 0) {

--- a/src/main/java/dao/impl/TreinoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/TreinoDaoNativeImpl.java
@@ -12,6 +12,8 @@ import infra.Logger;
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
 import model.Treino;
+import org.hibernate.query.NativeQuery;
+import org.hibernate.type.StandardBasicTypes;
 
 public class TreinoDaoNativeImpl implements TreinoDao {
 
@@ -22,10 +24,11 @@ public class TreinoDaoNativeImpl implements TreinoDao {
         try {
             em.getTransaction().begin();
             String sql = "INSERT INTO Treino (nome, classe, id_rotina) VALUES (:nome, :classe, CAST(:idRotina AS INTEGER))";
-            Query query = em.createNativeQuery(sql);
+            NativeQuery<?> query = (NativeQuery<?>) em.createNativeQuery(sql);
             query.setParameter("nome", treino.getNome());
             query.setParameter("classe", treino.getClasse());
-            query.setParameter("idRotina", treino.getIdRotina());
+            Integer idRotina = treino.getIdRotina();
+            query.setParameter("idRotina", idRotina, StandardBasicTypes.INTEGER);
             query.executeUpdate();
             em.getTransaction().commit();
             Logger.info("TreinoDaoNativeImpl.create - sucesso");
@@ -45,10 +48,11 @@ public class TreinoDaoNativeImpl implements TreinoDao {
         try {
             em.getTransaction().begin();
             String sql = "UPDATE Treino SET nome=:nome, classe=:classe, id_rotina=CAST(:idRotina AS INTEGER) WHERE id_treino=:id";
-            Query query = em.createNativeQuery(sql);
+            NativeQuery<?> query = (NativeQuery<?>) em.createNativeQuery(sql);
             query.setParameter("nome", treino.getNome());
             query.setParameter("classe", treino.getClasse());
-            query.setParameter("idRotina", treino.getIdRotina());
+            Integer idRotina = treino.getIdRotina();
+            query.setParameter("idRotina", idRotina, StandardBasicTypes.INTEGER);
             query.setParameter("id", treino.getIdTreino());
             int updated = query.executeUpdate();
             if (updated == 0) {


### PR DESCRIPTION
## Summary
- Explicitly cast and bind nullable foreign key IDs as `INTEGER` in native DAO queries to prevent PostgreSQL from treating nulls as `bytea`.

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c082de629883258586254ebae78b16