### PR TITLE
refactor: replace EntityManager with JDBC in remaining DAOs

### DIFF
--- a/src/main/java/dao/impl/ExercicioDaoNativeImpl.java
+++ b/src/main/java/dao/impl/ExercicioDaoNativeImpl.java
@@ -1,219 +1,299 @@
 // path: src/main/java/dao/impl/ExercicioDaoNativeImpl.java
 package dao.impl;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import conexao.ConnectionFactory;
 import dao.api.ExercicioDao;
 import exception.ExercicioException;
-import infra.EntityManagerUtil;
 import infra.Logger;
-import javax.persistence.EntityManager;
-import javax.persistence.Query;
 import model.Exercicio;
 
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * JDBC implementation of {@link ExercicioDao} replacing the old EntityManager based version.
+ */
 public class ExercicioDaoNativeImpl implements ExercicioDao {
+
+    private Exercicio map(ResultSet rs) throws SQLException {
+        Exercicio e = new Exercicio();
+        e.setIdExercicio(rs.getInt("id_exercicio"));
+        e.setNome(rs.getString("nome"));
+        e.setCargaLeve((Integer) rs.getObject("carga_leve"));
+        e.setCargaMedia((Integer) rs.getObject("carga_media"));
+        e.setCargaMaxima((Integer) rs.getObject("carga_maxima"));
+        return e;
+    }
 
     @Override
     public void create(Exercicio exercicio) throws ExercicioException {
         Logger.info("ExercicioDaoNativeImpl.create - inicio");
-        EntityManager em = EntityManagerUtil.getEntityManager();
+        String sql = "INSERT INTO Exercicio (nome, carga_leve, carga_media, carga_maxima) VALUES (?,?,?,?)";
+        Connection conn = null;
         try {
-            em.getTransaction().begin();
-            String sql = "INSERT INTO Exercicio (nome, carga_leve, carga_media, carga_maxima) " +
-                    "VALUES (:nome, :cargaLeve, :cargaMedia, :cargaMaxima)";
-            Query query = em.createNativeQuery(sql);
-            query.setParameter("nome", exercicio.getNome());
-            query.setParameter("cargaLeve", exercicio.getCargaLeve());
-            query.setParameter("cargaMedia", exercicio.getCargaMedia());
-            query.setParameter("cargaMaxima", exercicio.getCargaMaxima());
-            query.executeUpdate();
-            em.getTransaction().commit();
+            conn = ConnectionFactory.getConnection();
+            conn.setAutoCommit(false);
+            try (PreparedStatement ps = conn.prepareStatement(sql)) {
+                ps.setString(1, exercicio.getNome());
+                if (exercicio.getCargaLeve() != null) {
+                    ps.setInt(2, exercicio.getCargaLeve());
+                } else {
+                    ps.setNull(2, Types.INTEGER);
+                }
+                if (exercicio.getCargaMedia() != null) {
+                    ps.setInt(3, exercicio.getCargaMedia());
+                } else {
+                    ps.setNull(3, Types.INTEGER);
+                }
+                if (exercicio.getCargaMaxima() != null) {
+                    ps.setInt(4, exercicio.getCargaMaxima());
+                } else {
+                    ps.setNull(4, Types.INTEGER);
+                }
+                ps.executeUpdate();
+            }
+            conn.commit();
             Logger.info("ExercicioDaoNativeImpl.create - sucesso");
-        } catch (Exception e) {
-            em.getTransaction().rollback();
+        } catch (SQLException e) {
+            if (conn != null) {
+                try { conn.rollback(); } catch (SQLException ex) { Logger.error("Rollback create", ex); }
+            }
             Logger.error("ExercicioDaoNativeImpl.create - erro", e);
             throw new ExercicioException("Erro ao criar Exercicio", e);
         } finally {
-            em.close();
+            if (conn != null) {
+                try { conn.close(); } catch (SQLException ignore) { }
+            }
         }
     }
 
     @Override
     public Exercicio update(Exercicio exercicio) throws ExercicioException {
         Logger.info("ExercicioDaoNativeImpl.update - inicio");
-        EntityManager em = EntityManagerUtil.getEntityManager();
+        String sql = "UPDATE Exercicio SET nome=?, carga_leve=?, carga_media=?, carga_maxima=? WHERE id_exercicio=?";
+        Connection conn = null;
         try {
-            em.getTransaction().begin();
-            String sql = "UPDATE Exercicio SET nome=:nome, carga_leve=:cargaLeve, carga_media=:cargaMedia, carga_maxima=:cargaMaxima WHERE id_exercicio=:id";
-            Query query = em.createNativeQuery(sql);
-            query.setParameter("nome", exercicio.getNome());
-            query.setParameter("cargaLeve", exercicio.getCargaLeve());
-            query.setParameter("cargaMedia", exercicio.getCargaMedia());
-            query.setParameter("cargaMaxima", exercicio.getCargaMaxima());
-            query.setParameter("id", exercicio.getIdExercicio());
-            int updated = query.executeUpdate();
-            if (updated == 0) {
-                throw new ExercicioException("Exercicio não encontrado: id=" + exercicio.getIdExercicio());
+            conn = ConnectionFactory.getConnection();
+            conn.setAutoCommit(false);
+            try (PreparedStatement ps = conn.prepareStatement(sql)) {
+                ps.setString(1, exercicio.getNome());
+                if (exercicio.getCargaLeve() != null) {
+                    ps.setInt(2, exercicio.getCargaLeve());
+                } else {
+                    ps.setNull(2, Types.INTEGER);
+                }
+                if (exercicio.getCargaMedia() != null) {
+                    ps.setInt(3, exercicio.getCargaMedia());
+                } else {
+                    ps.setNull(3, Types.INTEGER);
+                }
+                if (exercicio.getCargaMaxima() != null) {
+                    ps.setInt(4, exercicio.getCargaMaxima());
+                } else {
+                    ps.setNull(4, Types.INTEGER);
+                }
+                ps.setInt(5, exercicio.getIdExercicio());
+                int updated = ps.executeUpdate();
+                if (updated == 0) {
+                    throw new ExercicioException("Exercicio não encontrado: id=" + exercicio.getIdExercicio());
+                }
             }
-            em.getTransaction().commit();
+            conn.commit();
             Logger.info("ExercicioDaoNativeImpl.update - sucesso");
             return findById(exercicio.getIdExercicio());
-        } catch (ExercicioException e) {
-            em.getTransaction().rollback();
-            Logger.error("ExercicioDaoNativeImpl.update - erro", e);
-            throw e;
-        } catch (Exception e) {
-            em.getTransaction().rollback();
+        } catch (SQLException e) {
+            if (conn != null) {
+                try { conn.rollback(); } catch (SQLException ex) { Logger.error("Rollback update", ex); }
+            }
             Logger.error("ExercicioDaoNativeImpl.update - erro", e);
             throw new ExercicioException("Erro ao atualizar Exercicio", e);
         } finally {
-            em.close();
+            if (conn != null) {
+                try { conn.close(); } catch (SQLException ignore) { }
+            }
         }
     }
 
     @Override
     public void deleteById(Integer id) throws ExercicioException {
         Logger.info("ExercicioDaoNativeImpl.deleteById - inicio");
-        EntityManager em = EntityManagerUtil.getEntityManager();
+        String sql = "DELETE FROM Exercicio WHERE id_exercicio=?";
+        Connection conn = null;
         try {
-            em.getTransaction().begin();
-            String sql = "DELETE FROM Exercicio WHERE id_exercicio=:id";
-            Query query = em.createNativeQuery(sql);
-            query.setParameter("id", id);
-            int deleted = query.executeUpdate();
-            if (deleted == 0) {
-                throw new ExercicioException("Exercicio não encontrado: id=" + id);
+            conn = ConnectionFactory.getConnection();
+            conn.setAutoCommit(false);
+            try (PreparedStatement ps = conn.prepareStatement(sql)) {
+                ps.setInt(1, id);
+                int deleted = ps.executeUpdate();
+                if (deleted == 0) {
+                    throw new ExercicioException("Exercicio não encontrado: id=" + id);
+                }
             }
-            em.getTransaction().commit();
+            conn.commit();
             Logger.info("ExercicioDaoNativeImpl.deleteById - sucesso");
-        } catch (ExercicioException e) {
-            em.getTransaction().rollback();
-            Logger.error("ExercicioDaoNativeImpl.deleteById - erro", e);
-            throw e;
-        } catch (Exception e) {
-            em.getTransaction().rollback();
+        } catch (SQLException e) {
+            if (conn != null) {
+                try { conn.rollback(); } catch (SQLException ex) { Logger.error("Rollback delete", ex); }
+            }
             Logger.error("ExercicioDaoNativeImpl.deleteById - erro", e);
             throw new ExercicioException("Erro ao deletar Exercicio", e);
         } finally {
-            em.close();
+            if (conn != null) {
+                try { conn.close(); } catch (SQLException ignore) { }
+            }
         }
     }
 
     @Override
     public Exercicio findById(Integer id) throws ExercicioException {
         Logger.info("ExercicioDaoNativeImpl.findById - inicio");
-        EntityManager em = EntityManagerUtil.getEntityManager();
-        try {
-            String sql = "SELECT id_exercicio, nome, carga_leve, carga_media, carga_maxima FROM Exercicio WHERE id_exercicio=:id";
-            Query query = em.createNativeQuery(sql, Exercicio.class);
-            query.setParameter("id", id);
-            Exercicio e = (Exercicio) query.getSingleResult();
-            Logger.info("ExercicioDaoNativeImpl.findById - sucesso");
-            return e;
-        } catch (Exception e) {
+        String sql = "SELECT id_exercicio, nome, carga_leve, carga_media, carga_maxima FROM Exercicio WHERE id_exercicio=?";
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    Logger.info("ExercicioDaoNativeImpl.findById - sucesso");
+                    return map(rs);
+                }
+            }
+            throw new ExercicioException("Exercicio não encontrado: id=" + id);
+        } catch (SQLException e) {
             Logger.error("ExercicioDaoNativeImpl.findById - erro", e);
             throw new ExercicioException("Exercicio não encontrado: id=" + id, e);
-        } finally {
-            em.close();
         }
     }
 
     @Override
     public List<Exercicio> findAll() {
         Logger.info("ExercicioDaoNativeImpl.findAll - inicio");
-        EntityManager em = EntityManagerUtil.getEntityManager();
-        try {
-            String sql = "SELECT id_exercicio, nome, carga_leve, carga_media, carga_maxima FROM Exercicio";
-            Query query = em.createNativeQuery(sql, Exercicio.class);
-            List<Exercicio> list = query.getResultList();
+        String sql = "SELECT id_exercicio, nome, carga_leve, carga_media, carga_maxima FROM Exercicio";
+        List<Exercicio> list = new ArrayList<>();
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql);
+             ResultSet rs = ps.executeQuery()) {
+            while (rs.next()) {
+                list.add(map(rs));
+            }
             Logger.info("ExercicioDaoNativeImpl.findAll - sucesso");
-            return list;
-        } finally {
-            em.close();
+        } catch (SQLException e) {
+            Logger.error("ExercicioDaoNativeImpl.findAll - erro", e);
         }
+        return list;
     }
 
     @Override
     public List<Exercicio> findAll(int page, int size) {
         Logger.info("ExercicioDaoNativeImpl.findAll(page) - inicio");
-        EntityManager em = EntityManagerUtil.getEntityManager();
-        try {
-            String sql = "SELECT id_exercicio, nome, carga_leve, carga_media, carga_maxima FROM Exercicio LIMIT :limit OFFSET :offset";
-            Query query = em.createNativeQuery(sql, Exercicio.class);
-            query.setParameter("limit", size);
-            query.setParameter("offset", page * size);
-            List<Exercicio> list = query.getResultList();
+        String sql = "SELECT id_exercicio, nome, carga_leve, carga_media, carga_maxima FROM Exercicio LIMIT ? OFFSET ?";
+        List<Exercicio> list = new ArrayList<>();
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, size);
+            ps.setInt(2, page * size);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    list.add(map(rs));
+                }
+            }
             Logger.info("ExercicioDaoNativeImpl.findAll(page) - sucesso");
