### PR TITLE
Refactor DAO implementations to use JDBC

### DIFF
--- a/src/main/java/dao/impl/AlimentacaoIngredienteDaoNativeImpl.java
+++ b/src/main/java/dao/impl/AlimentacaoIngredienteDaoNativeImpl.java
@@ -2,82 +2,227 @@ package dao.impl;
 
 import dao.api.AlimentacaoIngredienteDao;
 import exception.AlimentacaoIngredienteException;
-import infra.EntityManagerUtil;
 import infra.Logger;
-import javax.persistence.EntityManager;
-import javax.persistence.Query;
 import model.AlimentacaoIngrediente;
 
+import conexao.ConnectionFactory;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * JDBC-based implementation of AlimentacaoIngredienteDao.
+ */
 public class AlimentacaoIngredienteDaoNativeImpl implements AlimentacaoIngredienteDao {
-    private final EntityManager em = EntityManagerUtil.getEntityManager();
+    private AlimentacaoIngrediente map(ResultSet rs) throws SQLException {
+        AlimentacaoIngrediente ai = new AlimentacaoIngrediente();
+        ai.setIdAlimentacaoIngrediente(rs.getInt("id_alimentacao_ingrediente"));
+        ai.setQuantidade(rs.getInt("quantidade"));
+        ai.setIdAlimentacao(rs.getInt("id_alimentacao"));
+        ai.setIdIngrediente(rs.getInt("id_ingrediente"));
+        return ai;
+    }
 
     @Override
     public void create(AlimentacaoIngrediente e) {
         Logger.info("AlimentacaoIngredienteDaoNativeImpl.create");
-        em.getTransaction().begin();
-        e.setIdAlimentacaoIngrediente(null);
-        em.persist(e);
-        em.getTransaction().commit();
+        String sql = "INSERT INTO Alimentacao_Ingrediente (quantidade, id_alimentacao, id_ingrediente) VALUES (?,?,?)";
+        Connection conn = null;
+        try {
+            conn = ConnectionFactory.getConnection();
+            conn.setAutoCommit(false);
+            try (PreparedStatement ps = conn.prepareStatement(sql)) {
+                ps.setInt(1, e.getQuantidade());
+                ps.setInt(2, e.getIdAlimentacao());
+                ps.setInt(3, e.getIdIngrediente());
+                ps.executeUpdate();
+            }
+            conn.commit();
+        } catch (SQLException ex) {
+            if (conn != null) {
+                try { conn.rollback(); } catch (SQLException ignore) { }
+            }
+            Logger.error("AlimentacaoIngredienteDaoNativeImpl.create - erro", ex);
+            throw new AlimentacaoIngredienteException("Erro ao criar AlimentacaoIngrediente", ex);
+        } finally {
+            if (conn != null) {
+                try { conn.close(); } catch (SQLException ignore) { }
+            }
+        }
     }
 
     @Override
     public void update(AlimentacaoIngrediente e) {
         Logger.info("AlimentacaoIngredienteDaoNativeImpl.update");
-        em.getTransaction().begin();
-        em.merge(e);
-        em.getTransaction().commit();
+        String sql = "UPDATE Alimentacao_Ingrediente SET quantidade=?, id_alimentacao=?, id_ingrediente=? WHERE id_alimentacao_ingrediente=?";
+        Connection conn = null;
+        try {
+            conn = ConnectionFactory.getConnection();
+            conn.setAutoCommit(false);
+            try (PreparedStatement ps = conn.prepareStatement(sql)) {
+                ps.setInt(1, e.getQuantidade());
+                ps.setInt(2, e.getIdAlimentacao());
+                ps.setInt(3, e.getIdIngrediente());
+                ps.setInt(4, e.getIdAlimentacaoIngrediente());
+                if (ps.executeUpdate() == 0) {
+                    throw new AlimentacaoIngredienteException("AlimentacaoIngrediente nao encontrado: id=" + e.getIdAlimentacaoIngrediente());
+                }
+            }
+            conn.commit();
+        } catch (SQLException ex) {
+            if (conn != null) {
+                try { conn.rollback(); } catch (SQLException ignore) { }
+            }
+            Logger.error("AlimentacaoIngredienteDaoNativeImpl.update - erro", ex);
+            throw new AlimentacaoIngredienteException("Erro ao atualizar AlimentacaoIngrediente", ex);
+        } finally {
+            if (conn != null) {
+                try { conn.close(); } catch (SQLException ignore) { }
+            }
+        }
     }
 
     @Override
     public void deleteById(Integer id) {
         Logger.info("AlimentacaoIngredienteDaoNativeImpl.deleteById");
-        AlimentacaoIngrediente e = em.find(AlimentacaoIngrediente.class, id);
-        if (e == null) throw new AlimentacaoIngredienteException("AlimentacaoIngrediente nao encontrado: id=" + id);
-        em.getTransaction().begin();
-        em.remove(e);
-        em.getTransaction().commit();
+        String sql = "DELETE FROM Alimentacao_Ingrediente WHERE id_alimentacao_ingrediente=?";
+        Connection conn = null;
+        try {
+            conn = ConnectionFactory.getConnection();
+            conn.setAutoCommit(false);
+            try (PreparedStatement ps = conn.prepareStatement(sql)) {
+                ps.setInt(1, id);
+                if (ps.executeUpdate() == 0) {
+                    throw new AlimentacaoIngredienteException("AlimentacaoIngrediente nao encontrado: id=" + id);
+                }
+            }
+            conn.commit();
+        } catch (SQLException ex) {
+            if (conn != null) {
+                try { conn.rollback(); } catch (SQLException ignore) { }
+            }
+            Logger.error("AlimentacaoIngredienteDaoNativeImpl.deleteById - erro", ex);
+            throw new AlimentacaoIngredienteException("Erro ao deletar AlimentacaoIngrediente", ex);
+        } finally {
+            if (conn != null) {
+                try { conn.close(); } catch (SQLException ignore) { }
+            }
+        }
     }
 
     @Override
     public AlimentacaoIngrediente findById(Integer id) {
-        String sql = "SELECT id_alimentacao_ingrediente, quantidade, id_alimentacao, id_ingrediente FROM Alimentacao_Ingrediente WHERE id_alimentacao_ingrediente = :id";
-        Query q = em.createNativeQuery(sql, AlimentacaoIngrediente.class).setParameter("id", id);
-        return (AlimentacaoIngrediente) q.getSingleResult();
+        String sql = "SELECT id_alimentacao_ingrediente, quantidade, id_alimentacao, id_ingrediente FROM Alimentacao_Ingrediente WHERE id_alimentacao_ingrediente = ?";
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return map(rs);
+                }
+            }
+        } catch (SQLException ex) {
+            Logger.error("AlimentacaoIngredienteDaoNativeImpl.findById - erro", ex);
+            throw new AlimentacaoIngredienteException("Erro ao buscar AlimentacaoIngrediente", ex);
+        }
+        throw new AlimentacaoIngredienteException("AlimentacaoIngrediente nao encontrado: id=" + id);
     }
 
     @Override
     public List<AlimentacaoIngrediente> findAll() {
         String sql = "SELECT id_alimentacao_ingrediente, quantidade, id_alimentacao, id_ingrediente FROM Alimentacao_Ingrediente";
-        return em.createNativeQuery(sql, AlimentacaoIngrediente.class).getResultList();
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql);
+             ResultSet rs = ps.executeQuery()) {
+            List<AlimentacaoIngrediente> list = new ArrayList<>();
+            while (rs.next()) {
+                list.add(map(rs));
+            }
+            return list;
+        } catch (SQLException ex) {
+            Logger.error("AlimentacaoIngredienteDaoNativeImpl.findAll - erro", ex);
+            throw new AlimentacaoIngredienteException("Erro ao listar AlimentacaoIngrediente", ex);
+        }
     }
 
     @Override
     public List<AlimentacaoIngrediente> findAll(int page, int size) {
-        String sql = "SELECT id_alimentacao_ingrediente, quantidade, id_alimentacao, id_ingrediente FROM Alimentacao_Ingrediente LIMIT :size OFFSET :off";
-        return em.createNativeQuery(sql, AlimentacaoIngrediente.class)
-                .setParameter("size", size)
-                .setParameter("off", page * size)
-                .getResultList();
+        String sql = "SELECT id_alimentacao_ingrediente, quantidade, id_alimentacao, id_ingrediente FROM Alimentacao_Ingrediente LIMIT ? OFFSET ?";
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, size);
+            ps.setInt(2, page * size);
+            try (ResultSet rs = ps.executeQuery()) {
+                List<AlimentacaoIngrediente> list = new ArrayList<>();
+                while (rs.next()) {
+                    list.add(map(rs));
+                }
+                return list;
+            }
+        } catch (SQLException ex) {
+            Logger.error("AlimentacaoIngredienteDaoNativeImpl.findAll(page) - erro", ex);
+            throw new AlimentacaoIngredienteException("Erro ao paginar AlimentacaoIngrediente", ex);
+        }
     }
 
     @Override
     public List<AlimentacaoIngrediente> findByQuantidade(Integer quantidade) {
-        String sql = "SELECT id_alimentacao_ingrediente, quantidade, id_alimentacao, id_ingrediente FROM Alimentacao_Ingrediente WHERE quantidade = :v";
-        return em.createNativeQuery(sql, AlimentacaoIngrediente.class).setParameter("v", quantidade).getResultList();
+        String sql = "SELECT id_alimentacao_ingrediente, quantidade, id_alimentacao, id_ingrediente FROM Alimentacao_Ingrediente WHERE quantidade = ?";
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, quantidade);
+            try (ResultSet rs = ps.executeQuery()) {
+                List<AlimentacaoIngrediente> list = new ArrayList<>();
+                while (rs.next()) {
+                    list.add(map(rs));
+                }
+                return list;
+            }
+        } catch (SQLException ex) {
+            Logger.error("AlimentacaoIngredienteDaoNativeImpl.findByQuantidade - erro", ex);
+            throw new AlimentacaoIngredienteException("Erro ao buscar por quantidade", ex);
+        }
     }
 
     @Override
     public List<AlimentacaoIngrediente> findByIdAlimentacao(Integer idAlimentacao) {
-        String sql = "SELECT id_alimentacao_ingrediente, quantidade, id_alimentacao, id_ingrediente FROM Alimentacao_Ingrediente WHERE id_alimentacao = :v";
-        return em.createNativeQuery(sql, AlimentacaoIngrediente.class).setParameter("v", idAlimentacao).getResultList();
+        String sql = "SELECT id_alimentacao_ingrediente, quantidade, id_alimentacao, id_ingrediente FROM Alimentacao_Ingrediente WHERE id_alimentacao = ?";
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, idAlimentacao);
+            try (ResultSet rs = ps.executeQuery()) {
+                List<AlimentacaoIngrediente> list = new ArrayList<>();
+                while (rs.next()) {
+                    list.add(map(rs));
+                }
+                return list;
+            }
+        } catch (SQLException ex) {
+            Logger.error("AlimentacaoIngredienteDaoNativeImpl.findByIdAlimentacao - erro", ex);
+            throw new AlimentacaoIngredienteException("Erro ao buscar por idAlimentacao", ex);
+        }
     }
 
     @Override
     public List<AlimentacaoIngrediente> findByIdIngrediente(Integer idIngrediente) {
-        String sql = "SELECT id_alimentacao_ingrediente, quantidade, id_alimentacao, id_ingrediente FROM Alimentacao_Ingrediente WHERE id_ingrediente = :v";
-        return em.createNativeQuery(sql, AlimentacaoIngrediente.class).setParameter("v", idIngrediente).getResultList();
+        String sql = "SELECT id_alimentacao_ingrediente, quantidade, id_alimentacao, id_ingrediente FROM Alimentacao_Ingrediente WHERE id_ingrediente = ?";
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, idIngrediente);
+            try (ResultSet rs = ps.executeQuery()) {
+                List<AlimentacaoIngrediente> list = new ArrayList<>();
+                while (rs.next()) {
+                    list.add(map(rs));
+                }
+                return list;
+            }
+        } catch (SQLException ex) {
+            Logger.error("AlimentacaoIngredienteDaoNativeImpl.findByIdIngrediente - erro", ex);
+            throw new AlimentacaoIngredienteException("Erro ao buscar por idIngrediente", ex);
+        }
     }
 
     @Override
