### PR TITLE
Simplify menu and enable window drag

### DIFF
--- a/src/main/java/component/Menu.java
+++ b/src/main/java/component/Menu.java
@@ -55,19 +55,7 @@ public class Menu extends javax.swing.JPanel {
 
     public void initMenuItem() {
         addMenu(new ModelMenu(new ImageIcon(getClass().getResource("/icon/1.png")), "Dashboard", "Home", "Usuario", "Categoria", "Evento", "Movimentacao"));
-        addMenu(new ModelMenu(new ImageIcon(getClass().getResource("/icon/2.png")), "Charts", "Morris", "Flot", "Line"));
-        addMenu(new ModelMenu(new ImageIcon(getClass().getResource("/icon/3.png")), "Report", "Income", "Expense", "Profit"));
-        addMenu(new ModelMenu(new ImageIcon(getClass().getResource("/icon/4.png")), "Message", "Sender", "Inbox", "User"));
-        addMenu(new ModelMenu(new ImageIcon(getClass().getResource("/icon/5.png")), "Staff", "Sender", "Inbox", "User"));
-        addMenu(new ModelMenu(new ImageIcon(getClass().getResource("/icon/6.png")), "Student", "Menu 001", "Menu 002", "Menu 003"));
-        addMenu(new ModelMenu(new ImageIcon(getClass().getResource("/icon/7.png")), "Library", "Menu 001", "Menu 002", "Menu 003"));
-        addMenu(new ModelMenu(new ImageIcon(getClass().getResource("/icon/8.png")), "Holiday", "Menu 001", "Menu 002", "Menu 003"));
-        addMenu(new ModelMenu(new ImageIcon(getClass().getResource("/icon/9.png")), "Calendar", "Menu 001", "Menu 002", "Menu 003"));
-        addMenu(new ModelMenu(new ImageIcon(getClass().getResource("/icon/10.png")), "Chat App", "Menu 001", "Menu 002", "Menu 003"));
-        addMenu(new ModelMenu(new ImageIcon(getClass().getResource("/icon/11.png")), "Contace", "Menu 001", "Menu 002", "Menu 003"));
-        addMenu(new ModelMenu(new ImageIcon(getClass().getResource("/icon/12.png")), "File Manager", "Menu 001", "Menu 002", "Menu 003"));
-        addMenu(new ModelMenu(new ImageIcon(getClass().getResource("/icon/13.png")), "Our Centres"));
-        addMenu(new ModelMenu(new ImageIcon(getClass().getResource("/icon/14.png")), "Gallery"));
+        addMenu(new ModelMenu(new ImageIcon(getClass().getResource("/icon/2.png")), "Sair"));
     }
 
     private void addMenu(ModelMenu menu) {

--- a/src/main/java/form/MovimentacaoForm.java
+++ b/src/main/java/form/MovimentacaoForm.java
@@ -1,9 +1,7 @@
 package form;
 
-import controller.CaixaController;
 import controller.MovimentacaoController;
 import controller.PeriodoController;
-import dao.impl.CaixaDaoNativeImpl;
 import dao.impl.MovimentacaoDaoNativeImpl;
 import dao.impl.PeriodoDaoNativeImpl;
 import java.awt.BorderLayout;
@@ -27,7 +25,6 @@ import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.DefaultTableModel;
-import model.Caixa;
 import model.Movimentacao;
 import model.ModelCard;
 import model.Periodo;
@@ -44,12 +41,10 @@ public class MovimentacaoForm extends JPanel {
 
     private final MovimentacaoController movController;
     private final PeriodoController periodoController;
-    private final CaixaController caixaController;
 
     private Card cardDesconto;
     private Card cardVantagem;
     private Card cardLiquido;
-    private Card cardCaixa;
     private Card cardPontos;
     private Table table;
     private JComboBox<Integer> cbAno;
@@ -64,13 +59,11 @@ public class MovimentacaoForm extends JPanel {
     private Icon iconDesc;
     private Icon iconVant;
     private Icon iconLiq;
-    private Icon iconCaixa;
     private Icon iconPonto;
 
     public MovimentacaoForm() {
         movController = new MovimentacaoController(new MovimentacaoDaoNativeImpl());
         periodoController = new PeriodoController(new PeriodoDaoNativeImpl());
-        caixaController = new CaixaController(new CaixaDaoNativeImpl());
         initComponents();
         carregarAnos();
         carregarMovimentacoes();
@@ -81,7 +74,7 @@ public class MovimentacaoForm extends JPanel {
         setBackground(Color.WHITE);
 
         // Painel de cards
-        JPanel cards = new JPanel(new java.awt.GridLayout(1, 5, 18, 0));
+        JPanel cards = new JPanel(new java.awt.GridLayout(1, 4, 18, 0));
         cards.setBackground(Color.WHITE);
 
         iconDesc = IconFontSwing.buildIcon(
@@ -110,15 +103,6 @@ public class MovimentacaoForm extends JPanel {
         cardLiquido.setColorGradient(new Color(255, 203, 107));
         cardLiquido.setData(new ModelCard("Total Líquido", 0, 0, iconLiq));
         cards.add(cardLiquido);
-
-        iconCaixa = IconFontSwing.buildIcon(
-                GoogleMaterialDesignIcons.ACCOUNT_BALANCE_WALLET, 60, Color.WHITE,
-                new Color(255, 255, 255, 15));
-        cardCaixa = new Card();
-        cardCaixa.setBackground(new Color(63, 81, 181));
-        cardCaixa.setColorGradient(new Color(121, 134, 203));
-        cardCaixa.setData(new ModelCard("Saldo Caixa", 0, 0, iconCaixa));
-        cards.add(cardCaixa);
 
         iconPonto = IconFontSwing.buildIcon(
                 GoogleMaterialDesignIcons.PIN_DROP, 60, Color.WHITE,
@@ -271,9 +255,7 @@ public class MovimentacaoForm extends JPanel {
         BigDecimal totalDesc = BigDecimal.ZERO;
         BigDecimal totalVant = BigDecimal.ZERO;
         BigDecimal totalLiq = BigDecimal.ZERO;
-        BigDecimal totalCx = BigDecimal.ZERO;
         int totalPontos = 0;
-        Set<Integer> caixasProcessadas = new HashSet<>();
 
         for (Movimentacao m : movs) {
             if (m.getDesconto() != null) {
@@ -285,15 +267,6 @@ public class MovimentacaoForm extends JPanel {
             if (m.getLiquido() != null) {
                 totalLiq = totalLiq.add(m.getLiquido());
             }
-            if (m.getCaixa() != null && m.getCaixa().getIdCaixa() != null) {
-                int id = m.getCaixa().getIdCaixa();
-                if (caixasProcessadas.add(id)) {
-                    Caixa c = caixaController.buscarPorId(id);
-                    if (c != null && c.getValorTotal() != null) {
-                        totalCx = totalCx.add(c.getValorTotal());
-                    }
-                }
-            }
             if (m.getPonto() != null) {
                 totalPontos += m.getPonto();
             }
@@ -302,7 +275,6 @@ public class MovimentacaoForm extends JPanel {
         cardDesconto.setData(new ModelCard("Total Desconto", totalDesc.doubleValue(), 0, iconDesc));
         cardVantagem.setData(new ModelCard("Total Vantagem", totalVant.doubleValue(), 0, iconVant));
         cardLiquido.setData(new ModelCard("Total Líquido", totalLiq.doubleValue(), 0, iconLiq));
-        cardCaixa.setData(new ModelCard("Saldo Caixa", totalCx.doubleValue(), 0, iconCaixa));
         cardPontos.setData(new ModelCard("Total Pontos", totalPontos, 0, iconPonto));
     }
 

--- a/src/main/java/main/Main.java
+++ b/src/main/java/main/Main.java
@@ -17,6 +17,9 @@ import swing.icon.IconFontSwing;
 import java.awt.Component;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseMotionAdapter;
 import net.miginfocom.swing.MigLayout;
 import org.jdesktop.animation.timing.Animator;
 import org.jdesktop.animation.timing.TimingTarget;
@@ -29,6 +32,8 @@ public class Main extends javax.swing.JFrame {
     private Header header;
     private MainForm main;
     private Animator animator;
+    private int x;
+    private int y;
 
     public Main() {
         initComponents();
@@ -41,6 +46,19 @@ public class Main extends javax.swing.JFrame {
         menu = new Menu();
         header = new Header();
         main = new MainForm();
+        header.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mousePressed(MouseEvent e) {
+                x = e.getX();
+                y = e.getY();
+            }
+        });
+        header.addMouseMotionListener(new MouseMotionAdapter() {
+            @Override
+            public void mouseDragged(MouseEvent e) {
+                setLocation(e.getXOnScreen() - x, e.getYOnScreen() - y);
+            }
+        });
         menu.addEvent(new EventMenuSelected() {
             @Override
             public void menuSelected(int menuIndex, int subMenuIndex) {
@@ -57,6 +75,8 @@ public class Main extends javax.swing.JFrame {
                     } else if (subMenuIndex == 4) {
                         main.showForm(new MovimentacaoForm());
                     }
+                } else if (menuIndex == 1) {
+                    System.exit(0);
                 }
             }
         });


### PR DESCRIPTION
## Summary
- Remove extra side menu items, keeping only Dashboard and new Exit option
- Allow dragging the undecorated window via the header and exit application when Exit menu is selected
- Drop cash balance card from dashboard header and related calculations

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c1dce2f1048325967297a1232a9843