-            return list;
-        } finally {
-            em.close();
+        } catch (SQLException e) {
+            Logger.error("ExercicioDaoNativeImpl.findAll(page) - erro", e);
         }
+        return list;
     }
 
     @Override
     public List<Exercicio> findByNome(String nome) {
         Logger.info("ExercicioDaoNativeImpl.findByNome - inicio");
-        EntityManager em = EntityManagerUtil.getEntityManager();
-        try {
-            String sql = "SELECT id_exercicio, nome, carga_leve, carga_media, carga_maxima FROM Exercicio WHERE nome=:nome";
-            Query query = em.createNativeQuery(sql, Exercicio.class);
-            query.setParameter("nome", nome);
-            List<Exercicio> list = query.getResultList();
+        String sql = "SELECT id_exercicio, nome, carga_leve, carga_media, carga_maxima FROM Exercicio WHERE nome=?";
+        List<Exercicio> list = new ArrayList<>();
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, nome);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    list.add(map(rs));
+                }
+            }
             Logger.info("ExercicioDaoNativeImpl.findByNome - sucesso");
-            return list;
-        } finally {
-            em.close();
+        } catch (SQLException e) {
+            Logger.error("ExercicioDaoNativeImpl.findByNome - erro", e);
         }
+        return list;
     }
 
     @Override
     public List<Exercicio> findByCargaLeve(Integer cargaLeve) {
         Logger.info("ExercicioDaoNativeImpl.findByCargaLeve - inicio");
-        EntityManager em = EntityManagerUtil.getEntityManager();
-        try {
-            String sql = "SELECT id_exercicio, nome, carga_leve, carga_media, carga_maxima FROM Exercicio WHERE carga_leve=:cargaLeve";
-            Query query = em.createNativeQuery(sql, Exercicio.class);
-            query.setParameter("cargaLeve", cargaLeve);
-            List<Exercicio> list = query.getResultList();
+        String sql = "SELECT id_exercicio, nome, carga_leve, carga_media, carga_maxima FROM Exercicio WHERE carga_leve=?";
+        List<Exercicio> list = new ArrayList<>();
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            if (cargaLeve != null) {
+                ps.setInt(1, cargaLeve);
+            } else {
+                ps.setNull(1, Types.INTEGER);
+            }
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    list.add(map(rs));
+                }
+            }
             Logger.info("ExercicioDaoNativeImpl.findByCargaLeve - sucesso");
-            return list;
-        } finally {
-            em.close();
+        } catch (SQLException e) {
+            Logger.error("ExercicioDaoNativeImpl.findByCargaLeve - erro", e);
         }
+        return list;
     }
 
     @Override
     public List<Exercicio> findByCargaMedia(Integer cargaMedia) {
         Logger.info("ExercicioDaoNativeImpl.findByCargaMedia - inicio");
-        EntityManager em = EntityManagerUtil.getEntityManager();
-        try {
-            String sql = "SELECT id_exercicio, nome, carga_leve, carga_media, carga_maxima FROM Exercicio WHERE carga_media=:cargaMedia";
-            Query query = em.createNativeQuery(sql, Exercicio.class);
-            query.setParameter("cargaMedia", cargaMedia);
-            List<Exercicio> list = query.getResultList();
+        String sql = "SELECT id_exercicio, nome, carga_leve, carga_media, carga_maxima FROM Exercicio WHERE carga_media=?";
+        List<Exercicio> list = new ArrayList<>();
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            if (cargaMedia != null) {
+                ps.setInt(1, cargaMedia);
+            } else {
+                ps.setNull(1, Types.INTEGER);
+            }
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    list.add(map(rs));
+                }
+            }
             Logger.info("ExercicioDaoNativeImpl.findByCargaMedia - sucesso");
