### PR TITLE
Add token file reader for GitHub PR approval example

### DIFF
--- a/src/main/java/tarefas/ExemploAprovadorPullRequests.java
+++ b/src/main/java/tarefas/ExemploAprovadorPullRequests.java
@@ -3,18 +3,22 @@ package tarefas;
 /**
  * Exemplo de utilização da classe {@link AprovadorPullRequests}.
  *
- * <p>Substitua o valor da constante {@code TOKEN} por um token pessoal
- * do GitHub antes de executar.</p>
+ * <p>O token de acesso é lido de um arquivo texto cujo caminho relativo
+ * deve ser informado como primeiro argumento da aplicação.</p>
  */
 public class ExemploAprovadorPullRequests {
 
     private static final String REPO_URL = "https://github.com/kadulobo/RotinaMaisDesktop";
 
-    // TODO: inserir token do GitHub aqui
-    private static final String TOKEN = "SEU_TOKEN_AQUI";
+    private static String TOKEN;
 
     public static void main(String[] args) {
+        if (args.length == 0) {
+            System.err.println("Informe o caminho relativo do arquivo com o token.");
+            return;
+        }
         try {
+            TOKEN = LeitorToken.ler(args[0]);
             AprovadorPullRequests aprovador = new AprovadorPullRequests(REPO_URL, TOKEN);
             aprovador.aprovarPendentes();
             System.out.println("Pull requests aprovados com sucesso.");
@@ -23,3 +27,4 @@ public class ExemploAprovadorPullRequests {
         }
     }
 }
+

--- a/src/main/java/tarefas/LeitorToken.java
+++ b/src/main/java/tarefas/LeitorToken.java
@@ -1,0 +1,35 @@
+package tarefas;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Utilitário para leitura do token a partir de um arquivo de texto.
+ *
+ * <p>O caminho pode ser informado de forma relativa, como em
+ * {@code "pasta\\token.txt"} no Windows. O conteúdo é retornado
+ * sem espaços em branco nas extremidades.</p>
+ */
+public final class LeitorToken {
+
+    private LeitorToken() {
+        // Utilidade, não instanciável
+    }
+
+    /**
+     * Lê o conteúdo do arquivo informado e o retorna como token.
+     *
+     * @param caminhoRelativo caminho relativo do arquivo que contém o token
+     * @return token lido do arquivo
+     * @throws IOException se ocorrer problema de leitura
+     */
+    public static String ler(String caminhoRelativo) throws IOException {
+        Path caminho = Paths.get(caminhoRelativo);
+        byte[] bytes = Files.readAllBytes(caminho);
+        return new String(bytes, StandardCharsets.UTF_8).trim();
+    }
+}
+


### PR DESCRIPTION
## Summary
- update example to load GitHub token from a path passed in arguments
- add utility to read token text from a file

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a7c285748325a1c8486b4466707b