### PR TITLE
feat: enhance user management UI with dialogs and actions

### DIFF
--- a/src/main/java/form/Form_Home.java
+++ b/src/main/java/form/Form_Home.java
@@ -30,7 +30,7 @@ public class Form_Home extends javax.swing.JPanel {
     }
 
     private void initTableData() {
-        EventAction eventAction = new EventAction() {
+        EventAction<ModelStudent> eventAction = new EventAction<ModelStudent>() {
             @Override
             public void delete(ModelStudent student) {
                 if (showMessage("Delete Student : " + student.getName())) {

--- a/src/main/java/form/UsuarioDialog.java
+++ b/src/main/java/form/UsuarioDialog.java
@@ -1,0 +1,119 @@
+package form;
+
+import java.awt.Color;
+import java.awt.Frame;
+import javax.swing.GroupLayout;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JPasswordField;
+import javax.swing.JTextField;
+import model.Usuario;
+import swing.Button;
+
+/**
+ * Dialog used for creating or editing an {@link Usuario}.
+ */
+public class UsuarioDialog extends JDialog {
+
+    private Usuario usuario;
+    private boolean confirmed = false;
+
+    private JTextField txtNome;
+    private JTextField txtEmail;
+    private JTextField txtCpf;
+    private JPasswordField txtSenha;
+
+    public UsuarioDialog(Frame parent, Usuario usuario) {
+        super(parent, true);
+        this.usuario = usuario != null ? usuario : new Usuario();
+        initComponents();
+        setLocationRelativeTo(parent);
+        if (usuario != null) {
+            txtNome.setText(usuario.getNome());
+            txtEmail.setText(usuario.getEmail());
+            txtCpf.setText(usuario.getCpf());
+            txtSenha.setText(usuario.getSenha());
+        }
+    }
+
+    private void initComponents() {
+        setTitle("Usuário");
+        JPanel panel = new JPanel();
+
+        JLabel lblNome = new JLabel("Nome");
+        txtNome = new JTextField(20);
+        JLabel lblEmail = new JLabel("Email");
+        txtEmail = new JTextField(20);
+        JLabel lblCpf = new JLabel("CPF");
+        txtCpf = new JTextField(15);
+        JLabel lblSenha = new JLabel("Senha");
+        txtSenha = new JPasswordField(20);
+
+        Button btnSalvar = new Button();
+        btnSalvar.setText("Salvar");
+        btnSalvar.setBackground(new Color(75, 134, 253));
+        btnSalvar.setForeground(Color.WHITE);
+        btnSalvar.addActionListener(e -> salvar());
+
+        Button btnCancelar = new Button();
+        btnCancelar.setText("Cancelar");
+        btnCancelar.addActionListener(e -> dispose());
+
+        GroupLayout layout = new GroupLayout(panel);
+        panel.setLayout(layout);
+        layout.setAutoCreateGaps(true);
+        layout.setAutoCreateContainerGaps(true);
+
+        layout.setHorizontalGroup(
+            layout.createParallelGroup(GroupLayout.Alignment.LEADING)
+                .addComponent(lblNome)
+                .addComponent(txtNome)
+                .addComponent(lblEmail)
+                .addComponent(txtEmail)
+                .addComponent(lblCpf)
+                .addComponent(txtCpf)
+                .addComponent(lblSenha)
+                .addComponent(txtSenha)
+                .addGroup(layout.createSequentialGroup()
+                    .addComponent(btnSalvar, GroupLayout.PREFERRED_SIZE, 90, GroupLayout.PREFERRED_SIZE)
+                    .addComponent(btnCancelar, GroupLayout.PREFERRED_SIZE, 90, GroupLayout.PREFERRED_SIZE))
+        );
+
+        layout.setVerticalGroup(
+            layout.createSequentialGroup()
+                .addComponent(lblNome)
+                .addComponent(txtNome, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE)
+                .addComponent(lblEmail)
+                .addComponent(txtEmail, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE)
+                .addComponent(lblCpf)
+                .addComponent(txtCpf, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE)
+                .addComponent(lblSenha)
+                .addComponent(txtSenha, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE)
+                .addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                    .addComponent(btnSalvar, GroupLayout.PREFERRED_SIZE, 30, GroupLayout.PREFERRED_SIZE)
+                    .addComponent(btnCancelar, GroupLayout.PREFERRED_SIZE, 30, GroupLayout.PREFERRED_SIZE))
+        );
+
+        getContentPane().add(panel);
+        pack();
+    }
+
+    private void salvar() {
+        usuario.setNome(txtNome.getText());
+        usuario.setEmail(txtEmail.getText());
+        usuario.setCpf(txtCpf.getText());
+        usuario.setSenha(new String(txtSenha.getPassword()));
+        confirmed = true;
+        dispose();
+    }
+
+    public boolean isConfirmed() {
+        return confirmed;
+    }
+
+    public Usuario getUsuario() {
+        return usuario;
+    }
+}
+

--- a/src/main/java/form/UsuarioForm.java
+++ b/src/main/java/form/UsuarioForm.java
@@ -2,36 +2,74 @@ package form;
 
 import controller.UsuarioController;
 import dao.impl.UsuarioDaoNativeImpl;
+import java.awt.Color;
+import java.awt.Frame;
 import java.util.List;
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
+import javax.swing.SwingUtilities;
 import model.Usuario;
+import swing.icon.GoogleMaterialDesignIcons;
+import swing.icon.IconFontSwing;
+import swing.table.EventAction;
+import swing.table.ModelAction;
+import swing.table.ModelProfile;
 
 /**
- * Form that lists usuarios fetched from the database.
+ * Form that lists usuarios fetched from the database with action buttons for
+ * edit and delete and a button to add new usuarios.
  */
 public class UsuarioForm extends javax.swing.JPanel {
 
+    private final UsuarioController controller;
+
     public UsuarioForm() {
+        controller = new UsuarioController(new UsuarioDaoNativeImpl());
         initComponents();
         table1.fixTable(jScrollPane1);
         setOpaque(false);
-        initData();
+        loadUsuarios();
     }
 
-    private void initData() {
-        UsuarioController controller = new UsuarioController(new UsuarioDaoNativeImpl());
+    private void loadUsuarios() {
+        javax.swing.table.DefaultTableModel model = (javax.swing.table.DefaultTableModel) table1.getModel();
+        model.setRowCount(0);
+
         List<Usuario> usuarios = controller.listar();
+        EventAction<Usuario> eventAction = new EventAction<Usuario>() {
+            @Override
+            public void delete(Usuario u) {
+                controller.remover(u.getIdUsuario());
+                loadUsuarios();
+            }
+
+            @Override
+            public void update(Usuario u) {
+                Frame frame = (Frame) SwingUtilities.getWindowAncestor(UsuarioForm.this);
+                UsuarioDialog dialog = new UsuarioDialog(frame, u);
+                dialog.setVisible(true);
+                if (dialog.isConfirmed()) {
+                    controller.atualizar(dialog.getUsuario());
+                    loadUsuarios();
+                }
+            }
+        };
+
         for (Usuario u : usuarios) {
-            table1.addRow(new Object[]{u.getIdUsuario(), u.getNome(), u.getEmail(), u.getCpf()});
+            Icon icon = u.getFoto() != null ? new ImageIcon(u.getFoto())
+                    : new ImageIcon(getClass().getResource("/icon/profile.jpg"));
+            model.addRow(new Object[]{new ModelProfile(icon, u.getNome()), u.getEmail(), u.getCpf(),
+                new ModelAction<>(u, eventAction)});
         }
     }
 
     @SuppressWarnings("unchecked")
-    // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents
     private void initComponents() {
 
         jLabel1 = new javax.swing.JLabel();
         jScrollPane1 = new javax.swing.JScrollPane();
         table1 = new swing.table.Table();
+        btnAdd = new swing.Button();
 
         jLabel1.setFont(new java.awt.Font("sansserif", 1, 15)); // NOI18N
         jLabel1.setForeground(new java.awt.Color(76, 76, 76));
@@ -43,11 +81,11 @@ public class UsuarioForm extends javax.swing.JPanel {
 
             },
             new String [] {
-                "ID", "Nome", "Email", "CPF"
+                "Usuário", "Email", "CPF", ""
             }
         ) {
             boolean[] canEdit = new boolean [] {
-                false, false, false, false
+                false, false, false, true
             };
 
             public boolean isCellEditable(int rowIndex, int columnIndex) {
@@ -56,9 +94,18 @@ public class UsuarioForm extends javax.swing.JPanel {
         });
         jScrollPane1.setViewportView(table1);
         if (table1.getColumnModel().getColumnCount() > 0) {
-            table1.getColumnModel().getColumn(0).setPreferredWidth(50);
-            table1.getColumnModel().getColumn(1).setPreferredWidth(150);
+            table1.getColumnModel().getColumn(0).setPreferredWidth(150);
         }
+
+        btnAdd.setBackground(new java.awt.Color(75, 134, 253));
+        btnAdd.setForeground(new java.awt.Color(255, 255, 255));
+        btnAdd.setIcon(IconFontSwing.buildIcon(GoogleMaterialDesignIcons.ADD, 18, Color.WHITE));
+        btnAdd.setText("Adicionar");
+        btnAdd.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                btnAddActionPerformed(evt);
+            }
+        });
 
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
         this.setLayout(layout);
@@ -66,20 +113,38 @@ public class UsuarioForm extends javax.swing.JPanel {
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addComponent(jLabel1, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
             .addComponent(jScrollPane1, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+            .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, layout.createSequentialGroup()
+                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                .addComponent(btnAdd, javax.swing.GroupLayout.PREFERRED_SIZE, 120, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addContainerGap())
         );
         layout.setVerticalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
                 .addComponent(jLabel1)
                 .addGap(0, 0, 0)
-                .addComponent(jScrollPane1, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                .addComponent(jScrollPane1, javax.swing.GroupLayout.DEFAULT_SIZE, 338, Short.MAX_VALUE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(btnAdd, javax.swing.GroupLayout.PREFERRED_SIZE, 35, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addContainerGap())
         );
-    }// </editor-fold>//GEN-END:initComponents
+    }
 
-    // Variables declaration - do not modify//GEN-BEGIN:variables
+    private void btnAddActionPerformed(java.awt.event.ActionEvent evt) {
+        Frame frame = (Frame) SwingUtilities.getWindowAncestor(this);
+        UsuarioDialog dialog = new UsuarioDialog(frame, null);
+        dialog.setVisible(true);
+        if (dialog.isConfirmed()) {
+            controller.criar(dialog.getUsuario());
+            loadUsuarios();
+        }
+    }
+
+    // Variables declaration - do not modify
+    private swing.Button btnAdd;
     private javax.swing.JLabel jLabel1;
     private javax.swing.JScrollPane jScrollPane1;
     private swing.table.Table table1;
-    // End of variables declaration//GEN-END:variables
+    // End of variables declaration
 }
 

--- a/src/main/java/model/ModelStudent.java
+++ b/src/main/java/model/ModelStudent.java
@@ -67,8 +67,8 @@ public class ModelStudent {
     private String course;
     private double fees;
 
-    public Object[] toRowTable(EventAction event) {
+    public Object[] toRowTable(EventAction<ModelStudent> event) {
         DecimalFormat df = new DecimalFormat("$#,##0.00");
-        return new Object[]{new ModelProfile(icon, name), gender, course, df.format(fees), new ModelAction(this, event)};
+        return new Object[]{new ModelProfile(icon, name), gender, course, df.format(fees), new ModelAction<>(this, event)};
     }
 }

--- a/src/main/java/swing/table/Action.java
+++ b/src/main/java/swing/table/Action.java
@@ -5,20 +5,20 @@ import java.awt.Graphics;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
-public class Action extends javax.swing.JPanel {
+public class Action<T> extends javax.swing.JPanel {
 
-    public Action(ModelAction data) {
+    public Action(ModelAction<T> data) {
         initComponents();
         cmdEdit.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent ae) {
-                data.getEvent().update(data.getStudent());
+                data.getEvent().update(data.getData());
             }
         });
         cmdDelete.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent ae) {
-                data.getEvent().delete(data.getStudent());
+                data.getEvent().delete(data.getData());
             }
         });
     }

--- a/src/main/java/swing/table/EventAction.java
+++ b/src/main/java/swing/table/EventAction.java
@@ -1,10 +1,14 @@
 package swing.table;
 
-import model.ModelStudent;
+/**
+ * Generic event callback used by table action buttons. Implementations can
+ * decide how to handle update and delete events for the provided data type.
+ *
+ * @param <T> Type of the row data associated with the action buttons
+ */
+public interface EventAction<T> {
 
-public interface EventAction {
+    void delete(T data);
 
-    public void delete(ModelStudent student);
-
-    public void update(ModelStudent student);
+    void update(T data);
 }

--- a/src/main/java/swing/table/ModelAction.java
+++ b/src/main/java/swing/table/ModelAction.java
@@ -1,33 +1,37 @@
 package swing.table;
 
-import model.ModelStudent;
+/**
+ * Wrapper model used by the table to keep the row data and the callbacks that
+ * should be invoked when the action buttons are pressed.
+ *
+ * @param <T> Type of the row data
+ */
+public class ModelAction<T> {
 
-public class ModelAction {
+    private T data;
+    private EventAction<T> event;
 
-    public ModelStudent getStudent() {
-        return student;
-    }
-
-    public void setStudent(ModelStudent student) {
-        this.student = student;
-    }
-
-    public EventAction getEvent() {
-        return event;
-    }
-
-    public void setEvent(EventAction event) {
-        this.event = event;
-    }
-
-    public ModelAction(ModelStudent student, EventAction event) {
-        this.student = student;
+    public ModelAction(T data, EventAction<T> event) {
+        this.data = data;
         this.event = event;
     }
 
     public ModelAction() {
     }
 
-    private ModelStudent student;
-    private EventAction event;
+    public T getData() {
+        return data;
+    }
+
+    public void setData(T data) {
+        this.data = data;
+    }
+
+    public EventAction<T> getEvent() {
+        return event;
+    }
+
+    public void setEvent(EventAction<T> event) {
+        this.event = event;
+    }
 }

--- a/src/main/java/swing/table/Table.java
+++ b/src/main/java/swing/table/Table.java
@@ -23,7 +23,7 @@ public class Table extends JTable {
             @Override
             public Component getTableCellRendererComponent(JTable jtable, Object o, boolean bln, boolean bln1, int i, int i1) {
                 TableHeader header = new TableHeader(o + "");
-                if (i1 == 4) {
+                if (i1 == jtable.getColumnCount() - 1) {
                     header.setHorizontalAlignment(JLabel.CENTER);
                 }
                 return header;
@@ -43,8 +43,8 @@ public class Table extends JTable {
                     return cell;
 
                 } else if (o instanceof ModelAction) {
-                    ModelAction data = (ModelAction) o;
-                    Action cell = new Action(data);
+                    ModelAction<?> data = (ModelAction<?>) o;
+                    Action<?> cell = new Action<>(data);
                     if (selected) {
                         cell.setBackground(new Color(239, 244, 255));
                     } else {
@@ -68,7 +68,7 @@ public class Table extends JTable {
 
     @Override
     public TableCellEditor getCellEditor(int row, int col) {
-        if (col == 4) {
+        if (col == getColumnCount() - 1) {
             return new TableCellAction();
         } else {
             return super.getCellEditor(row, col);

--- a/src/main/java/swing/table/TableCellAction.java
+++ b/src/main/java/swing/table/TableCellAction.java
@@ -8,7 +8,7 @@ import javax.swing.JTable;
 
 public class TableCellAction extends DefaultCellEditor {
 
-    private ModelAction data;
+    private ModelAction<?> data;
 
     public TableCellAction() {
         super(new JCheckBox());
@@ -16,8 +16,8 @@ public class TableCellAction extends DefaultCellEditor {
 
     @Override
     public Component getTableCellEditorComponent(JTable jtable, Object o, boolean bln, int i, int i1) {
-        data = (ModelAction) o;
-        Action cell = new Action(data);
+        data = (ModelAction<?>) o;
+        Action<?> cell = new Action<>(data);
         cell.setBackground(new Color(239, 244, 255));
         return cell;
     }


### PR DESCRIPTION
## Summary
- show user avatar, edit and delete actions, and add button in user table
- implement reusable generic table action framework
- add dialog for creating and editing users

## Testing
- `mvn -q -e test` *(fails: PluginResolutionException)*
- `mvn -q -e -DskipTests package` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ae06ecdc8325ad47a2b4a9e26fac