-            return list;
-        } finally {
-            em.close();
+        } catch (SQLException e) {
+            Logger.error("ExercicioDaoNativeImpl.findByCargaMedia - erro", e);
         }
+        return list;
     }
 
     @Override
     public List<Exercicio> findByCargaMaxima(Integer cargaMaxima) {
         Logger.info("ExercicioDaoNativeImpl.findByCargaMaxima - inicio");
-        EntityManager em = EntityManagerUtil.getEntityManager();
-        try {
-            String sql = "SELECT id_exercicio, nome, carga_leve, carga_media, carga_maxima FROM Exercicio WHERE carga_maxima=:cargaMaxima";
-            Query query = em.createNativeQuery(sql, Exercicio.class);
-            query.setParameter("cargaMaxima", cargaMaxima);
-            List<Exercicio> list = query.getResultList();
+        String sql = "SELECT id_exercicio, nome, carga_leve, carga_media, carga_maxima FROM Exercicio WHERE carga_maxima=?";
+        List<Exercicio> list = new ArrayList<>();
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            if (cargaMaxima != null) {
+                ps.setInt(1, cargaMaxima);
+            } else {
+                ps.setNull(1, Types.INTEGER);
+            }
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    list.add(map(rs));
+                }
+            }
             Logger.info("ExercicioDaoNativeImpl.findByCargaMaxima - sucesso");
-            return list;
-        } finally {
-            em.close();
+        } catch (SQLException e) {
+            Logger.error("ExercicioDaoNativeImpl.findByCargaMaxima - erro", e);
         }
+        return list;
     }
 
     @Override
@@ -224,42 +304,45 @@ public class ExercicioDaoNativeImpl implements ExercicioDao {
     @Override
     public List<Exercicio> search(Exercicio filtro, int page, int size) {
         Logger.info("ExercicioDaoNativeImpl.search - inicio");
-        EntityManager em = EntityManagerUtil.getEntityManager();
-        try {
-            StringBuilder sb = new StringBuilder("SELECT id_exercicio, nome, carga_leve, carga_media, carga_maxima FROM Exercicio WHERE 1=1");
-            Map<String, Object> params = new HashMap<>();
-            if (filtro.getNome() != null && !filtro.getNome().isEmpty()) {
-                sb.append(" AND nome=:nome");
-                params.put("nome", filtro.getNome());
-            }
-            if (filtro.getCargaLeve() != null) {
-                sb.append(" AND carga_leve=:cargaLeve");
-                params.put("cargaLeve", filtro.getCargaLeve());
-            }
-            if (filtro.getCargaMedia() != null) {
-                sb.append(" AND carga_media=:cargaMedia");
-                params.put("cargaMedia", filtro.getCargaMedia());
-            }
-            if (filtro.getCargaMaxima() != null) {
-                sb.append(" AND carga_maxima=:cargaMaxima");
-                params.put("cargaMaxima", filtro.getCargaMaxima());
-            }
-            if (page >= 0 && size > 0) {
-                sb.append(" LIMIT :limit OFFSET :offset");
-            }
-            Query query = em.createNativeQuery(sb.toString(), Exercicio.class);
-            for (Map.Entry<String, Object> e : params.entrySet()) {
-                query.setParameter(e.getKey(), e.getValue());
-            }
-            if (page >= 0 && size > 0) {
-                query.setParameter("limit", size);
-                query.setParameter("offset", page * size);
-            }
-            List<Exercicio> list = query.getResultList();
-            Logger.info("ExercicioDaoNativeImpl.search - sucesso");
-            return list;
-        } finally {
-            em.close();
+        StringBuilder sb = new StringBuilder("SELECT id_exercicio, nome, carga_leve, carga_media, carga_maxima FROM Exercicio WHERE 1=1");
+        List<Object> params = new ArrayList<>();
+        if (filtro.getNome() != null && !filtro.getNome().isEmpty()) {
+            sb.append(" AND nome=?");
+            params.add(filtro.getNome());
         }
+        if (filtro.getCargaLeve() != null) {
+            sb.append(" AND carga_leve=?");
+            params.add(filtro.getCargaLeve());
+        }
+        if (filtro.getCargaMedia() != null) {
+            sb.append(" AND carga_media=?");
+            params.add(filtro.getCargaMedia());
+        }
+        if (filtro.getCargaMaxima() != null) {
+            sb.append(" AND carga_maxima=?");
+            params.add(filtro.getCargaMaxima());
+        }
+        if (page >= 0 && size > 0) {
+            sb.append(" LIMIT ? OFFSET ?");
+            params.add(size);
+            params.add(page * size);
+        }
+        List<Exercicio> list = new ArrayList<>();
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sb.toString())) {
+            for (int i = 0; i < params.size(); i++) {
+                ps.setObject(i + 1, params.get(i));
+            }
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    list.add(map(rs));
+                }
+            }
+            Logger.info("ExercicioDaoNativeImpl.search - sucesso");
+        } catch (SQLException e) {
+            Logger.error("ExercicioDaoNativeImpl.search - erro", e);
+        }
+        return list;
     }
 }
+

--- a/src/main/java/dao/impl/FornecedorDaoNativeImpl.java
+++ b/src/main/java/dao/impl/FornecedorDaoNativeImpl.java
@@ -1,238 +1,297 @@
 // path: src/main/java/dao/impl/FornecedorDaoNativeImpl.java
 package dao.impl;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import conexao.ConnectionFactory;
 import dao.api.FornecedorDao;
 import exception.FornecedorException;
-import infra.EntityManagerUtil;
 import infra.Logger;