@@ -88,15 +233,38 @@ public class AlimentacaoIngredienteDaoNativeImpl implements AlimentacaoIngredien
     @Override
     public List<AlimentacaoIngrediente> search(AlimentacaoIngrediente f, int page, int size) {
         StringBuilder sb = new StringBuilder("SELECT id_alimentacao_ingrediente, quantidade, id_alimentacao, id_ingrediente FROM Alimentacao_Ingrediente WHERE 1=1");
-        if (f.getQuantidade() != null) sb.append(" AND quantidade = :quantidade");
-        if (f.getIdAlimentacao() != null) sb.append(" AND id_alimentacao = :idAlimentacao");
-        if (f.getIdIngrediente() != null) sb.append(" AND id_ingrediente = :idIngrediente");
-        Query q = em.createNativeQuery(sb.toString(), AlimentacaoIngrediente.class);
-        if (f.getQuantidade() != null) q.setParameter("quantidade", f.getQuantidade());
-        if (f.getIdAlimentacao() != null) q.setParameter("idAlimentacao", f.getIdAlimentacao());
-        if (f.getIdIngrediente() != null) q.setParameter("idIngrediente", f.getIdIngrediente());
-        q.setFirstResult(page * size);
-        q.setMaxResults(size);
-        return q.getResultList();
+        List<Object> params = new ArrayList<>();
+        if (f.getQuantidade() != null) {
+            sb.append(" AND quantidade = ?");
+            params.add(f.getQuantidade());
+        }
+        if (f.getIdAlimentacao() != null) {
+            sb.append(" AND id_alimentacao = ?");
+            params.add(f.getIdAlimentacao());
+        }
+        if (f.getIdIngrediente() != null) {
+            sb.append(" AND id_ingrediente = ?");
+            params.add(f.getIdIngrediente());
+        }
+        sb.append(" LIMIT ? OFFSET ?");
+        params.add(size);
+        params.add(page * size);
+
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sb.toString())) {
+            for (int i = 0; i < params.size(); i++) {
+                ps.setObject(i + 1, params.get(i));
+            }
+            try (ResultSet rs = ps.executeQuery()) {
+                List<AlimentacaoIngrediente> list = new ArrayList<>();
+                while (rs.next()) {
+                    list.add(map(rs));
+                }
+                return list;
+            }
+        } catch (SQLException ex) {
+            Logger.error("AlimentacaoIngredienteDaoNativeImpl.search - erro", ex);
+            throw new AlimentacaoIngredienteException("Erro na busca de AlimentacaoIngrediente", ex);
+        }
     }
 }

