### PR TITLE
Adicionar suporte de foto ao cofre

### DIFF
--- a/src/main/java/controller/CofreController.java
+++ b/src/main/java/controller/CofreController.java
@@ -52,6 +52,11 @@ public class CofreController {
         return dao.findByLogin(login);
     }
 
+    public List<Cofre> buscarPorTipo(Integer tipo) {
+        Logger.info("CofreController.buscarPorTipo");
+        return dao.findByTipo(tipo);
+    }
+
     public List<Cofre> pesquisar(Cofre filtro) {
         Logger.info("CofreController.pesquisar");
         return dao.search(filtro);

--- a/src/main/java/dao/impl/CofreDaoNativeImpl.java
+++ b/src/main/java/dao/impl/CofreDaoNativeImpl.java
@@ -22,6 +22,7 @@ public class CofreDaoNativeImpl implements CofreDao {
         c.setSenha(rs.getString("senha"));
         int tipo = rs.getInt("tipo");
         c.setTipo(rs.wasNull() ? null : tipo);
+        c.setFoto(rs.getBytes("foto"));
         c.setPlataforma(rs.getString("plataforma"));
         int idUsuario = rs.getInt("id_usuario");
         c.setIdUsuario(rs.wasNull() ? null : idUsuario);
@@ -31,7 +32,7 @@ public class CofreDaoNativeImpl implements CofreDao {
     @Override
     public void create(Cofre c) {
         Logger.info("CofreDao.create");
-        String sql = "INSERT INTO Cofre (login, senha, tipo, plataforma, id_usuario) VALUES (?,?,?,?,?)";
+        String sql = "INSERT INTO Cofre (login, senha, tipo, plataforma, id_usuario, foto) VALUES (?,?,?,?,?,?)";
         Connection conn = null;
         try {
             conn = ConnectionFactory.getConnection();
@@ -42,6 +43,7 @@ public class CofreDaoNativeImpl implements CofreDao {
                 if (c.getTipo() != null) ps.setInt(3, c.getTipo()); else ps.setNull(3, java.sql.Types.INTEGER);
                 ps.setString(4, c.getPlataforma());
                 if (c.getIdUsuario() != null) ps.setInt(5, c.getIdUsuario()); else ps.setNull(5, java.sql.Types.INTEGER);
+                if (c.getFoto() != null) ps.setBytes(6, c.getFoto()); else ps.setNull(6, java.sql.Types.BINARY);
                 ps.executeUpdate();
             }
             conn.commit();
@@ -61,7 +63,7 @@ public class CofreDaoNativeImpl implements CofreDao {
     @Override
     public void update(Cofre c) {
         Logger.info("CofreDao.update");
-        String sql = "UPDATE Cofre SET login=?, senha=?, tipo=?, plataforma=?, id_usuario=? WHERE id_cofre=?";
+        String sql = "UPDATE Cofre SET login=?, senha=?, tipo=?, plataforma=?, id_usuario=?, foto=? WHERE id_cofre=?";
         Connection conn = null;
         try {
             conn = ConnectionFactory.getConnection();
@@ -72,7 +74,8 @@ public class CofreDaoNativeImpl implements CofreDao {
                 if (c.getTipo() != null) ps.setInt(3, c.getTipo()); else ps.setNull(3, java.sql.Types.INTEGER);
                 ps.setString(4, c.getPlataforma());
                 if (c.getIdUsuario() != null) ps.setInt(5, c.getIdUsuario()); else ps.setNull(5, java.sql.Types.INTEGER);
-                ps.setInt(6, c.getIdCofre());
+                if (c.getFoto() != null) ps.setBytes(6, c.getFoto()); else ps.setNull(6, java.sql.Types.BINARY);
+                ps.setInt(7, c.getIdCofre());
                 int upd = ps.executeUpdate();
                 if (upd == 0) throw new CofreException("Cofre nao encontrado: id=" + c.getIdCofre());
             }
@@ -119,7 +122,7 @@ public class CofreDaoNativeImpl implements CofreDao {
 
     @Override
     public Cofre findById(Integer id) {
-        String sql = "SELECT id_cofre, login, senha, tipo, plataforma, id_usuario FROM Cofre WHERE id_cofre = ?";
+        String sql = "SELECT id_cofre, login, senha, tipo, plataforma, id_usuario, foto FROM Cofre WHERE id_cofre = ?";
         try (Connection conn = ConnectionFactory.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
             ps.setInt(1, id);
@@ -154,31 +157,31 @@ public class CofreDaoNativeImpl implements CofreDao {
 
     @Override
     public List<Cofre> findAll() {
-        String sql = "SELECT id_cofre, login, senha, tipo, plataforma, id_usuario FROM Cofre";
+        String sql = "SELECT id_cofre, login, senha, tipo, plataforma, id_usuario, foto FROM Cofre";
         return listBySql(sql);
     }
 
     @Override
     public List<Cofre> findAll(int page, int size) {
-        String sql = "SELECT id_cofre, login, senha, tipo, plataforma, id_usuario FROM Cofre LIMIT ? OFFSET ?";
+        String sql = "SELECT id_cofre, login, senha, tipo, plataforma, id_usuario, foto FROM Cofre LIMIT ? OFFSET ?";
         return listBySql(sql, size, page * size);
     }
 
     @Override
     public List<Cofre> findByLogin(String login) {
-        String sql = "SELECT id_cofre, login, senha, tipo, plataforma, id_usuario FROM Cofre WHERE login = ?";
+        String sql = "SELECT id_cofre, login, senha, tipo, plataforma, id_usuario, foto FROM Cofre WHERE login = ?";
         return listBySql(sql, login);
     }
 
     @Override
     public List<Cofre> findByTipo(Integer tipo) {
-        String sql = "SELECT id_cofre, login, senha, tipo, plataforma, id_usuario FROM Cofre WHERE tipo = ?";
+        String sql = "SELECT id_cofre, login, senha, tipo, plataforma, id_usuario, foto FROM Cofre WHERE tipo = ?";
         return listBySql(sql, tipo);
     }
 
     @Override
     public List<Cofre> findByIdUsuario(Integer idUsuario) {
-        String sql = "SELECT id_cofre, login, senha, tipo, plataforma, id_usuario FROM Cofre WHERE id_usuario = ?";
+        String sql = "SELECT id_cofre, login, senha, tipo, plataforma, id_usuario, foto FROM Cofre WHERE id_usuario = ?";
         return listBySql(sql, idUsuario);
     }
 
@@ -189,7 +192,7 @@ public class CofreDaoNativeImpl implements CofreDao {
 
     @Override
     public List<Cofre> search(Cofre f, int page, int size) {
-        StringBuilder sb = new StringBuilder("SELECT id_cofre, login, senha, tipo, plataforma, id_usuario FROM Cofre WHERE 1=1");
+        StringBuilder sb = new StringBuilder("SELECT id_cofre, login, senha, tipo, plataforma, id_usuario, foto FROM Cofre WHERE 1=1");
         List<Object> params = new ArrayList<>();
         if (f.getLogin() != null && !f.getLogin().isEmpty()) {
             sb.append(" AND login = ?");

--- a/src/main/java/form/CofreDialog.java
+++ b/src/main/java/form/CofreDialog.java
@@ -5,6 +5,8 @@ import java.awt.Frame;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
+import java.io.IOException;
+import java.io.InputStream;
 import javax.swing.JComboBox;
 import javax.swing.JDialog;
 import javax.swing.JLabel;
@@ -39,6 +41,28 @@ public class CofreDialog extends JDialog {
             if (this.cofre.getTipo() != null && this.cofre.getTipo() >= 1 && this.cofre.getTipo() <= 3) {
                 cbTipo.setSelectedIndex(this.cofre.getTipo() - 1);
             }
+        }
+    }
+
+    private byte[] defaultFoto(int tipo) {
+        String path;
+        switch (tipo) {
+            case 1:
+                path = "/icon/profile.jpg";
+                break;
+            case 2:
+                path = "/icon/profile1.jpg";
+                break;
+            case 3:
+                path = "/icon/profile2.jpg";
+                break;
+            default:
+                return null;
+        }
+        try (InputStream is = getClass().getResourceAsStream(path)) {
+            return is != null ? is.readAllBytes() : null;
+        } catch (IOException ex) {
+            return null;
         }
     }
 
@@ -99,6 +123,7 @@ public class CofreDialog extends JDialog {
         cofre.setLogin(txtLogin.getText());
         cofre.setSenha(new String(txtSenha.getPassword()));
         cofre.setTipo(cbTipo.getSelectedIndex() + 1);
+        cofre.setFoto(defaultFoto(cofre.getTipo()));
         confirmed = true;
         dispose();
     }

--- a/src/main/java/form/CofreForm.java
+++ b/src/main/java/form/CofreForm.java
@@ -27,6 +27,9 @@ import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableCellRenderer;
 import model.Cofre;
 import model.ModelCard;
+import javax.swing.ImageIcon;
+import swing.ImageAvatar;
+import util.ImageUtils;
 import swing.Button;
 import swing.icon.GoogleMaterialDesignIcons;
 import swing.icon.IconFontSwing;
@@ -149,13 +152,19 @@ public class CofreForm extends JPanel {
 
         table = new Table();
         table.setModel(new DefaultTableModel(new Object[][]{}, new String[]{
-            "ID", "Plataforma", "Login", "Senha", "Tipo", "Ações"
+            "Foto", "Plataforma", "Login", "Senha", "Tipo", "Ações"
         }) {
             @Override
             public boolean isCellEditable(int row, int column) {
                 return column == 5;
             }
+
+            @Override
+            public Class<?> getColumnClass(int columnIndex) {
+                return columnIndex == 0 ? ImageIcon.class : Object.class;
+            }
         });
+        table.setRowHeight(40);
         JScrollPane scroll = new JScrollPane(table);
         table.fixTable(scroll);
         table.setRowSelectionAllowed(false);
@@ -207,8 +216,12 @@ public class CofreForm extends JPanel {
             }
         };
         for (Cofre c : lista) {
+            ImageIcon icon = ImageUtils.bytesToImageIcon(c.getFoto());
+            if (icon == null) {
+                icon = new ImageIcon(getClass().getResource("/icon/profile.jpg"));
+            }
             model.addRow(new Object[]{
-                c.getIdCofre(),
+                icon,
                 c.getPlataforma(),
                 c.getLogin(),
                 mask(c.getSenha()),
@@ -216,6 +229,17 @@ public class CofreForm extends JPanel {
                 new ModelAction<>(c, eventAction)
             });
         }
+        table.getColumnModel().getColumn(0).setCellRenderer(new TableCellRenderer() {
+            @Override
+            public Component getTableCellRendererComponent(JTable tbl, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+                ImageAvatar avatar = new ImageAvatar();
+                avatar.setPreferredSize(new Dimension(40, 40));
+                if (value instanceof ImageIcon) {
+                    avatar.setIcon((ImageIcon) value);
+                }
+                return avatar;
+            }
+        });
         int tipoCol = table.getColumnModel().getColumnCount() - 2;
         table.getColumnModel().getColumn(tipoCol).setCellRenderer(new TableCellRenderer() {
             @Override

--- a/src/main/java/model/Cofre.java
+++ b/src/main/java/model/Cofre.java
@@ -20,6 +20,9 @@ public class Cofre {
     @Column(name = "tipo")
     private Integer tipo;
 
+    @Column(name = "foto")
+    private byte[] foto;
+
     @Column(name = "plataforma")
     private String plataforma;
 
@@ -35,6 +38,8 @@ public class Cofre {
     public void setSenha(String senha) { this.senha = senha; }
     public Integer getTipo() { return tipo; }
     public void setTipo(Integer tipo) { this.tipo = tipo; }
+    public byte[] getFoto() { return foto; }
+    public void setFoto(byte[] foto) { this.foto = foto; }
     public String getPlataforma() { return plataforma; }
     public void setPlataforma(String plataforma) { this.plataforma = plataforma; }
     public Integer getIdUsuario() { return idUsuario; }

--- a/src/main/java/test/CofreControllerTest.java
+++ b/src/main/java/test/CofreControllerTest.java
@@ -13,6 +13,7 @@ public class CofreControllerTest {
 
         Cofre cofre = new Cofre();
         cofre.setLogin("login");
+        cofre.setFoto(new byte[]{1});
         controller.criar(cofre);
 
         List<Cofre> list = controller.listar();


### PR DESCRIPTION
## Summary
- adicionar coluna `foto` ao modelo de Cofre
- suportar `foto` nas operações do DAO e controller
- exibir foto do Cofre na tabela e definir imagens padrão conforme tipo

## Testing
- `mvn -q test` *(falhou: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f7350c588325848e41dd12758bfd