-import javax.persistence.EntityManager;
-import javax.persistence.Query;
 import model.Fornecedor;
 
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * JDBC implementation of {@link FornecedorDao}.
+ */
 public class FornecedorDaoNativeImpl implements FornecedorDao {
+
+    private Fornecedor map(ResultSet rs, boolean withFoto) throws SQLException {
+        Fornecedor f = new Fornecedor();
+        f.setIdFornecedor(rs.getInt("id_fornecedor"));
+        f.setNome(rs.getString("nome"));
+        if (withFoto) {
+            f.setFoto(rs.getBytes("foto"));
+        }
+        f.setEndereco(rs.getString("endereco"));
+        f.setOnline((Boolean) rs.getObject("online"));
+        return f;
+    }
 
     @Override
     public void create(Fornecedor fornecedor) throws FornecedorException {
         Logger.info("FornecedorDaoNativeImpl.create - inicio");
-        EntityManager em = EntityManagerUtil.getEntityManager();
+        String sql = "INSERT INTO Fornecedor (nome, foto, endereco, online) VALUES (?,?,?,?)";
+        Connection conn = null;
         try {
-            em.getTransaction().begin();
-            String sql = "INSERT INTO Fornecedor (nome, foto, endereco, online) " +
-                    "VALUES (:nome, :foto, :endereco, :online)";
-            Query query = em.createNativeQuery(sql);
-            query.setParameter("nome", fornecedor.getNome());
-            query.setParameter("foto", fornecedor.getFoto());
-            query.setParameter("endereco", fornecedor.getEndereco());
-            query.setParameter("online", fornecedor.getOnline());
-            query.executeUpdate();
-            em.getTransaction().commit();
+            conn = ConnectionFactory.getConnection();
+            conn.setAutoCommit(false);
+            try (PreparedStatement ps = conn.prepareStatement(sql)) {
+                ps.setString(1, fornecedor.getNome());
+                ps.setBytes(2, fornecedor.getFoto());
+                ps.setString(3, fornecedor.getEndereco());
+                if (fornecedor.getOnline() != null) {
+                    ps.setBoolean(4, fornecedor.getOnline());
+                } else {
+                    ps.setNull(4, Types.BOOLEAN);
+                }
+                ps.executeUpdate();
+            }
+            conn.commit();
             Logger.info("FornecedorDaoNativeImpl.create - sucesso");
-        } catch (Exception e) {
-            em.getTransaction().rollback();
+        } catch (SQLException e) {
+            if (conn != null) {
+                try { conn.rollback(); } catch (SQLException ex) { Logger.error("Rollback create", ex); }
+            }
             Logger.error("FornecedorDaoNativeImpl.create - erro", e);
             throw new FornecedorException("Erro ao criar Fornecedor", e);
         } finally {
-            em.close();
+            if (conn != null) {
+                try { conn.close(); } catch (SQLException ignore) { }
+            }
         }
     }
 
     @Override
     public Fornecedor update(Fornecedor fornecedor) throws FornecedorException {
         Logger.info("FornecedorDaoNativeImpl.update - inicio");
-        EntityManager em = EntityManagerUtil.getEntityManager();
+        String sql = "UPDATE Fornecedor SET nome=?, foto=?, endereco=?, online=? WHERE id_fornecedor=?";
+        Connection conn = null;
         try {
-            em.getTransaction().begin();
-            String sql = "UPDATE Fornecedor SET nome=:nome, foto=:foto, endereco=:endereco, online=:online WHERE id_fornecedor=:id";
-            Query query = em.createNativeQuery(sql);
-            query.setParameter("nome", fornecedor.getNome());
-            query.setParameter("foto", fornecedor.getFoto());
-            query.setParameter("endereco", fornecedor.getEndereco());
-            query.setParameter("online", fornecedor.getOnline());
-            query.setParameter("id", fornecedor.getIdFornecedor());
-            int updated = query.executeUpdate();
-            if (updated == 0) {
-                throw new FornecedorException("Fornecedor não encontrado: id=" + fornecedor.getIdFornecedor());
+            conn = ConnectionFactory.getConnection();
+            conn.setAutoCommit(false);
+            try (PreparedStatement ps = conn.prepareStatement(sql)) {
+                ps.setString(1, fornecedor.getNome());
+                ps.setBytes(2, fornecedor.getFoto());
+                ps.setString(3, fornecedor.getEndereco());
+                if (fornecedor.getOnline() != null) {
+                    ps.setBoolean(4, fornecedor.getOnline());
+                } else {
+                    ps.setNull(4, Types.BOOLEAN);
+                }
+                ps.setInt(5, fornecedor.getIdFornecedor());
+                int updated = ps.executeUpdate();
+                if (updated == 0) {
+                    throw new FornecedorException("Fornecedor não encontrado: id=" + fornecedor.getIdFornecedor());
+                }
             }
-            em.getTransaction().commit();
+            conn.commit();
             Logger.info("FornecedorDaoNativeImpl.update - sucesso");
             return findById(fornecedor.getIdFornecedor());
-        } catch (FornecedorException e) {
-            em.getTransaction().rollback();
-            Logger.error("FornecedorDaoNativeImpl.update - erro", e);
-            throw e;
-        } catch (Exception e) {
-            em.getTransaction().rollback();
+        } catch (SQLException e) {
+            if (conn != null) {
+                try { conn.rollback(); } catch (SQLException ex) { Logger.error("Rollback update", ex); }
+            }
             Logger.error("FornecedorDaoNativeImpl.update - erro", e);
             throw new FornecedorException("Erro ao atualizar Fornecedor", e);
         } finally {
-            em.close();
+            if (conn != null) {
+                try { conn.close(); } catch (SQLException ignore) { }
+            }
         }
     }
 
     @Override
     public void deleteById(Integer id) throws FornecedorException {
         Logger.info("FornecedorDaoNativeImpl.deleteById - inicio");
-        EntityManager em = EntityManagerUtil.getEntityManager();
+        String sql = "DELETE FROM Fornecedor WHERE id_fornecedor=?";
+        Connection conn = null;
         try {
-            em.getTransaction().begin();
-            String sql = "DELETE FROM Fornecedor WHERE id_fornecedor=:id";
-            Query query = em.createNativeQuery(sql);
-            query.setParameter("id", id);
-            int deleted = query.executeUpdate();
-            if (deleted == 0) {
-                throw new FornecedorException("Fornecedor não encontrado: id=" + id);
+            conn = ConnectionFactory.getConnection();
+            conn.setAutoCommit(false);
+            try (PreparedStatement ps = conn.prepareStatement(sql)) {
+                ps.setInt(1, id);
+                int deleted = ps.executeUpdate();
+                if (deleted == 0) {
+                    throw new FornecedorException("Fornecedor não encontrado: id=" + id);
+                }
             }
-            em.getTransaction().commit();
+            conn.commit();
             Logger.info("FornecedorDaoNativeImpl.deleteById - sucesso");
-        } catch (FornecedorException e) {
-            em.getTransaction().rollback();
-            Logger.error("FornecedorDaoNativeImpl.deleteById - erro", e);
-            throw e;
-        } catch (Exception e) {
-            em.getTransaction().rollback();
+        } catch (SQLException e) {
+            if (conn != null) {
+                try { conn.rollback(); } catch (SQLException ex) { Logger.error("Rollback delete", ex); }
+            }
             Logger.error("FornecedorDaoNativeImpl.deleteById - erro", e);
             throw new FornecedorException("Erro ao deletar Fornecedor", e);
         } finally {
-            em.close();
+            if (conn != null) {
+                try { conn.close(); } catch (SQLException ignore) { }
+            }
         }
     }
 
     @Override
     public Fornecedor findById(Integer id) throws FornecedorException {
         Logger.info("FornecedorDaoNativeImpl.findById - inicio");
-        EntityManager em = EntityManagerUtil.getEntityManager();
-        try {
-            String sql = "SELECT id_fornecedor, nome, endereco, online FROM Fornecedor WHERE id_fornecedor=:id";
-            Query query = em.createNativeQuery(sql, Fornecedor.class);
-            query.setParameter("id", id);
-            Fornecedor f = (Fornecedor) query.getSingleResult();
-            Logger.info("FornecedorDaoNativeImpl.findById - sucesso");
-            return f;
-        } catch (Exception e) {
+        String sql = "SELECT id_fornecedor, nome, endereco, online FROM Fornecedor WHERE id_fornecedor=?";
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    Logger.info("FornecedorDaoNativeImpl.findById - sucesso");
+                    return map(rs, false);
+                }
+            }
+            throw new FornecedorException("Fornecedor não encontrado: id=" + id);
+        } catch (SQLException e) {
             Logger.error("FornecedorDaoNativeImpl.findById - erro", e);
             throw new FornecedorException("Fornecedor não encontrado: id=" + id, e);
-        } finally {
-            em.close();
         }
     }
 
     @Override
     public Fornecedor findWithFotoById(Integer id) throws FornecedorException {
         Logger.info("FornecedorDaoNativeImpl.findWithFotoById - inicio");
-        EntityManager em = EntityManagerUtil.getEntityManager();
-        try {
-            String sql = "SELECT id_fornecedor, nome, foto, endereco, online FROM Fornecedor WHERE id_fornecedor=:id";
-            Query query = em.createNativeQuery(sql, Fornecedor.class);
-            query.setParameter("id", id);
-            Fornecedor f = (Fornecedor) query.getSingleResult();
-            Logger.info("FornecedorDaoNativeImpl.findWithFotoById - sucesso");
-            return f;
-        } catch (Exception e) {
+        String sql = "SELECT id_fornecedor, nome, foto, endereco, online FROM Fornecedor WHERE id_fornecedor=?";
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    Logger.info("FornecedorDaoNativeImpl.findWithFotoById - sucesso");
+                    return map(rs, true);
+                }
+            }
+            throw new FornecedorException("Fornecedor não encontrado: id=" + id);
+        } catch (SQLException e) {
             Logger.error("FornecedorDaoNativeImpl.findWithFotoById - erro", e);
             throw new FornecedorException("Fornecedor não encontrado: id=" + id, e);
-        } finally {
-            em.close();
         }
     }
 
     @Override
     public List<Fornecedor> findAll() {
         Logger.info("FornecedorDaoNativeImpl.findAll - inicio");
-        EntityManager em = EntityManagerUtil.getEntityManager();
-        try {
-            String sql = "SELECT id_fornecedor, nome, endereco, online FROM Fornecedor";
-            Query query = em.createNativeQuery(sql, Fornecedor.class);
-            List<Fornecedor> list = query.getResultList();
+        String sql = "SELECT id_fornecedor, nome, endereco, online FROM Fornecedor";
+        List<Fornecedor> list = new ArrayList<>();
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql);
+             ResultSet rs = ps.executeQuery()) {
+            while (rs.next()) {
+                list.add(map(rs, false));
+            }
             Logger.info("FornecedorDaoNativeImpl.findAll - sucesso");
-            return list;
-        } finally {
-            em.close();
+        } catch (SQLException e) {
+            Logger.error("FornecedorDaoNativeImpl.findAll - erro", e);
         }
