### PR TITLE
Improve user card spacing and table border color

### DIFF
--- a/src/main/java/form/UsuarioForm.java
+++ b/src/main/java/form/UsuarioForm.java
@@ -143,9 +143,10 @@ public class UsuarioForm extends JPanel {
         viewContainer.setBackground(Color.WHITE);
 
         // Cards view split into two rows of three cards
+        int buttonHeight = btnAdd.getPreferredSize().height;
         cardsPanel = new JPanel();
         cardsPanel.setLayout(new BoxLayout(cardsPanel, BoxLayout.Y_AXIS));
-        cardsPanel.setBorder(new EmptyBorder(10, 10, 10, 10));
+        cardsPanel.setBorder(new EmptyBorder(buttonHeight, 10, 10, 10));
         cardsPanel.setBackground(Color.WHITE);
 
         cardsTopPanel = new JPanel(new FlowLayout(FlowLayout.CENTER, 10, 10));
@@ -155,6 +156,7 @@ public class UsuarioForm extends JPanel {
         cardsTopPanel.setBackground(Color.WHITE);
         cardsBottomPanel.setBackground(Color.WHITE);
         cardsPanel.add(cardsTopPanel);
+        cardsPanel.add(Box.createVerticalStrut(buttonHeight));
         cardsPanel.add(cardsBottomPanel);
 
         JScrollPane cardScroll = new JScrollPane(cardsPanel,

--- a/src/main/java/swing/table/Table.java
+++ b/src/main/java/swing/table/Table.java
@@ -16,7 +16,7 @@ public class Table extends JTable {
 
     public Table() {
         setShowHorizontalLines(true);
-        setGridColor(new Color(230, 230, 230));
+        setGridColor(new Color(75, 134, 253));
         setRowHeight(40);
         getTableHeader().setReorderingAllowed(false);
         getTableHeader().setDefaultRenderer(new DefaultTableCellRenderer() {


### PR DESCRIPTION
## Summary
- Change table grid color to blue for clearer user grid lines
- Adjust card layout spacing so the top row sits lower and rows are separated by a button's height

## Testing
- `mvn -q test` *(fails: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b137ba9c83259c624c07db379e9c