--- a/src/main/java/dao/impl/IngredienteFornecedorDaoNativeImpl.java
+++ b/src/main/java/dao/impl/IngredienteFornecedorDaoNativeImpl.java
@@ -2,90 +2,253 @@ package dao.impl;
 
 import dao.api.IngredienteFornecedorDao;
 import exception.IngredienteFornecedorException;
-import infra.EntityManagerUtil;
 import infra.Logger;
-import javax.persistence.EntityManager;
-import javax.persistence.Query;
 import model.IngredienteFornecedor;
 
+import conexao.ConnectionFactory;
 import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * JDBC-based implementation of IngredienteFornecedorDao.
+ */
 public class IngredienteFornecedorDaoNativeImpl implements IngredienteFornecedorDao {
-    private final EntityManager em = EntityManagerUtil.getEntityManager();
+    private IngredienteFornecedor map(ResultSet rs) throws SQLException {
+        IngredienteFornecedor obj = new IngredienteFornecedor();
+        obj.setIdFornecedorIngrediente(rs.getInt("id_fornecedor_ingrediente"));
+        obj.setValor(rs.getBigDecimal("valor"));
+        Date d = rs.getDate("data");
+        if (d != null) obj.setData(d.toLocalDate());
+        obj.setIdFornecedor(rs.getInt("id_fornecedor"));
+        obj.setIdIngrediente(rs.getInt("id_ingrediente"));
+        return obj;
+    }
 
     @Override
     public void create(IngredienteFornecedor e) {
         Logger.info("IngredienteFornecedorDaoNativeImpl.create");
-        em.getTransaction().begin();
-        e.setIdFornecedorIngrediente(null);
-        em.persist(e);
-        em.getTransaction().commit();
+        String sql = "INSERT INTO Ingrediente_fornecedor (valor, data, id_fornecedor, id_ingrediente) VALUES (?,?,?,?)";
+        Connection conn = null;
+        try {
+            conn = ConnectionFactory.getConnection();
+            conn.setAutoCommit(false);
+            try (PreparedStatement ps = conn.prepareStatement(sql)) {
+                ps.setBigDecimal(1, e.getValor());
+                ps.setDate(2, e.getData() != null ? Date.valueOf(e.getData()) : null);
+                ps.setInt(3, e.getIdFornecedor());
+                ps.setInt(4, e.getIdIngrediente());
+                ps.executeUpdate();
+            }
+            conn.commit();
+        } catch (SQLException ex) {
+            if (conn != null) {
+                try { conn.rollback(); } catch (SQLException ignore) { }
+            }
+            Logger.error("IngredienteFornecedorDaoNativeImpl.create - erro", ex);
+            throw new IngredienteFornecedorException("Erro ao criar IngredienteFornecedor", ex);
+        } finally {
+            if (conn != null) {
+                try { conn.close(); } catch (SQLException ignore) { }
+            }
+        }
     }
 
     @Override
     public void update(IngredienteFornecedor e) {
         Logger.info("IngredienteFornecedorDaoNativeImpl.update");
-        em.getTransaction().begin();
-        em.merge(e);
-        em.getTransaction().commit();
+        String sql = "UPDATE Ingrediente_fornecedor SET valor=?, data=?, id_fornecedor=?, id_ingrediente=? WHERE id_fornecedor_ingrediente=?";
+        Connection conn = null;
+        try {
+            conn = ConnectionFactory.getConnection();
+            conn.setAutoCommit(false);
+            try (PreparedStatement ps = conn.prepareStatement(sql)) {
+                ps.setBigDecimal(1, e.getValor());
+                ps.setDate(2, e.getData() != null ? Date.valueOf(e.getData()) : null);
+                ps.setInt(3, e.getIdFornecedor());
+                ps.setInt(4, e.getIdIngrediente());
+                ps.setInt(5, e.getIdFornecedorIngrediente());
+                if (ps.executeUpdate() == 0) {
+                    throw new IngredienteFornecedorException("IngredienteFornecedor nao encontrado: id=" + e.getIdFornecedorIngrediente());
+                }
+            }
+            conn.commit();
+        } catch (SQLException ex) {
+            if (conn != null) {
+                try { conn.rollback(); } catch (SQLException ignore) { }
+            }
+            Logger.error("IngredienteFornecedorDaoNativeImpl.update - erro", ex);
+            throw new IngredienteFornecedorException("Erro ao atualizar IngredienteFornecedor", ex);
+        } finally {
+            if (conn != null) {
+                try { conn.close(); } catch (SQLException ignore) { }
+            }
+        }
     }
 
     @Override
     public void deleteById(Integer id) {
         Logger.info("IngredienteFornecedorDaoNativeImpl.deleteById");
-        IngredienteFornecedor e = em.find(IngredienteFornecedor.class, id);
-        if (e == null) throw new IngredienteFornecedorException("IngredienteFornecedor nao encontrado: id=" + id);
-        em.getTransaction().begin();
-        em.remove(e);
-        em.getTransaction().commit();
+        String sql = "DELETE FROM Ingrediente_fornecedor WHERE id_fornecedor_ingrediente=?";
+        Connection conn = null;
+        try {
+            conn = ConnectionFactory.getConnection();
+            conn.setAutoCommit(false);
+            try (PreparedStatement ps = conn.prepareStatement(sql)) {
+                ps.setInt(1, id);
+                if (ps.executeUpdate() == 0) {
+                    throw new IngredienteFornecedorException("IngredienteFornecedor nao encontrado: id=" + id);
+                }
+            }
+            conn.commit();
+        } catch (SQLException ex) {
+            if (conn != null) {
+                try { conn.rollback(); } catch (SQLException ignore) { }
+            }
+            Logger.error("IngredienteFornecedorDaoNativeImpl.deleteById - erro", ex);
+            throw new IngredienteFornecedorException("Erro ao deletar IngredienteFornecedor", ex);
+        } finally {
+            if (conn != null) {
+                try { conn.close(); } catch (SQLException ignore) { }
+            }
+        }
     }
 
     @Override
     public IngredienteFornecedor findById(Integer id) {
-        String sql = "SELECT id_fornecedor_ingrediente, valor, data, id_fornecedor, id_ingrediente FROM Ingrediente_fornecedor WHERE id_fornecedor_ingrediente = :id";
-        Query q = em.createNativeQuery(sql, IngredienteFornecedor.class).setParameter("id", id);
-        return (IngredienteFornecedor) q.getSingleResult();
+        String sql = "SELECT id_fornecedor_ingrediente, valor, data, id_fornecedor, id_ingrediente FROM Ingrediente_fornecedor WHERE id_fornecedor_ingrediente = ?";
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return map(rs);
+                }
+            }
+        } catch (SQLException ex) {
+            Logger.error("IngredienteFornecedorDaoNativeImpl.findById - erro", ex);
+            throw new IngredienteFornecedorException("Erro ao buscar IngredienteFornecedor", ex);
+        }
+        throw new IngredienteFornecedorException("IngredienteFornecedor nao encontrado: id=" + id);
     }
 
     @Override
     public List<IngredienteFornecedor> findAll() {
         String sql = "SELECT id_fornecedor_ingrediente, valor, data, id_fornecedor, id_ingrediente FROM Ingrediente_fornecedor";
-        return em.createNativeQuery(sql, IngredienteFornecedor.class).getResultList();
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql);
+             ResultSet rs = ps.executeQuery()) {
+            List<IngredienteFornecedor> list = new ArrayList<>();
+            while (rs.next()) {
+                list.add(map(rs));
+            }
+            return list;
+        } catch (SQLException ex) {
+            Logger.error("IngredienteFornecedorDaoNativeImpl.findAll - erro", ex);
+            throw new IngredienteFornecedorException("Erro ao listar IngredienteFornecedor", ex);
+        }
     }
 
     @Override
     public List<IngredienteFornecedor> findAll(int page, int size) {
-        String sql = "SELECT id_fornecedor_ingrediente, valor, data, id_fornecedor, id_ingrediente FROM Ingrediente_fornecedor LIMIT :size OFFSET :off";
-        return em.createNativeQuery(sql, IngredienteFornecedor.class)
-                .setParameter("size", size)
-                .setParameter("off", page * size)
-                .getResultList();
+        String sql = "SELECT id_fornecedor_ingrediente, valor, data, id_fornecedor, id_ingrediente FROM Ingrediente_fornecedor LIMIT ? OFFSET ?";
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, size);
+            ps.setInt(2, page * size);
+            try (ResultSet rs = ps.executeQuery()) {
+                List<IngredienteFornecedor> list = new ArrayList<>();
+                while (rs.next()) {
+                    list.add(map(rs));
+                }
+                return list;
+            }
+        } catch (SQLException ex) {
+            Logger.error("IngredienteFornecedorDaoNativeImpl.findAll(page) - erro", ex);
+            throw new IngredienteFornecedorException("Erro ao paginar IngredienteFornecedor", ex);
+        }
     }
 
     @Override
     public List<IngredienteFornecedor> findByValor(BigDecimal valor) {
-        String sql = "SELECT id_fornecedor_ingrediente, valor, data, id_fornecedor, id_ingrediente FROM Ingrediente_fornecedor WHERE valor = :v";
-        return em.createNativeQuery(sql, IngredienteFornecedor.class).setParameter("v", valor).getResultList();
+        String sql = "SELECT id_fornecedor_ingrediente, valor, data, id_fornecedor, id_ingrediente FROM Ingrediente_fornecedor WHERE valor = ?";
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setBigDecimal(1, valor);
+            try (ResultSet rs = ps.executeQuery()) {
+                List<IngredienteFornecedor> list = new ArrayList<>();
+                while (rs.next()) {
+                    list.add(map(rs));
+                }
+                return list;
+            }
+        } catch (SQLException ex) {
+            Logger.error("IngredienteFornecedorDaoNativeImpl.findByValor - erro", ex);
+            throw new IngredienteFornecedorException("Erro ao buscar por valor", ex);
+        }
     }
 
     @Override
     public List<IngredienteFornecedor> findByData(LocalDate data) {
-        String sql = "SELECT id_fornecedor_ingrediente, valor, data, id_fornecedor, id_ingrediente FROM Ingrediente_fornecedor WHERE data = :v";
-        return em.createNativeQuery(sql, IngredienteFornecedor.class).setParameter("v", data).getResultList();
+        String sql = "SELECT id_fornecedor_ingrediente, valor, data, id_fornecedor, id_ingrediente FROM Ingrediente_fornecedor WHERE data = ?";
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setDate(1, data != null ? Date.valueOf(data) : null);
+            try (ResultSet rs = ps.executeQuery()) {
+                List<IngredienteFornecedor> list = new ArrayList<>();
+                while (rs.next()) {
+                    list.add(map(rs));
+                }
+                return list;
+            }
+        } catch (SQLException ex) {
+            Logger.error("IngredienteFornecedorDaoNativeImpl.findByData - erro", ex);
+            throw new IngredienteFornecedorException("Erro ao buscar por data", ex);
+        }
     }
 
     @Override
     public List<IngredienteFornecedor> findByIdFornecedor(Integer idFornecedor) {
-        String sql = "SELECT id_fornecedor_ingrediente, valor, data, id_fornecedor, id_ingrediente FROM Ingrediente_fornecedor WHERE id_fornecedor = :v";
-        return em.createNativeQuery(sql, IngredienteFornecedor.class).setParameter("v", idFornecedor).getResultList();
+        String sql = "SELECT id_fornecedor_ingrediente, valor, data, id_fornecedor, id_ingrediente FROM Ingrediente_fornecedor WHERE id_fornecedor = ?";
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, idFornecedor);
+            try (ResultSet rs = ps.executeQuery()) {
+                List<IngredienteFornecedor> list = new ArrayList<>();
+                while (rs.next()) {
+                    list.add(map(rs));
+                }
+                return list;
+            }
+        } catch (SQLException ex) {
+            Logger.error("IngredienteFornecedorDaoNativeImpl.findByIdFornecedor - erro", ex);
+            throw new IngredienteFornecedorException("Erro ao buscar por idFornecedor", ex);
+        }
     }
 
     @Override
     public List<IngredienteFornecedor> findByIdIngrediente(Integer idIngrediente) {
-        String sql = "SELECT id_fornecedor_ingrediente, valor, data, id_fornecedor, id_ingrediente FROM Ingrediente_fornecedor WHERE id_ingrediente = :v";
-        return em.createNativeQuery(sql, IngredienteFornecedor.class).setParameter("v", idIngrediente).getResultList();
+        String sql = "SELECT id_fornecedor_ingrediente, valor, data, id_fornecedor, id_ingrediente FROM Ingrediente_fornecedor WHERE id_ingrediente = ?";
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, idIngrediente);
+            try (ResultSet rs = ps.executeQuery()) {
+                List<IngredienteFornecedor> list = new ArrayList<>();
+                while (rs.next()) {
+                    list.add(map(rs));
+                }
+                return list;
+            }
+        } catch (SQLException ex) {
+            Logger.error("IngredienteFornecedorDaoNativeImpl.findByIdIngrediente - erro", ex);
+            throw new IngredienteFornecedorException("Erro ao buscar por idIngrediente", ex);
+        }
     }
 
     @Override