+        return list;
     }
 
     @Override
     public List<Fornecedor> findAll(int page, int size) {
         Logger.info("FornecedorDaoNativeImpl.findAll(page) - inicio");
-        EntityManager em = EntityManagerUtil.getEntityManager();
-        try {
-            String sql = "SELECT id_fornecedor, nome, endereco, online FROM Fornecedor LIMIT :limit OFFSET :offset";
-            Query query = em.createNativeQuery(sql, Fornecedor.class);
-            query.setParameter("limit", size);
-            query.setParameter("offset", page * size);
-            List<Fornecedor> list = query.getResultList();
+        String sql = "SELECT id_fornecedor, nome, endereco, online FROM Fornecedor LIMIT ? OFFSET ?";
+        List<Fornecedor> list = new ArrayList<>();
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, size);
+            ps.setInt(2, page * size);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    list.add(map(rs, false));
+                }
+            }
             Logger.info("FornecedorDaoNativeImpl.findAll(page) - sucesso");
-            return list;
-        } finally {
-            em.close();
+        } catch (SQLException e) {
+            Logger.error("FornecedorDaoNativeImpl.findAll(page) - erro", e);
         }
+        return list;
     }
 
     @Override
     public List<Fornecedor> findByNome(String nome) {
         Logger.info("FornecedorDaoNativeImpl.findByNome - inicio");
-        EntityManager em = EntityManagerUtil.getEntityManager();
-        try {
-            String sql = "SELECT id_fornecedor, nome, endereco, online FROM Fornecedor WHERE nome=:nome";
-            Query query = em.createNativeQuery(sql, Fornecedor.class);
-            query.setParameter("nome", nome);
-            List<Fornecedor> list = query.getResultList();
+        String sql = "SELECT id_fornecedor, nome, endereco, online FROM Fornecedor WHERE nome=?";
+        List<Fornecedor> list = new ArrayList<>();
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, nome);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    list.add(map(rs, false));
+                }
+            }
             Logger.info("FornecedorDaoNativeImpl.findByNome - sucesso");
-            return list;
-        } finally {
-            em.close();
+        } catch (SQLException e) {
+            Logger.error("FornecedorDaoNativeImpl.findByNome - erro", e);
         }
+        return list;
     }
 
     @Override
     public List<Fornecedor> findByFoto(byte[] foto) {
         Logger.info("FornecedorDaoNativeImpl.findByFoto - inicio");
-        EntityManager em = EntityManagerUtil.getEntityManager();
-        try {
-            String sql = "SELECT id_fornecedor, nome, foto, endereco, online FROM Fornecedor WHERE foto=:foto";
-            Query query = em.createNativeQuery(sql, Fornecedor.class);
-            query.setParameter("foto", foto);
-            List<Fornecedor> list = query.getResultList();
+        String sql = "SELECT id_fornecedor, nome, foto, endereco, online FROM Fornecedor WHERE foto=?";
+        List<Fornecedor> list = new ArrayList<>();
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setBytes(1, foto);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    list.add(map(rs, true));
+                }
+            }
             Logger.info("FornecedorDaoNativeImpl.findByFoto - sucesso");
-            return list;
-        } finally {
-            em.close();
+        } catch (SQLException e) {
+            Logger.error("FornecedorDaoNativeImpl.findByFoto - erro", e);
         }
+        return list;
     }
 
     @Override
     public List<Fornecedor> findByEndereco(String endereco) {
         Logger.info("FornecedorDaoNativeImpl.findByEndereco - inicio");
-        EntityManager em = EntityManagerUtil.getEntityManager();
-        try {
-            String sql = "SELECT id_fornecedor, nome, endereco, online FROM Fornecedor WHERE endereco=:endereco";
-            Query query = em.createNativeQuery(sql, Fornecedor.class);
-            query.setParameter("endereco", endereco);
-            List<Fornecedor> list = query.getResultList();
+        String sql = "SELECT id_fornecedor, nome, endereco, online FROM Fornecedor WHERE endereco=?";
+        List<Fornecedor> list = new ArrayList<>();
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, endereco);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    list.add(map(rs, false));
+                }
+            }
             Logger.info("FornecedorDaoNativeImpl.findByEndereco - sucesso");
-            return list;
-        } finally {
-            em.close();
+        } catch (SQLException e) {
+            Logger.error("FornecedorDaoNativeImpl.findByEndereco - erro", e);
         }
+        return list;
     }
 
     @Override
     public List<Fornecedor> findByOnline(Boolean online) {
         Logger.info("FornecedorDaoNativeImpl.findByOnline - inicio");
-        EntityManager em = EntityManagerUtil.getEntityManager();
-        try {
-            String sql = "SELECT id_fornecedor, nome, endereco, online FROM Fornecedor WHERE online=:online";
-            Query query = em.createNativeQuery(sql, Fornecedor.class);
-            query.setParameter("online", online);
-            List<Fornecedor> list = query.getResultList();
+        String sql = "SELECT id_fornecedor, nome, endereco, online FROM Fornecedor WHERE online=?";
+        List<Fornecedor> list = new ArrayList<>();
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            if (online != null) {
+                ps.setBoolean(1, online);
+            } else {
+                ps.setNull(1, Types.BOOLEAN);
+            }
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    list.add(map(rs, false));
+                }
+            }
             Logger.info("FornecedorDaoNativeImpl.findByOnline - sucesso");
-            return list;
-        } finally {
-            em.close();
+        } catch (SQLException e) {
+            Logger.error("FornecedorDaoNativeImpl.findByOnline - erro", e);
         }
+        return list;
     }
 
     @Override
