### PR TITLE
docs: clarify Maven version handling

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,6 +4,8 @@ Requer **Java 17** ou superior para compilar e executar, devido às
 dependências Jakarta Persistence 3.x e Hibernate 6.x.
 - Versão do projeto definida no pom.xml: 1.0.0-SNAPSHOT.
 - Para alterar a versão, edite a tag <version> no pom.xml.
+- Para consultar a versão atual pela linha de comando, execute `mvn -q help:evaluate -Dexpression=project.version -DforceStdout`.
+- Em cada release, incremente este número seguindo a convenção MAJOR.MINOR.PATCH.
 - Código refatorado em PT-BR (component, swing, evento, model, dialog, form, main).
 - Utilitário de ícones: swing.icon.Icones (PNG/JPG em /resources/icon + fallback Material Icons).
 - Coloque seus PNGs/JPGs de ícones em: src/main/resources/icon/


### PR DESCRIPTION
## Summary
- document how to query project version via Maven
- note version numbering convention MAJOR.MINOR.PATCH

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c342c3595083259d86406821370082