@@ -96,17 +259,42 @@ public class IngredienteFornecedorDaoNativeImpl implements IngredienteFornecedor
     @Override
     public List<IngredienteFornecedor> search(IngredienteFornecedor f, int page, int size) {
         StringBuilder sb = new StringBuilder("SELECT id_fornecedor_ingrediente, valor, data, id_fornecedor, id_ingrediente FROM Ingrediente_fornecedor WHERE 1=1");
-        if (f.getValor() != null) sb.append(" AND valor = :valor");
-        if (f.getData() != null) sb.append(" AND data = :data");
-        if (f.getIdFornecedor() != null) sb.append(" AND id_fornecedor = :idFornecedor");
-        if (f.getIdIngrediente() != null) sb.append(" AND id_ingrediente = :idIngrediente");
-        Query q = em.createNativeQuery(sb.toString(), IngredienteFornecedor.class);
-        if (f.getValor() != null) q.setParameter("valor", f.getValor());
-        if (f.getData() != null) q.setParameter("data", f.getData());
-        if (f.getIdFornecedor() != null) q.setParameter("idFornecedor", f.getIdFornecedor());
-        if (f.getIdIngrediente() != null) q.setParameter("idIngrediente", f.getIdIngrediente());
-        q.setFirstResult(page * size);
-        q.setMaxResults(size);
-        return q.getResultList();
+        List<Object> params = new ArrayList<>();
+        if (f.getValor() != null) {
+            sb.append(" AND valor = ?");
+            params.add(f.getValor());
+        }
+        if (f.getData() != null) {
+            sb.append(" AND data = ?");
+            params.add(Date.valueOf(f.getData()));
+        }
+        if (f.getIdFornecedor() != null) {
+            sb.append(" AND id_fornecedor = ?");
+            params.add(f.getIdFornecedor());
+        }
+        if (f.getIdIngrediente() != null) {
+            sb.append(" AND id_ingrediente = ?");
+            params.add(f.getIdIngrediente());
+        }
+        sb.append(" LIMIT ? OFFSET ?");
+        params.add(size);
+        params.add(page * size);
+
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sb.toString())) {
+            for (int i = 0; i < params.size(); i++) {
+                ps.setObject(i + 1, params.get(i));
+            }
+            try (ResultSet rs = ps.executeQuery()) {
+                List<IngredienteFornecedor> list = new ArrayList<>();
+                while (rs.next()) {
+                    list.add(map(rs));
+                }
+                return list;
+            }
+        } catch (SQLException ex) {
+            Logger.error("IngredienteFornecedorDaoNativeImpl.search - erro", ex);
+            throw new IngredienteFornecedorException("Erro na busca de IngredienteFornecedor", ex);
+        }
     }
 }

