### PR TITLE
Corrige seleção de ID ao excluir usuário na tabela

### DIFF
--- a/src/main/java/form/UsuarioForm.java
+++ b/src/main/java/form/UsuarioForm.java
@@ -400,8 +400,21 @@ public class UsuarioForm extends JPanel {
         int opt = JOptionPane.showConfirmDialog(this, "Excluir usuário?", "Confirmação", JOptionPane.YES_NO_OPTION);
         if (opt == JOptionPane.YES_OPTION) {
             try {
-                controller.remover(u.getIdUsuario());
+                // Obter sempre o ID da linha atualmente editada/selecionada
+                int row = table.getEditingRow();
+                if (row < 0) {
+                    row = table.getSelectedRow();
+                }
+                int id = u.getIdUsuario();
+                if (row >= 0) {
+                    Object val = table.getValueAt(row, 0);
+                    if (val instanceof Integer) {
+                        id = (Integer) val;
+                    }
+                }
+                controller.remover(id);
                 loadUsuarios();
+                table.clearSelection();
             } catch (Exception ex) {
                 JOptionPane.showMessageDialog(this, ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
             }


### PR DESCRIPTION
## Summary
- Garante que a exclusão utilize o ID da linha atualmente selecionada/edição
- Limpa a seleção da tabela após recarregar os usuários

## Testing
- ❌ `mvn -q -e -DskipTests package` *(falha: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c1abc219fc8325ac931ffdfc6487e7