### PR TITLE
Support mandatory CPF in Usuario entity and DAO

### DIFF
--- a/src/main/java/controller/UsuarioController.java
+++ b/src/main/java/controller/UsuarioController.java
@@ -30,6 +30,9 @@ public class UsuarioController {
         if (usuario.getEmail() == null || usuario.getEmail().isEmpty()) {
             throw new UsuarioException("Email do Usuario é obrigatório");
         }
+        if (usuario.getCpf() == null || usuario.getCpf().isEmpty()) {
+            throw new UsuarioException("CPF do Usuario é obrigatório");
+        }
         dao.create(usuario);
         Logger.info("UsuarioController.criar - sucesso");
     }
@@ -47,6 +50,9 @@ public class UsuarioController {
         }
         if (usuario.getEmail() == null || usuario.getEmail().isEmpty()) {
             throw new UsuarioException("Email do Usuario é obrigatório");
+        }
+        if (usuario.getCpf() == null || usuario.getCpf().isEmpty()) {
+            throw new UsuarioException("CPF do Usuario é obrigatório");
         }
         Usuario updated = dao.update(usuario);
         Logger.info("UsuarioController.atualizar - sucesso");
@@ -123,6 +129,16 @@ public class UsuarioController {
         }
         List<Usuario> list = dao.findByEmail(email);
         Logger.info("UsuarioController.buscarPorEmail - sucesso");
+        return list;
+    }
+
+    public List<Usuario> buscarPorCpf(String cpf) {
+        Logger.info("UsuarioController.buscarPorCpf - inicio");
+        if (cpf == null || cpf.isEmpty()) {
+            throw new UsuarioException("CPF não pode ser vazio");
+        }
+        List<Usuario> list = dao.findByCpf(cpf);
+        Logger.info("UsuarioController.buscarPorCpf - sucesso");
         return list;
     }
 