--- a/src/main/java/dao/impl/TreinoExercicioDaoNativeImpl.java
+++ b/src/main/java/dao/impl/TreinoExercicioDaoNativeImpl.java
@@ -2,100 +2,306 @@ package dao.impl;
 
 import dao.api.TreinoExercicioDao;
 import exception.TreinoExercicioException;
-import infra.EntityManagerUtil;
 import infra.Logger;
-import javax.persistence.EntityManager;
-import javax.persistence.Query;
 import model.TreinoExercicio;
 
+import conexao.ConnectionFactory;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * JDBC-based implementation of TreinoExercicioDao.
+ */
 public class TreinoExercicioDaoNativeImpl implements TreinoExercicioDao {
-    private final EntityManager em = EntityManagerUtil.getEntityManager();
+    private TreinoExercicio map(ResultSet rs) throws SQLException {
+        TreinoExercicio t = new TreinoExercicio();
+        t.setIdTreinoExercicio(rs.getInt("id_treino_exercicio"));
+        t.setQtdRepeticao(rs.getInt("qtd_repeticao"));
+        t.setTempoDescanso(rs.getString("tempo_descanso"));
+        t.setOrdem(rs.getInt("ordem"));
+        Object feitoObj = rs.getObject("feito");
+        t.setFeito(feitoObj != null ? rs.getBoolean("feito") : null);
+        t.setIdExercicio(rs.getInt("id_exercicio"));
+        t.setIdTreino(rs.getInt("id_treino"));
+        return t;
+    }
 
     @Override
     public void create(TreinoExercicio e) {
         Logger.info("TreinoExercicioDaoNativeImpl.create");
-        em.getTransaction().begin();
-        e.setIdTreinoExercicio(null);
-        em.persist(e);
-        em.getTransaction().commit();
+        String sql = "INSERT INTO Treino_Exercicio (qtd_repeticao, tempo_descanso, ordem, feito, id_exercicio, id_treino) VALUES (?,?,?,?,?,?)";
+        Connection conn = null;
+        try {
+            conn = ConnectionFactory.getConnection();
+            conn.setAutoCommit(false);
+            try (PreparedStatement ps = conn.prepareStatement(sql)) {
+                ps.setInt(1, e.getQtdRepeticao());
+                ps.setString(2, e.getTempoDescanso());
+                ps.setInt(3, e.getOrdem());
+                if (e.getFeito() != null) {
+                    ps.setBoolean(4, e.getFeito());
+                } else {
+                    ps.setNull(4, java.sql.Types.BOOLEAN);
+                }
+                ps.setInt(5, e.getIdExercicio());
+                ps.setInt(6, e.getIdTreino());
+                ps.executeUpdate();
+            }
+            conn.commit();
+        } catch (SQLException ex) {
+            if (conn != null) {
+                try { conn.rollback(); } catch (SQLException ignore) { }
+            }
+            Logger.error("TreinoExercicioDaoNativeImpl.create - erro", ex);
+            throw new TreinoExercicioException("Erro ao criar TreinoExercicio", ex);
+        } finally {
+            if (conn != null) {
+                try { conn.close(); } catch (SQLException ignore) { }
+            }
+        }
     }
 
     @Override
     public void update(TreinoExercicio e) {
         Logger.info("TreinoExercicioDaoNativeImpl.update");
-        em.getTransaction().begin();
-        em.merge(e);
-        em.getTransaction().commit();
+        String sql = "UPDATE Treino_Exercicio SET qtd_repeticao=?, tempo_descanso=?, ordem=?, feito=?, id_exercicio=?, id_treino=? WHERE id_treino_exercicio=?";
+        Connection conn = null;
+        try {
+            conn = ConnectionFactory.getConnection();
+            conn.setAutoCommit(false);
+            try (PreparedStatement ps = conn.prepareStatement(sql)) {
+                ps.setInt(1, e.getQtdRepeticao());
+                ps.setString(2, e.getTempoDescanso());
+                ps.setInt(3, e.getOrdem());
+                if (e.getFeito() != null) {
+                    ps.setBoolean(4, e.getFeito());
+                } else {
+                    ps.setNull(4, java.sql.Types.BOOLEAN);
+                }
+                ps.setInt(5, e.getIdExercicio());
+                ps.setInt(6, e.getIdTreino());
+                ps.setInt(7, e.getIdTreinoExercicio());
+                if (ps.executeUpdate() == 0) {
+                    throw new TreinoExercicioException("TreinoExercicio nao encontrado: id=" + e.getIdTreinoExercicio());
+                }
+            }
+            conn.commit();
+        } catch (SQLException ex) {
+            if (conn != null) {
+                try { conn.rollback(); } catch (SQLException ignore) { }
+            }
+            Logger.error("TreinoExercicioDaoNativeImpl.update - erro", ex);
+            throw new TreinoExercicioException("Erro ao atualizar TreinoExercicio", ex);
+        } finally {
+            if (conn != null) {
+                try { conn.close(); } catch (SQLException ignore) { }
+            }
+        }
     }
 
     @Override
     public void deleteById(Integer id) {
         Logger.info("TreinoExercicioDaoNativeImpl.deleteById");
-        TreinoExercicio e = em.find(TreinoExercicio.class, id);
-        if (e == null) throw new TreinoExercicioException("TreinoExercicio nao encontrado: id=" + id);
-        em.getTransaction().begin();
-        em.remove(e);
-        em.getTransaction().commit();
+        String sql = "DELETE FROM Treino_Exercicio WHERE id_treino_exercicio=?";
+        Connection conn = null;
+        try {
+            conn = ConnectionFactory.getConnection();
+            conn.setAutoCommit(false);
+            try (PreparedStatement ps = conn.prepareStatement(sql)) {
+                ps.setInt(1, id);
+                if (ps.executeUpdate() == 0) {
+                    throw new TreinoExercicioException("TreinoExercicio nao encontrado: id=" + id);
+                }
+            }
+            conn.commit();
+        } catch (SQLException ex) {
+            if (conn != null) {
+                try { conn.rollback(); } catch (SQLException ignore) { }
+            }
+            Logger.error("TreinoExercicioDaoNativeImpl.deleteById - erro", ex);
+            throw new TreinoExercicioException("Erro ao deletar TreinoExercicio", ex);
+        } finally {
+            if (conn != null) {
+                try { conn.close(); } catch (SQLException ignore) { }
+            }
+        }
     }
 
     @Override
     public TreinoExercicio findById(Integer id) {
-        String sql = "SELECT id_treino_exercicio, qtd_repeticao, tempo_descanso, ordem, feito, id_exercicio, id_treino FROM Treino_Exercicio WHERE id_treino_exercicio = :id";
-        Query q = em.createNativeQuery(sql, TreinoExercicio.class).setParameter("id", id);
-        return (TreinoExercicio) q.getSingleResult();
+        String sql = "SELECT id_treino_exercicio, qtd_repeticao, tempo_descanso, ordem, feito, id_exercicio, id_treino FROM Treino_Exercicio WHERE id_treino_exercicio = ?";
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return map(rs);
+                }
+            }
+        } catch (SQLException ex) {
+            Logger.error("TreinoExercicioDaoNativeImpl.findById - erro", ex);
+            throw new TreinoExercicioException("Erro ao buscar TreinoExercicio", ex);
+        }
+        throw new TreinoExercicioException("TreinoExercicio nao encontrado: id=" + id);
     }
 
     @Override
     public List<TreinoExercicio> findAll() {
         String sql = "SELECT id_treino_exercicio, qtd_repeticao, tempo_descanso, ordem, feito, id_exercicio, id_treino FROM Treino_Exercicio";
-        return em.createNativeQuery(sql, TreinoExercicio.class).getResultList();
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql);
+             ResultSet rs = ps.executeQuery()) {
+            List<TreinoExercicio> list = new ArrayList<>();
+            while (rs.next()) {
+                list.add(map(rs));
+            }
+            return list;
+        } catch (SQLException ex) {
+            Logger.error("TreinoExercicioDaoNativeImpl.findAll - erro", ex);
+            throw new TreinoExercicioException("Erro ao listar TreinoExercicio", ex);
+        }
     }
 
     @Override
     public List<TreinoExercicio> findAll(int page, int size) {
-        String sql = "SELECT id_treino_exercicio, qtd_repeticao, tempo_descanso, ordem, feito, id_exercicio, id_treino FROM Treino_Exercicio LIMIT :size OFFSET :off";
-        return em.createNativeQuery(sql, TreinoExercicio.class)
-                .setParameter("size", size)
-                .setParameter("off", page * size)
-                .getResultList();
+        String sql = "SELECT id_treino_exercicio, qtd_repeticao, tempo_descanso, ordem, feito, id_exercicio, id_treino FROM Treino_Exercicio LIMIT ? OFFSET ?";
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, size);
+            ps.setInt(2, page * size);
+            try (ResultSet rs = ps.executeQuery()) {
+                List<TreinoExercicio> list = new ArrayList<>();
+                while (rs.next()) {
+                    list.add(map(rs));
+                }
+                return list;
+            }
+        } catch (SQLException ex) {
+            Logger.error("TreinoExercicioDaoNativeImpl.findAll(page) - erro", ex);
+            throw new TreinoExercicioException("Erro ao paginar TreinoExercicio", ex);
+        }
     }
 
     @Override
     public List<TreinoExercicio> findByQtdRepeticao(Integer qtdRepeticao) {
-        String sql = "SELECT id_treino_exercicio, qtd_repeticao, tempo_descanso, ordem, feito, id_exercicio, id_treino FROM Treino_Exercicio WHERE qtd_repeticao = :v";
-        return em.createNativeQuery(sql, TreinoExercicio.class).setParameter("v", qtdRepeticao).getResultList();
+        String sql = "SELECT id_treino_exercicio, qtd_repeticao, tempo_descanso, ordem, feito, id_exercicio, id_treino FROM Treino_Exercicio WHERE qtd_repeticao = ?";
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, qtdRepeticao);
+            try (ResultSet rs = ps.executeQuery()) {
+                List<TreinoExercicio> list = new ArrayList<>();
+                while (rs.next()) {
+                    list.add(map(rs));
+                }
+                return list;
+            }
+        } catch (SQLException ex) {
+            Logger.error("TreinoExercicioDaoNativeImpl.findByQtdRepeticao - erro", ex);
+            throw new TreinoExercicioException("Erro ao buscar por qtdRepeticao", ex);
+        }
     }
 
     @Override
     public List<TreinoExercicio> findByTempoDescanso(String tempoDescanso) {
-        String sql = "SELECT id_treino_exercicio, qtd_repeticao, tempo_descanso, ordem, feito, id_exercicio, id_treino FROM Treino_Exercicio WHERE tempo_descanso = :v";
-        return em.createNativeQuery(sql, TreinoExercicio.class).setParameter("v", tempoDescanso).getResultList();
+        String sql = "SELECT id_treino_exercicio, qtd_repeticao, tempo_descanso, ordem, feito, id_exercicio, id_treino FROM Treino_Exercicio WHERE tempo_descanso = ?";
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, tempoDescanso);
+            try (ResultSet rs = ps.executeQuery()) {
+                List<TreinoExercicio> list = new ArrayList<>();
+                while (rs.next()) {
+                    list.add(map(rs));
+                }
+                return list;
+            }
+        } catch (SQLException ex) {
+            Logger.error("TreinoExercicioDaoNativeImpl.findByTempoDescanso - erro", ex);
+            throw new TreinoExercicioException("Erro ao buscar por tempoDescanso", ex);
+        }
     }
 
     @Override
     public List<TreinoExercicio> findByOrdem(Integer ordem) {
-        String sql = "SELECT id_treino_exercicio, qtd_repeticao, tempo_descanso, ordem, feito, id_exercicio, id_treino FROM Treino_Exercicio WHERE ordem = :v";
-        return em.createNativeQuery(sql, TreinoExercicio.class).setParameter("v", ordem).getResultList();
+        String sql = "SELECT id_treino_exercicio, qtd_repeticao, tempo_descanso, ordem, feito, id_exercicio, id_treino FROM Treino_Exercicio WHERE ordem = ?";
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, ordem);
+            try (ResultSet rs = ps.executeQuery()) {
+                List<TreinoExercicio> list = new ArrayList<>();
+                while (rs.next()) {
+                    list.add(map(rs));
+                }
+                return list;
+            }
+        } catch (SQLException ex) {
+            Logger.error("TreinoExercicioDaoNativeImpl.findByOrdem - erro", ex);
+            throw new TreinoExercicioException("Erro ao buscar por ordem", ex);
+        }
     }
 
     @Override
     public List<TreinoExercicio> findByFeito(Boolean feito) {
-        String sql = "SELECT id_treino_exercicio, qtd_repeticao, tempo_descanso, ordem, feito, id_exercicio, id_treino FROM Treino_Exercicio WHERE feito = :v";
-        return em.createNativeQuery(sql, TreinoExercicio.class).setParameter("v", feito).getResultList();
+        String sql = "SELECT id_treino_exercicio, qtd_repeticao, tempo_descanso, ordem, feito, id_exercicio, id_treino FROM Treino_Exercicio WHERE feito = ?";
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            if (feito != null) {
+                ps.setBoolean(1, feito);
+            } else {
+                ps.setNull(1, java.sql.Types.BOOLEAN);
+            }
+            try (ResultSet rs = ps.executeQuery()) {
+                List<TreinoExercicio> list = new ArrayList<>();
+                while (rs.next()) {
+                    list.add(map(rs));
+                }
+                return list;
+            }
+        } catch (SQLException ex) {
+            Logger.error("TreinoExercicioDaoNativeImpl.findByFeito - erro", ex);
+            throw new TreinoExercicioException("Erro ao buscar por feito", ex);
+        }
     }
 
     @Override
     public List<TreinoExercicio> findByIdExercicio(Integer idExercicio) {
-        String sql = "SELECT id_treino_exercicio, qtd_repeticao, tempo_descanso, ordem, feito, id_exercicio, id_treino FROM Treino_Exercicio WHERE id_exercicio = :v";
-        return em.createNativeQuery(sql, TreinoExercicio.class).setParameter("v", idExercicio).getResultList();
+        String sql = "SELECT id_treino_exercicio, qtd_repeticao, tempo_descanso, ordem, feito, id_exercicio, id_treino FROM Treino_Exercicio WHERE id_exercicio = ?";
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, idExercicio);
+            try (ResultSet rs = ps.executeQuery()) {
+                List<TreinoExercicio> list = new ArrayList<>();
+                while (rs.next()) {
+                    list.add(map(rs));
+                }
+                return list;
+            }
+        } catch (SQLException ex) {
+            Logger.error("TreinoExercicioDaoNativeImpl.findByIdExercicio - erro", ex);
+            throw new TreinoExercicioException("Erro ao buscar por idExercicio", ex);
+        }
     }
 
     @Override
     public List<TreinoExercicio> findByIdTreino(Integer idTreino) {
-        String sql = "SELECT id_treino_exercicio, qtd_repeticao, tempo_descanso, ordem, feito, id_exercicio, id_treino FROM Treino_Exercicio WHERE id_treino = :v";
-        return em.createNativeQuery(sql, TreinoExercicio.class).setParameter("v", idTreino).getResultList();
+        String sql = "SELECT id_treino_exercicio, qtd_repeticao, tempo_descanso, ordem, feito, id_exercicio, id_treino FROM Treino_Exercicio WHERE id_treino = ?";
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, idTreino);
+            try (ResultSet rs = ps.executeQuery()) {
+                List<TreinoExercicio> list = new ArrayList<>();
+                while (rs.next()) {
+                    list.add(map(rs));
+                }
+                return list;
+            }
+        } catch (SQLException ex) {
+            Logger.error("TreinoExercicioDaoNativeImpl.findByIdTreino - erro", ex);
+            throw new TreinoExercicioException("Erro ao buscar por idTreino", ex);
+        }
     }
 
     @Override