@@ -243,42 +302,45 @@ public class FornecedorDaoNativeImpl implements FornecedorDao {
     @Override
     public List<Fornecedor> search(Fornecedor filtro, int page, int size) {
         Logger.info("FornecedorDaoNativeImpl.search - inicio");
-        EntityManager em = EntityManagerUtil.getEntityManager();
-        try {
-            StringBuilder sb = new StringBuilder("SELECT id_fornecedor, nome, endereco, online FROM Fornecedor WHERE 1=1");
-            Map<String, Object> params = new HashMap<>();
-            if (filtro.getNome() != null && !filtro.getNome().isEmpty()) {
-                sb.append(" AND nome=:nome");
-                params.put("nome", filtro.getNome());
-            }
-            if (filtro.getFoto() != null) {
-                sb.append(" AND foto=:foto");
-                params.put("foto", filtro.getFoto());
-            }
-            if (filtro.getEndereco() != null && !filtro.getEndereco().isEmpty()) {
-                sb.append(" AND endereco=:endereco");
-                params.put("endereco", filtro.getEndereco());
-            }
-            if (filtro.getOnline() != null) {
-                sb.append(" AND online=:online");
-                params.put("online", filtro.getOnline());
-            }
-            if (page >= 0 && size > 0) {
-                sb.append(" LIMIT :limit OFFSET :offset");
-            }
-            Query query = em.createNativeQuery(sb.toString(), Fornecedor.class);
-            for (Map.Entry<String, Object> e : params.entrySet()) {
-                query.setParameter(e.getKey(), e.getValue());
-            }
-            if (page >= 0 && size > 0) {
-                query.setParameter("limit", size);
-                query.setParameter("offset", page * size);
-            }
-            List<Fornecedor> list = query.getResultList();
-            Logger.info("FornecedorDaoNativeImpl.search - sucesso");
-            return list;
-        } finally {
-            em.close();
+        StringBuilder sb = new StringBuilder("SELECT id_fornecedor, nome, endereco, online FROM Fornecedor WHERE 1=1");
+        List<Object> params = new ArrayList<>();
+        if (filtro.getNome() != null && !filtro.getNome().isEmpty()) {
+            sb.append(" AND nome=?");
+            params.add(filtro.getNome());
         }
+        if (filtro.getFoto() != null) {
+            sb.append(" AND foto=?");
+            params.add(filtro.getFoto());
+        }
+        if (filtro.getEndereco() != null && !filtro.getEndereco().isEmpty()) {
+            sb.append(" AND endereco=?");
+            params.add(filtro.getEndereco());
+        }
+        if (filtro.getOnline() != null) {
+            sb.append(" AND online=?");
+            params.add(filtro.getOnline());
+        }
+        if (page >= 0 && size > 0) {
+            sb.append(" LIMIT ? OFFSET ?");
+            params.add(size);
+            params.add(page * size);
+        }
+        List<Fornecedor> list = new ArrayList<>();
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sb.toString())) {
+            for (int i = 0; i < params.size(); i++) {
+                ps.setObject(i + 1, params.get(i));
+            }
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    list.add(map(rs, false));
+                }
+            }
+            Logger.info("FornecedorDaoNativeImpl.search - sucesso");
+        } catch (SQLException e) {
+            Logger.error("FornecedorDaoNativeImpl.search - erro", e);
+        }
+        return list;
     }
 }
+

--- a/src/main/java/dao/impl/MetaDaoNativeImpl.java
+++ b/src/main/java/dao/impl/MetaDaoNativeImpl.java
@@ -1,102 +1,362 @@
 package dao.impl;
 
+import conexao.ConnectionFactory;
 import dao.api.MetaDao;
 import exception.MetaException;
-import infra.EntityManagerUtil;
 import infra.Logger;
-import javax.persistence.EntityManager;
-import javax.persistence.Query;
 import model.Meta;
 
