### PR TITLE
Fix compilation errors in event and category forms

### DIFF
--- a/src/main/java/form/CategoriaForm.java
+++ b/src/main/java/form/CategoriaForm.java
@@ -270,12 +270,12 @@ public class CategoriaForm extends JPanel {
         EventAction<Categoria> eventAction = new EventAction<Categoria>() {
             @Override
             public void delete(Categoria u) {
-                excluirCategoria(c);
+                excluirCategoria(u);
             }
 
             @Override
             public void update(Categoria u) {
-                editarCategoria(c);
+                editarCategoria(u);
             }
         };
         for (Categoria c : getCurrentPageCategorias()) {

--- a/src/main/java/form/EventoForm.java
+++ b/src/main/java/form/EventoForm.java
@@ -270,12 +270,12 @@ public class EventoForm extends JPanel {
         EventAction<Evento> eventAction = new EventAction<Evento>() {
             @Override
             public void delete(Evento u) {
-                excluirEvento(e);
+                excluirEvento(u);
             }
 
             @Override
             public void update(Evento u) {
-                editarEvento(e);
+                editarEvento(u);
             }
         };
         for (Evento e : getCurrentPageEventos()) {
@@ -326,9 +326,9 @@ public class EventoForm extends JPanel {
 
         JPopupMenu popup = new JPopupMenu();
         JMenuItem miEdit = new JMenuItem("Editar");
-        miEdit.addActionListener(e -> editarEvento(e));
+        miEdit.addActionListener(evt -> editarEvento(e));
         JMenuItem miDelete = new JMenuItem("Excluir");
-        miDelete.addActionListener(e -> excluirEvento(e));
+        miDelete.addActionListener(evt -> excluirEvento(e));
         popup.add(miEdit);
         popup.add(miDelete);
         lblMenu.addMouseListener(new MouseAdapter() {


### PR DESCRIPTION
## Summary
- Correct event handler references in `CategoriaForm` to use provided category instance
- Fix `EventoForm` table and menu actions to reference the appropriate event

## Testing
- `mvn -q -e -DskipTests compile` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c1bf8251848325a448549dda35fb28