@@ -106,21 +312,50 @@ public class TreinoExercicioDaoNativeImpl implements TreinoExercicioDao {
     @Override
     public List<TreinoExercicio> search(TreinoExercicio f, int page, int size) {
         StringBuilder sb = new StringBuilder("SELECT id_treino_exercicio, qtd_repeticao, tempo_descanso, ordem, feito, id_exercicio, id_treino FROM Treino_Exercicio WHERE 1=1");
-        if (f.getQtdRepeticao() != null) sb.append(" AND qtd_repeticao = :qtdRepeticao");
-        if (f.getTempoDescanso() != null && !f.getTempoDescanso().isEmpty()) sb.append(" AND tempo_descanso = :tempoDescanso");
-        if (f.getOrdem() != null) sb.append(" AND ordem = :ordem");
-        if (f.getFeito() != null) sb.append(" AND feito = :feito");
-        if (f.getIdExercicio() != null) sb.append(" AND id_exercicio = :idExercicio");
-        if (f.getIdTreino() != null) sb.append(" AND id_treino = :idTreino");
-        Query q = em.createNativeQuery(sb.toString(), TreinoExercicio.class);
-        if (f.getQtdRepeticao() != null) q.setParameter("qtdRepeticao", f.getQtdRepeticao());
-        if (f.getTempoDescanso() != null && !f.getTempoDescanso().isEmpty()) q.setParameter("tempoDescanso", f.getTempoDescanso());
-        if (f.getOrdem() != null) q.setParameter("ordem", f.getOrdem());
-        if (f.getFeito() != null) q.setParameter("feito", f.getFeito());
-        if (f.getIdExercicio() != null) q.setParameter("idExercicio", f.getIdExercicio());
-        if (f.getIdTreino() != null) q.setParameter("idTreino", f.getIdTreino());
-        q.setFirstResult(page * size);
-        q.setMaxResults(size);
-        return q.getResultList();
+        List<Object> params = new ArrayList<>();
+        if (f.getQtdRepeticao() != null) {
+            sb.append(" AND qtd_repeticao = ?");
+            params.add(f.getQtdRepeticao());
+        }
+        if (f.getTempoDescanso() != null && !f.getTempoDescanso().isEmpty()) {
+            sb.append(" AND tempo_descanso = ?");
+            params.add(f.getTempoDescanso());
+        }
+        if (f.getOrdem() != null) {
+            sb.append(" AND ordem = ?");
+            params.add(f.getOrdem());
+        }
+        if (f.getFeito() != null) {
+            sb.append(" AND feito = ?");
+            params.add(f.getFeito());
+        }
+        if (f.getIdExercicio() != null) {
+            sb.append(" AND id_exercicio = ?");
+            params.add(f.getIdExercicio());
+        }
+        if (f.getIdTreino() != null) {
+            sb.append(" AND id_treino = ?");
+            params.add(f.getIdTreino());
+        }
+        sb.append(" LIMIT ? OFFSET ?");
+        params.add(size);
+        params.add(page * size);
+
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sb.toString())) {
+            for (int i = 0; i < params.size(); i++) {
+                ps.setObject(i + 1, params.get(i));
+            }
+            try (ResultSet rs = ps.executeQuery()) {
+                List<TreinoExercicio> list = new ArrayList<>();
+                while (rs.next()) {
+                    list.add(map(rs));
+                }
+                return list;
+            }
+        } catch (SQLException ex) {
+            Logger.error("TreinoExercicioDaoNativeImpl.search - erro", ex);
+            throw new TreinoExercicioException("Erro na busca de TreinoExercicio", ex);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- replace JPA `EntityManager` usage with JDBC in `AlimentacaoIngredienteDaoNativeImpl`
- switch `IngredienteFornecedorDaoNativeImpl` to use `ConnectionFactory` and `PreparedStatement`
- convert `TreinoExercicioDaoNativeImpl` to JDBC operations
- document JDBC-based DAO implementations with class-level Javadoc

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c089cef8a48325a5dad6c229988cc7