### PR TITLE
Corrige regex de AprovadorPullRequests

### DIFF
--- a/src/main/java/tarefas/AprovadorPullRequests.java
+++ b/src/main/java/tarefas/AprovadorPullRequests.java
@@ -75,7 +75,7 @@ public class AprovadorPullRequests {
 
     private List<Integer> listarPullRequests(String owner, String repo) throws IOException {
         List<Integer> numeros = new ArrayList<>();
-        Pattern padrao = Pattern.compile("\"number\"\s*:\s*(\\d+)");
+        Pattern padrao = Pattern.compile("\"number\"\\s*:\\s*(\\d+)");
         int page = 1;
         while (true) {
             URL url = new URL("https://api.github.com/repos/" + owner + "/" + repo


### PR DESCRIPTION
## Summary
- corrige as sequências de escape no padrão que busca números de pull requests

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c29f449578832596775da34c584784