--- a/src/main/java/dao/api/UsuarioDao.java
+++ b/src/main/java/dao/api/UsuarioDao.java
@@ -27,6 +27,8 @@ public interface UsuarioDao {
 
     List<Usuario> findByEmail(String email);
 
+    List<Usuario> findByCpf(String cpf);
+
     List<Usuario> findByFoto(byte[] foto);
 
     List<Usuario> search(Usuario filtro);

--- a/src/main/java/dao/impl/UsuarioDaoNativeImpl.java
+++ b/src/main/java/dao/impl/UsuarioDaoNativeImpl.java
@@ -24,13 +24,14 @@ public class UsuarioDaoNativeImpl implements UsuarioDao {
             u.setFoto(rs.getBytes("foto"));
         }
         u.setEmail(rs.getString("email"));
+        u.setCpf(rs.getString("cpf"));
         return u;
     }
 
     @Override
     public void create(Usuario usuario) throws UsuarioException {
         Logger.info("UsuarioDaoNativeImpl.create - inicio");
-        String sql = "INSERT INTO Usuario (nome, senha, foto, email) VALUES (?,?,?,?)";
+        String sql = "INSERT INTO Usuario (nome, senha, foto, email, cpf) VALUES (?,?,?,?,?)";
         Connection conn = null;
         try {
             conn = ConnectionFactory.getConnection();
@@ -40,6 +41,7 @@ public class UsuarioDaoNativeImpl implements UsuarioDao {
                 ps.setString(2, usuario.getSenha());
                 ps.setBytes(3, usuario.getFoto());
                 ps.setString(4, usuario.getEmail());
+                ps.setString(5, usuario.getCpf());
                 ps.executeUpdate();
             }
             conn.commit();
@@ -60,7 +62,7 @@ public class UsuarioDaoNativeImpl implements UsuarioDao {
     @Override
     public Usuario update(Usuario usuario) throws UsuarioException {
         Logger.info("UsuarioDaoNativeImpl.update - inicio");
-        String sql = "UPDATE Usuario SET nome=?, senha=?, foto=?, email=? WHERE id_usuario=?";
+        String sql = "UPDATE Usuario SET nome=?, senha=?, foto=?, email=?, cpf=? WHERE id_usuario=?";
         Connection conn = null;
         try {
             conn = ConnectionFactory.getConnection();
@@ -70,7 +72,8 @@ public class UsuarioDaoNativeImpl implements UsuarioDao {
                 ps.setString(2, usuario.getSenha());
                 ps.setBytes(3, usuario.getFoto());
                 ps.setString(4, usuario.getEmail());
-                ps.setInt(5, usuario.getIdUsuario());
+                ps.setString(5, usuario.getCpf());
+                ps.setInt(6, usuario.getIdUsuario());
                 int updated = ps.executeUpdate();
                 if (updated == 0) {
                     throw new UsuarioException("Usuario não encontrado: id=" + usuario.getIdUsuario());
@@ -125,7 +128,7 @@ public class UsuarioDaoNativeImpl implements UsuarioDao {
     @Override
     public Usuario findById(Integer id) throws UsuarioException {
         Logger.info("UsuarioDaoNativeImpl.findById - inicio");
-        String sql = "SELECT id_usuario, nome, senha, email FROM Usuario WHERE id_usuario=?";
+        String sql = "SELECT id_usuario, nome, senha, email, cpf FROM Usuario WHERE id_usuario=?";
         try (Connection conn = ConnectionFactory.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
             ps.setInt(1, id);
@@ -145,7 +148,7 @@ public class UsuarioDaoNativeImpl implements UsuarioDao {
     @Override
     public Usuario findWithBlobsById(Integer id) throws UsuarioException {
         Logger.info("UsuarioDaoNativeImpl.findWithBlobsById - inicio");
-        String sql = "SELECT id_usuario, nome, senha, foto, email FROM Usuario WHERE id_usuario=?";
+        String sql = "SELECT id_usuario, nome, senha, foto, email, cpf FROM Usuario WHERE id_usuario=?";
         try (Connection conn = ConnectionFactory.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
             ps.setInt(1, id);
@@ -165,7 +168,7 @@ public class UsuarioDaoNativeImpl implements UsuarioDao {
     @Override
     public List<Usuario> findAll() {
         Logger.info("UsuarioDaoNativeImpl.findAll - inicio");
-        String sql = "SELECT id_usuario, nome, senha, email FROM Usuario";
+        String sql = "SELECT id_usuario, nome, senha, email, cpf FROM Usuario";
         List<Usuario> list = new ArrayList<>();
         try (Connection conn = ConnectionFactory.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql);
@@ -183,7 +186,7 @@ public class UsuarioDaoNativeImpl implements UsuarioDao {
     @Override
     public List<Usuario> findAll(int page, int size) {
         Logger.info("UsuarioDaoNativeImpl.findAll(page) - inicio");
-        String sql = "SELECT id_usuario, nome, senha, email FROM Usuario LIMIT ? OFFSET ?";
+        String sql = "SELECT id_usuario, nome, senha, email, cpf FROM Usuario LIMIT ? OFFSET ?";
         List<Usuario> list = new ArrayList<>();
         try (Connection conn = ConnectionFactory.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -204,7 +207,7 @@ public class UsuarioDaoNativeImpl implements UsuarioDao {
     @Override
     public List<Usuario> findByNome(String nome) {
         Logger.info("UsuarioDaoNativeImpl.findByNome - inicio");
-        String sql = "SELECT id_usuario, nome, senha, email FROM Usuario WHERE nome=?";
+        String sql = "SELECT id_usuario, nome, senha, email, cpf FROM Usuario WHERE nome=?";
         List<Usuario> list = new ArrayList<>();
         try (Connection conn = ConnectionFactory.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -224,7 +227,7 @@ public class UsuarioDaoNativeImpl implements UsuarioDao {
     @Override
     public List<Usuario> findBySenha(String senha) {
         Logger.info("UsuarioDaoNativeImpl.findBySenha - inicio");
-        String sql = "SELECT id_usuario, nome, senha, email FROM Usuario WHERE senha=?";
+        String sql = "SELECT id_usuario, nome, senha, email, cpf FROM Usuario WHERE senha=?";
         List<Usuario> list = new ArrayList<>();
         try (Connection conn = ConnectionFactory.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -244,7 +247,7 @@ public class UsuarioDaoNativeImpl implements UsuarioDao {
     @Override
     public List<Usuario> findByEmail(String email) {
         Logger.info("UsuarioDaoNativeImpl.findByEmail - inicio");
-        String sql = "SELECT id_usuario, nome, senha, email FROM Usuario WHERE email=?";
+        String sql = "SELECT id_usuario, nome, senha, email, cpf FROM Usuario WHERE email=?";
         List<Usuario> list = new ArrayList<>();
         try (Connection conn = ConnectionFactory.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -262,9 +265,29 @@ public class UsuarioDaoNativeImpl implements UsuarioDao {
     }
 
     @Override
+    public List<Usuario> findByCpf(String cpf) {
+        Logger.info("UsuarioDaoNativeImpl.findByCpf - inicio");
+        String sql = "SELECT id_usuario, nome, senha, email, cpf FROM Usuario WHERE cpf=?";
+        List<Usuario> list = new ArrayList<>();
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, cpf);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    list.add(mapUsuario(rs, false));
+                }
+            }
+            Logger.info("UsuarioDaoNativeImpl.findByCpf - sucesso");
+        } catch (SQLException e) {
+            Logger.error("UsuarioDaoNativeImpl.findByCpf - erro", e);
+        }
+        return list;
+    }
+
+    @Override
     public List<Usuario> findByFoto(byte[] foto) {
         Logger.info("UsuarioDaoNativeImpl.findByFoto - inicio");
-        String sql = "SELECT id_usuario, nome, senha, foto, email FROM Usuario WHERE foto=?";
+        String sql = "SELECT id_usuario, nome, senha, foto, email, cpf FROM Usuario WHERE foto=?";
         List<Usuario> list = new ArrayList<>();
         try (Connection conn = ConnectionFactory.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -289,7 +312,7 @@ public class UsuarioDaoNativeImpl implements UsuarioDao {
     @Override
     public List<Usuario> search(Usuario filtro, int page, int size) {
         Logger.info("UsuarioDaoNativeImpl.search - inicio");
-        StringBuilder sb = new StringBuilder("SELECT id_usuario, nome, senha, email FROM Usuario WHERE 1=1");
+        StringBuilder sb = new StringBuilder("SELECT id_usuario, nome, senha, email, cpf FROM Usuario WHERE 1=1");
         List<Object> params = new ArrayList<>();
         if (filtro.getNome() != null && !filtro.getNome().isEmpty()) {
             sb.append(" AND nome=?");
@@ -302,6 +325,10 @@ public class UsuarioDaoNativeImpl implements UsuarioDao {
         if (filtro.getEmail() != null && !filtro.getEmail().isEmpty()) {
             sb.append(" AND email=?");
             params.add(filtro.getEmail());
+        }
+        if (filtro.getCpf() != null && !filtro.getCpf().isEmpty()) {
+            sb.append(" AND cpf=?");
+            params.add(filtro.getCpf());
         }
         if (page >= 0 && size > 0) {
             sb.append(" LIMIT ? OFFSET ?");

--- a/src/main/java/model/Usuario.java
+++ b/src/main/java/model/Usuario.java
@@ -34,6 +34,9 @@ public class Usuario {
     @Column(name = "email")
     private String email;
 
+    @Column(name = "cpf")
+    private String cpf;
+
     @OneToMany(mappedBy = "usuario")
     private List<Movimentacao> movimentacoes = new ArrayList<>();
 
@@ -80,6 +83,14 @@ public class Usuario {
         this.email = email;
     }
 
+    public String getCpf() {
+        return cpf;
+    }
+
+    public void setCpf(String cpf) {
+        this.cpf = cpf;
+    }
+
     public List<Movimentacao> getMovimentacoes() {
         return movimentacoes;
     }
@@ -115,6 +126,7 @@ public class Usuario {
                 "idUsuario=" + idUsuario +
                 ", nome='" + nome + '\'' +
                 ", email='" + email + '\'' +
+                ", cpf='" + cpf + '\'' +
                 '}';
     }
 }

--- a/src/main/java/test/UsuarioControllerTest.java
+++ b/src/main/java/test/UsuarioControllerTest.java
@@ -22,11 +22,12 @@ public class UsuarioControllerTest {
         usuario.setNome("Usuário Exemplo");
         usuario.setSenha("senha123");
         usuario.setEmail("usuario@example.com");
+        usuario.setCpf("12345678900");
         controller.criar(usuario);
 
         // Recuperar usuário persistido e atualizar
         List<Usuario> usuarios = controller.listar();
-        Usuario buscado = controller.buscarPorId(usuarios.get(0).getIdUsuario());
+        Usuario buscado = controller.buscarPorCpf("12345678900").get(0);
         buscado.setNome("Usuário Atualizado");
         controller.atualizar(buscado);
 


### PR DESCRIPTION
## Summary
- add cpf field to `Usuario` model
- propagate cpf through DAO queries and controller validations
- extend tests to exercise cpf lookup

## Testing
- `mvn -q test` *(fails: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a61cbb4c8325b59b74e1e5573bc2