### PR TITLE
fix: remove Java 9 API usage in CofreDialog

### DIFF
--- a/src/main/java/form/CofreDialog.java
+++ b/src/main/java/form/CofreDialog.java
@@ -7,6 +7,7 @@ import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.ByteArrayOutputStream;
 import javax.swing.JComboBox;
 import javax.swing.JDialog;
 import javax.swing.JLabel;
@@ -60,7 +61,14 @@ public class CofreDialog extends JDialog {
                 return null;
         }
         try (InputStream is = getClass().getResourceAsStream(path)) {
-            return is != null ? is.readAllBytes() : null;
+            if (is == null) return null;
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            byte[] buffer = new byte[1024];
+            int read;
+            while ((read = is.read(buffer)) != -1) {
+                baos.write(buffer, 0, read);
+            }
+            return baos.toByteArray();
         } catch (IOException ex) {
             return null;
         }


### PR DESCRIPTION
## Summary
- avoid using `InputStream.readAllBytes()` so code compiles with Java 8

## Testing
- `mvn -e compile` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c1fe86f8b883258b4930f7f19d3b2c