+import java.sql.*;
+import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * JDBC implementation of {@link MetaDao}.
+ */
 public class MetaDaoNativeImpl implements MetaDao {
-    private final EntityManager em = EntityManagerUtil.getEntityManager();
+
+    private Meta map(ResultSet rs, boolean withFoto) throws SQLException {
+        Meta m = new Meta();
+        m.setIdMeta(rs.getInt("id_meta"));
+        m.setPontoMinimo((Integer) rs.getObject("ponto_minimo"));
+        m.setPontoMedio((Integer) rs.getObject("ponto_medio"));
+        m.setPontoMaximo((Integer) rs.getObject("ponto_maximo"));
+        m.setStatus((Integer) rs.getObject("status"));
+        if (withFoto) {
+            m.setFoto(rs.getBytes("foto"));
+        }
+        m.setIdPeriodo((Integer) rs.getObject("id_periodo"));
+        return m;
+    }
 
     @Override
     public void create(Meta meta) {
-        Logger.info("MetaDao.create");
-        em.getTransaction().begin();
-        meta.setIdMeta(null);
-        em.persist(meta);
-        em.getTransaction().commit();
+        Logger.info("MetaDaoNativeImpl.create - inicio");
+        String sql = "INSERT INTO Meta (ponto_minimo, ponto_medio, ponto_maximo, status, foto, id_periodo) VALUES (?,?,?,?,?,?)";
+        Connection conn = null;
+        try {
+            conn = ConnectionFactory.getConnection();
+            conn.setAutoCommit(false);
+            try (PreparedStatement ps = conn.prepareStatement(sql)) {
+                if (meta.getPontoMinimo() != null) {
+                    ps.setInt(1, meta.getPontoMinimo());
+                } else {
+                    ps.setNull(1, Types.INTEGER);
+                }
+                if (meta.getPontoMedio() != null) {
+                    ps.setInt(2, meta.getPontoMedio());
+                } else {
+                    ps.setNull(2, Types.INTEGER);
+                }
+                if (meta.getPontoMaximo() != null) {
+                    ps.setInt(3, meta.getPontoMaximo());
+                } else {
+                    ps.setNull(3, Types.INTEGER);
+                }
+                if (meta.getStatus() != null) {
+                    ps.setInt(4, meta.getStatus());
+                } else {
+                    ps.setNull(4, Types.INTEGER);
+                }
+                ps.setBytes(5, meta.getFoto());
+                if (meta.getIdPeriodo() != null) {
+                    ps.setInt(6, meta.getIdPeriodo());
+                } else {
+                    ps.setNull(6, Types.INTEGER);
+                }
+                ps.executeUpdate();
+            }
+            conn.commit();
+        } catch (SQLException e) {
+            if (conn != null) {
+                try { conn.rollback(); } catch (SQLException ex) { Logger.error("Rollback create", ex); }
+            }
+            Logger.error("MetaDaoNativeImpl.create - erro", e);
+            throw new MetaException("Erro ao criar Meta", e);
+        } finally {
+            if (conn != null) {
+                try { conn.close(); } catch (SQLException ignore) { }
+            }
+        }
     }
 
     @Override
     public void update(Meta meta) {
-        Logger.info("MetaDao.update" );
-        em.getTransaction().begin();
-        em.merge(meta);
-        em.getTransaction().commit();
+        Logger.info("MetaDaoNativeImpl.update - inicio");
+        String sql = "UPDATE Meta SET ponto_minimo=?, ponto_medio=?, ponto_maximo=?, status=?, foto=?, id_periodo=? WHERE id_meta=?";
+        Connection conn = null;
+        try {
+            conn = ConnectionFactory.getConnection();
+            conn.setAutoCommit(false);
+            try (PreparedStatement ps = conn.prepareStatement(sql)) {
+                if (meta.getPontoMinimo() != null) {
+                    ps.setInt(1, meta.getPontoMinimo());
+                } else {
+                    ps.setNull(1, Types.INTEGER);
+                }
+                if (meta.getPontoMedio() != null) {
+                    ps.setInt(2, meta.getPontoMedio());
+                } else {
+                    ps.setNull(2, Types.INTEGER);
+                }
+                if (meta.getPontoMaximo() != null) {
+                    ps.setInt(3, meta.getPontoMaximo());
+                } else {
+                    ps.setNull(3, Types.INTEGER);
+                }
+                if (meta.getStatus() != null) {
+                    ps.setInt(4, meta.getStatus());
+                } else {
+                    ps.setNull(4, Types.INTEGER);
+                }
+                ps.setBytes(5, meta.getFoto());
+                if (meta.getIdPeriodo() != null) {
+                    ps.setInt(6, meta.getIdPeriodo());
+                } else {
+                    ps.setNull(6, Types.INTEGER);
+                }
+                ps.setInt(7, meta.getIdMeta());
+                int updated = ps.executeUpdate();
+                if (updated == 0) {
+                    throw new MetaException("Meta nao encontrada: id=" + meta.getIdMeta());
+                }
+            }
+            conn.commit();
+        } catch (SQLException e) {
+            if (conn != null) {
+                try { conn.rollback(); } catch (SQLException ex) { Logger.error("Rollback update", ex); }
+            }
+            Logger.error("MetaDaoNativeImpl.update - erro", e);
+            throw new MetaException("Erro ao atualizar Meta", e);
+        } finally {
+            if (conn != null) {
+                try { conn.close(); } catch (SQLException ignore) { }
+            }
+        }
     }
 
     @Override
     public void deleteById(Integer id) {
-        Logger.info("MetaDao.deleteById" );
-        Meta m = em.find(Meta.class, id);
-        if (m == null) throw new MetaException("Meta nao encontrada: id=" + id);
-        em.getTransaction().begin();
-        em.remove(m);
-        em.getTransaction().commit();
+        Logger.info("MetaDaoNativeImpl.deleteById - inicio");
+        String sql = "DELETE FROM Meta WHERE id_meta=?";
+        Connection conn = null;
+        try {
+            conn = ConnectionFactory.getConnection();
+            conn.setAutoCommit(false);
+            try (PreparedStatement ps = conn.prepareStatement(sql)) {
+                ps.setInt(1, id);
+                int deleted = ps.executeUpdate();
+                if (deleted == 0) {
+                    throw new MetaException("Meta nao encontrada: id=" + id);
+                }
+            }
+            conn.commit();
+        } catch (SQLException e) {
+            if (conn != null) {
+                try { conn.rollback(); } catch (SQLException ex) { Logger.error("Rollback delete", ex); }
+            }
+            Logger.error("MetaDaoNativeImpl.deleteById - erro", e);
+            throw new MetaException("Erro ao deletar Meta", e);
+        } finally {
+            if (conn != null) {
+                try { conn.close(); } catch (SQLException ignore) { }
+            }
+        }
     }
 
     @Override
     public Meta findById(Integer id) {
-        String sql = "SELECT id_meta, ponto_minimo, ponto_medio, ponto_maximo, status, NULL as foto, id_periodo FROM Meta WHERE id_meta = :id";
-        Query q = em.createNativeQuery(sql, Meta.class).setParameter("id", id);
-        return (Meta) q.getSingleResult();
+        Logger.info("MetaDaoNativeImpl.findById - inicio");
+        String sql = "SELECT id_meta, ponto_minimo, ponto_medio, ponto_maximo, status, id_periodo FROM Meta WHERE id_meta=?";
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    Logger.info("MetaDaoNativeImpl.findById - sucesso");
+                    return map(rs, false);
+                }
+            }
+            throw new MetaException("Meta nao encontrada: id=" + id);
+        } catch (SQLException e) {
+            Logger.error("MetaDaoNativeImpl.findById - erro", e);
+            throw new MetaException("Meta nao encontrada: id=" + id, e);
+        }
     }
 
     @Override
     public Meta findWithFotoById(Integer id) {
-        String sql = "SELECT * FROM Meta WHERE id_meta = :id";
-        Query q = em.createNativeQuery(sql, Meta.class).setParameter("id", id);
-        return (Meta) q.getSingleResult();
+        Logger.info("MetaDaoNativeImpl.findWithFotoById - inicio");
+        String sql = "SELECT id_meta, ponto_minimo, ponto_medio, ponto_maximo, status, foto, id_periodo FROM Meta WHERE id_meta=?";
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    Logger.info("MetaDaoNativeImpl.findWithFotoById - sucesso");
+                    return map(rs, true);
+                }
+            }
+            throw new MetaException("Meta nao encontrada: id=" + id);
+        } catch (SQLException e) {
+            Logger.error("MetaDaoNativeImpl.findWithFotoById - erro", e);
+            throw new MetaException("Meta nao encontrada: id=" + id, e);
+        }
     }
 
     @Override
     public List<Meta> findAll() {
-        String sql = "SELECT id_meta, ponto_minimo, ponto_medio, ponto_maximo, status, NULL as foto, id_periodo FROM Meta";
-        return em.createNativeQuery(sql, Meta.class).getResultList();
+        Logger.info("MetaDaoNativeImpl.findAll - inicio");
+        String sql = "SELECT id_meta, ponto_minimo, ponto_medio, ponto_maximo, status, id_periodo FROM Meta";
+        List<Meta> list = new ArrayList<>();
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql);
+             ResultSet rs = ps.executeQuery()) {
+            while (rs.next()) {
+                list.add(map(rs, false));
+            }
+            Logger.info("MetaDaoNativeImpl.findAll - sucesso");
+        } catch (SQLException e) {
+            Logger.error("MetaDaoNativeImpl.findAll - erro", e);
+        }
+        return list;
     }
 
     @Override
     public List<Meta> findAll(int page, int size) {
-        String sql = "SELECT id_meta, ponto_minimo, ponto_medio, ponto_maximo, status, NULL as foto, id_periodo FROM Meta LIMIT :size OFFSET :off";
-        return em.createNativeQuery(sql, Meta.class)
-                .setParameter("size", size)
-                .setParameter("off", page * size)
-                .getResultList();
+        Logger.info("MetaDaoNativeImpl.findAll(page) - inicio");
+        String sql = "SELECT id_meta, ponto_minimo, ponto_medio, ponto_maximo, status, id_periodo FROM Meta LIMIT ? OFFSET ?";
+        List<Meta> list = new ArrayList<>();
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, size);
+            ps.setInt(2, page * size);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    list.add(map(rs, false));
+                }
+            }
+            Logger.info("MetaDaoNativeImpl.findAll(page) - sucesso");
+        } catch (SQLException e) {
+            Logger.error("MetaDaoNativeImpl.findAll(page) - erro", e);
+        }
+        return list;
     }
 
     @Override
     public List<Meta> findByPontoMinimo(Integer pontoMinimo) {
-        String sql = "SELECT id_meta, ponto_minimo, ponto_medio, ponto_maximo, status, NULL as foto, id_periodo FROM Meta WHERE ponto_minimo = :v";
-        return em.createNativeQuery(sql, Meta.class).setParameter("v", pontoMinimo).getResultList();
+        Logger.info("MetaDaoNativeImpl.findByPontoMinimo - inicio");
+        String sql = "SELECT id_meta, ponto_minimo, ponto_medio, ponto_maximo, status, id_periodo FROM Meta WHERE ponto_minimo = ?";
+        List<Meta> list = new ArrayList<>();
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            if (pontoMinimo != null) {
+                ps.setInt(1, pontoMinimo);
+            } else {
+                ps.setNull(1, Types.INTEGER);
+            }
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    list.add(map(rs, false));
+                }
+            }
+            Logger.info("MetaDaoNativeImpl.findByPontoMinimo - sucesso");
+        } catch (SQLException e) {
+            Logger.error("MetaDaoNativeImpl.findByPontoMinimo - erro", e);
+        }
+        return list;
     }
 
     @Override
     public List<Meta> findByPontoMedio(Integer pontoMedio) {
-        String sql = "SELECT id_meta, ponto_minimo, ponto_medio, ponto_maximo, status, NULL as foto, id_periodo FROM Meta WHERE ponto_medio = :v";
-        return em.createNativeQuery(sql, Meta.class).setParameter("v", pontoMedio).getResultList();
+        Logger.info("MetaDaoNativeImpl.findByPontoMedio - inicio");
+        String sql = "SELECT id_meta, ponto_minimo, ponto_medio, ponto_maximo, status, id_periodo FROM Meta WHERE ponto_medio = ?";
+        List<Meta> list = new ArrayList<>();
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            if (pontoMedio != null) {
+                ps.setInt(1, pontoMedio);
+            } else {
+                ps.setNull(1, Types.INTEGER);
+            }
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    list.add(map(rs, false));
+                }
+            }
+            Logger.info("MetaDaoNativeImpl.findByPontoMedio - sucesso");
+        } catch (SQLException e) {
+            Logger.error("MetaDaoNativeImpl.findByPontoMedio - erro", e);
+        }
+        return list;
     }
 
     @Override
     public List<Meta> findByPontoMaximo(Integer pontoMaximo) {
-        String sql = "SELECT id_meta, ponto_minimo, ponto_medio, ponto_maximo, status, NULL as foto, id_periodo FROM Meta WHERE ponto_maximo = :v";
-        return em.createNativeQuery(sql, Meta.class).setParameter("v", pontoMaximo).getResultList();
+        Logger.info("MetaDaoNativeImpl.findByPontoMaximo - inicio");
+        String sql = "SELECT id_meta, ponto_minimo, ponto_medio, ponto_maximo, status, id_periodo FROM Meta WHERE ponto_maximo = ?";
+        List<Meta> list = new ArrayList<>();
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            if (pontoMaximo != null) {
+                ps.setInt(1, pontoMaximo);
+            } else {
+                ps.setNull(1, Types.INTEGER);
+            }
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    list.add(map(rs, false));
+                }
+            }
+            Logger.info("MetaDaoNativeImpl.findByPontoMaximo - sucesso");
+        } catch (SQLException e) {
+            Logger.error("MetaDaoNativeImpl.findByPontoMaximo - erro", e);
+        }
+        return list;
     }
 
     @Override
     public List<Meta> findByStatus(Integer status) {
-        String sql = "SELECT id_meta, ponto_minimo, ponto_medio, ponto_maximo, status, NULL as foto, id_periodo FROM Meta WHERE status = :v";
-        return em.createNativeQuery(sql, Meta.class).setParameter("v", status).getResultList();
+        Logger.info("MetaDaoNativeImpl.findByStatus - inicio");
+        String sql = "SELECT id_meta, ponto_minimo, ponto_medio, ponto_maximo, status, id_periodo FROM Meta WHERE status = ?";
+        List<Meta> list = new ArrayList<>();
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            if (status != null) {
+                ps.setInt(1, status);
+            } else {
+                ps.setNull(1, Types.INTEGER);
+            }
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    list.add(map(rs, false));
+                }
+            }
+            Logger.info("MetaDaoNativeImpl.findByStatus - sucesso");
+        } catch (SQLException e) {
+            Logger.error("MetaDaoNativeImpl.findByStatus - erro", e);
+        }
+        return list;
     }
 
     @Override
     public List<Meta> findByIdPeriodo(Integer idPeriodo) {
-        String sql = "SELECT id_meta, ponto_minimo, ponto_medio, ponto_maximo, status, NULL as foto, id_periodo FROM Meta WHERE id_periodo = :v";
-        return em.createNativeQuery(sql, Meta.class).setParameter("v", idPeriodo).getResultList();
+        Logger.info("MetaDaoNativeImpl.findByIdPeriodo - inicio");
+        String sql = "SELECT id_meta, ponto_minimo, ponto_medio, ponto_maximo, status, id_periodo FROM Meta WHERE id_periodo = ?";
+        List<Meta> list = new ArrayList<>();
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, idPeriodo);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    list.add(map(rs, false));
+                }
+            }
+            Logger.info("MetaDaoNativeImpl.findByIdPeriodo - sucesso");
+        } catch (SQLException e) {
+            Logger.error("MetaDaoNativeImpl.findByIdPeriodo - erro", e);
+        }
+        return list;
     }
 
     @Override
