### PR TITLE
fix: remove String.repeat to compile on Java 8

### DIFF
--- a/src/main/java/form/CofreForm.java
+++ b/src/main/java/form/CofreForm.java
@@ -286,7 +286,11 @@ public class CofreForm extends JPanel {
     private String mask(String s) {
         if (s == null) return "";
         int len = Math.min(6, s.length());
-        return "*".repeat(len);
+        StringBuilder sb = new StringBuilder(len);
+        for (int i = 0; i < len; i++) {
+            sb.append('*');
+        }
+        return sb.toString();
     }
 
     private String tipoTexto(Integer tipo) {


### PR DESCRIPTION
## Summary
- replace Java 11 String.repeat with manual loop in Cofre form mask helper

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f343e1348325a3e1b33f56f39823