### PR TITLE
Refatora ID de MonitoramentoObjeto para Integer

### DIFF
--- a/src/main/java/controller/MonitoramentoObjetoController.java
+++ b/src/main/java/controller/MonitoramentoObjetoController.java
@@ -28,13 +28,13 @@ public class MonitoramentoObjetoController {
         dao.update(e);
     }
 
-    public void remover(LocalDate id) {
+    public void remover(Integer id) {
         if (id == null) throw new MonitoramentoObjetoException("Id obrigatorio");
         Logger.info("MonitoramentoObjetoController.remover");
         dao.deleteById(id);
     }
 
-    public MonitoramentoObjeto buscarPorId(LocalDate id) {
+    public MonitoramentoObjeto buscarPorId(Integer id) {
         if (id == null) throw new MonitoramentoObjetoException("Id obrigatorio");
         Logger.info("MonitoramentoObjetoController.buscarPorId");
         return dao.findById(id);

--- a/src/main/java/dao/api/MonitoramentoObjetoDao.java
+++ b/src/main/java/dao/api/MonitoramentoObjetoDao.java
@@ -8,8 +8,8 @@ import model.MonitoramentoObjeto;
 public interface MonitoramentoObjetoDao {
     void create(MonitoramentoObjeto e);
     void update(MonitoramentoObjeto e);
-    void deleteById(LocalDate id);
-    MonitoramentoObjeto findById(LocalDate id);
+    void deleteById(Integer id);
+    MonitoramentoObjeto findById(Integer id);
     List<MonitoramentoObjeto> findAll();
     List<MonitoramentoObjeto> findAll(int page, int size);
     List<MonitoramentoObjeto> findByData(LocalDate data);

--- a/src/main/java/dao/impl/MonitoramentoObjetoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/MonitoramentoObjetoDaoNativeImpl.java
@@ -20,9 +20,9 @@ public class MonitoramentoObjetoDaoNativeImpl implements MonitoramentoObjetoDao 
 
     private MonitoramentoObjeto map(ResultSet rs) throws SQLException {
         MonitoramentoObjeto mo = new MonitoramentoObjeto();
-        Date id = rs.getDate("id_monitoramento_objeto");
-        if (id != null) {
-            mo.setIdMonitoramentoObjeto(id.toLocalDate());
+        int id = rs.getInt("id_monitoramento_objeto");
+        if (!rs.wasNull()) {
+            mo.setIdMonitoramentoObjeto(id);
         }
         Date data = rs.getDate("data");
         if (data != null) {
@@ -42,28 +42,26 @@ public class MonitoramentoObjetoDaoNativeImpl implements MonitoramentoObjetoDao 
     @Override
     public void create(MonitoramentoObjeto e) {
         Logger.info("MonitoramentoObjetoDaoNativeImpl.create");
-        String sql = "INSERT INTO Monitoramento_Objeto (id_monitoramento_objeto, data, id_monitoramento, id_objeto) VALUES (?,?,?,?)";
+        String sql = "INSERT INTO Monitoramento_Objeto (data, id_monitoramento, id_objeto) VALUES (?,?,?)";
         Connection conn = null;
         try {
             conn = ConnectionFactory.getConnection();
             conn.setAutoCommit(false);
             try (PreparedStatement ps = conn.prepareStatement(sql)) {
-                LocalDate id = e.getIdMonitoramentoObjeto() != null ? e.getIdMonitoramentoObjeto() : LocalDate.now();
-                ps.setDate(1, Date.valueOf(id));
                 if (e.getData() != null) {
-                    ps.setDate(2, Date.valueOf(e.getData()));
+                    ps.setDate(1, Date.valueOf(e.getData()));
                 } else {
-                    ps.setNull(2, Types.DATE);
+                    ps.setNull(1, Types.DATE);
                 }
                 if (e.getIdMonitoramento() != null) {
-                    ps.setInt(3, e.getIdMonitoramento());
+                    ps.setInt(2, e.getIdMonitoramento());
                 } else {
-                    ps.setNull(3, Types.INTEGER);
+                    ps.setNull(2, Types.INTEGER);
                 }
                 if (e.getIdObjeto() != null) {
-                    ps.setInt(4, e.getIdObjeto());
+                    ps.setInt(3, e.getIdObjeto());
                 } else {
-                    ps.setNull(4, Types.INTEGER);
+                    ps.setNull(3, Types.INTEGER);
                 }
                 ps.executeUpdate();
             }
@@ -106,9 +104,9 @@ public class MonitoramentoObjetoDaoNativeImpl implements MonitoramentoObjetoDao 
                     ps.setNull(3, Types.INTEGER);
                 }
                 if (e.getIdMonitoramentoObjeto() != null) {
-                    ps.setDate(4, Date.valueOf(e.getIdMonitoramentoObjeto()));
+                    ps.setInt(4, e.getIdMonitoramentoObjeto());
                 } else {
-                    ps.setNull(4, Types.DATE);
+                    ps.setNull(4, Types.INTEGER);
                 }
                 int upd = ps.executeUpdate();
                 if (upd == 0) {
@@ -130,7 +128,7 @@ public class MonitoramentoObjetoDaoNativeImpl implements MonitoramentoObjetoDao 
     }
 
     @Override
-    public void deleteById(LocalDate id) {
+    public void deleteById(Integer id) {
         Logger.info("MonitoramentoObjetoDaoNativeImpl.deleteById");
         String sql = "DELETE FROM Monitoramento_Objeto WHERE id_monitoramento_objeto=?";
         Connection conn = null;
@@ -138,7 +136,7 @@ public class MonitoramentoObjetoDaoNativeImpl implements MonitoramentoObjetoDao 
             conn = ConnectionFactory.getConnection();
             conn.setAutoCommit(false);
             try (PreparedStatement ps = conn.prepareStatement(sql)) {
-                ps.setDate(1, Date.valueOf(id));
+                ps.setInt(1, id);
                 int del = ps.executeUpdate();
                 if (del == 0) {
                     throw new MonitoramentoObjetoException("MonitoramentoObjeto nao encontrado: id=" + id);
@@ -159,11 +157,11 @@ public class MonitoramentoObjetoDaoNativeImpl implements MonitoramentoObjetoDao 
     }
 
     @Override
-    public MonitoramentoObjeto findById(LocalDate id) {
+    public MonitoramentoObjeto findById(Integer id) {
         String sql = "SELECT id_monitoramento_objeto, data, id_monitoramento, id_objeto FROM Monitoramento_Objeto WHERE id_monitoramento_objeto = ?";
         try (Connection conn = ConnectionFactory.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
-            ps.setDate(1, Date.valueOf(id));
+            ps.setInt(1, id);
             try (ResultSet rs = ps.executeQuery()) {
                 if (rs.next()) {
                     return map(rs);

--- a/src/main/java/model/MonitoramentoObjeto.java
+++ b/src/main/java/model/MonitoramentoObjeto.java
@@ -10,7 +10,7 @@ public class MonitoramentoObjeto {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id_monitoramento_objeto")
-    private LocalDate idMonitoramentoObjeto;
+    private Integer idMonitoramentoObjeto;
 
     
     @Column(name = "data")
@@ -24,8 +24,8 @@ public class MonitoramentoObjeto {
     @Column(name = "id_objeto")
     private Integer idObjeto;
 
-    public LocalDate getIdMonitoramentoObjeto() { return idMonitoramentoObjeto; }
-    public void setIdMonitoramentoObjeto(LocalDate idMonitoramentoObjeto) { this.idMonitoramentoObjeto = idMonitoramentoObjeto; }
+    public Integer getIdMonitoramentoObjeto() { return idMonitoramentoObjeto; }
+    public void setIdMonitoramentoObjeto(Integer idMonitoramentoObjeto) { this.idMonitoramentoObjeto = idMonitoramentoObjeto; }
 
     public LocalDate getData() { return data; }
     public void setData(LocalDate data) { this.data = data; }


### PR DESCRIPTION
## Resumo
- Converte o campo `idMonitoramentoObjeto` para `Integer` no modelo `MonitoramentoObjeto`.
- Ajusta interface e implementação do DAO para usar ID numérico e inserir sem especificar o campo.
- Atualiza o controller para aceitar `Integer` nos métodos de remoção e busca por ID.

## Testes
- `mvn -q -e -DskipTests package` *(falha: PluginResolutionException - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c09cfb19b883259d939d749f7d2173