@@ -106,20 +366,48 @@ public class MetaDaoNativeImpl implements MetaDao {
 
     @Override
     public List<Meta> search(Meta f, int page, int size) {
-        StringBuilder sb = new StringBuilder("SELECT id_meta, ponto_minimo, ponto_medio, ponto_maximo, status, NULL as foto, id_periodo FROM Meta WHERE 1=1");
-        if (f.getPontoMinimo() != null) sb.append(" AND ponto_minimo = :pontoMinimo");
-        if (f.getPontoMedio() != null) sb.append(" AND ponto_medio = :pontoMedio");
-        if (f.getPontoMaximo() != null) sb.append(" AND ponto_maximo = :pontoMaximo");
-        if (f.getStatus() != null) sb.append(" AND status = :status");
-        if (f.getIdPeriodo() != null) sb.append(" AND id_periodo = :idPeriodo");
-        Query q = em.createNativeQuery(sb.toString(), Meta.class);
-        if (f.getPontoMinimo() != null) q.setParameter("pontoMinimo", f.getPontoMinimo());
-        if (f.getPontoMedio() != null) q.setParameter("pontoMedio", f.getPontoMedio());
-        if (f.getPontoMaximo() != null) q.setParameter("pontoMaximo", f.getPontoMaximo());
-        if (f.getStatus() != null) q.setParameter("status", f.getStatus());
-        if (f.getIdPeriodo() != null) q.setParameter("idPeriodo", f.getIdPeriodo());
-        q.setFirstResult(page * size);
-        q.setMaxResults(size);
-        return q.getResultList();
+        Logger.info("MetaDaoNativeImpl.search - inicio");
+        StringBuilder sb = new StringBuilder("SELECT id_meta, ponto_minimo, ponto_medio, ponto_maximo, status, id_periodo FROM Meta WHERE 1=1");
+        List<Object> params = new ArrayList<>();
+        if (f.getPontoMinimo() != null) {
+            sb.append(" AND ponto_minimo = ?");
+            params.add(f.getPontoMinimo());
+        }
+        if (f.getPontoMedio() != null) {
+            sb.append(" AND ponto_medio = ?");
+            params.add(f.getPontoMedio());
+        }
+        if (f.getPontoMaximo() != null) {
+            sb.append(" AND ponto_maximo = ?");
+            params.add(f.getPontoMaximo());
+        }
+        if (f.getStatus() != null) {
+            sb.append(" AND status = ?");
+            params.add(f.getStatus());
+        }
+        if (f.getIdPeriodo() != null) {
+            sb.append(" AND id_periodo = ?");
+            params.add(f.getIdPeriodo());
+        }
+        sb.append(" LIMIT ? OFFSET ?");
+        params.add(size);
+        params.add(page * size);
+        List<Meta> list = new ArrayList<>();
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sb.toString())) {
+            for (int i = 0; i < params.size(); i++) {
+                ps.setObject(i + 1, params.get(i));
+            }
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    list.add(map(rs, false));
+                }
+            }
+            Logger.info("MetaDaoNativeImpl.search - sucesso");
+        } catch (SQLException e) {
+            Logger.error("MetaDaoNativeImpl.search - erro", e);
+        }
+        return list;
     }
 }
+


### PR DESCRIPTION
## Summary
- replace EntityManager usage with JDBC implementations for Exercicio, Fornecedor, Lancamento and Meta DAOs
- add result mapping helpers and manual transaction handling

## Testing
- `mvn -q -e -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c093d5177483258613c8f03ef46edd