### PR TITLE
Add status support and search tweaks for Categoria and Evento

### DIFF
--- a/src/main/java/dao/impl/CategoriaDaoNativeImpl.java
+++ b/src/main/java/dao/impl/CategoriaDaoNativeImpl.java
@@ -16,6 +16,7 @@ public class CategoriaDaoNativeImpl implements CategoriaDao {
         c.setIdCategoria(rs.getInt("id_categoria"));
         c.setNome(rs.getString("nome"));
         c.setDescricao(rs.getString("descricao"));
+        c.setStatus((Integer) rs.getObject("status"));
         if (withFoto) {
             c.setFoto(rs.getBytes("foto"));
         }
@@ -29,19 +30,24 @@ public class CategoriaDaoNativeImpl implements CategoriaDao {
     @Override
     public void create(Categoria categoria) throws CategoriaException {
         Logger.info("CategoriaDaoNativeImpl.create - inicio");
-        String sql = "INSERT INTO Categoria (nome, descricao, foto, data_criacao) VALUES (?,?,?,?)";
+        String sql = "INSERT INTO Categoria (status, nome, descricao, foto, data_criacao) VALUES (?,?,?,?,?)";
         Connection conn = null;
         try {
             conn = ConnectionFactory.getConnection();
             conn.setAutoCommit(false);
             try (PreparedStatement ps = conn.prepareStatement(sql)) {
-                ps.setString(1, categoria.getNome());
-                ps.setString(2, categoria.getDescricao());
-                ps.setBytes(3, categoria.getFoto());
-                if (categoria.getDataCriacao() != null) {
-                    ps.setDate(4, Date.valueOf(categoria.getDataCriacao()));
+                if (categoria.getStatus() != null) {
+                    ps.setInt(1, categoria.getStatus());
                 } else {
-                    ps.setNull(4, Types.DATE);
+                    ps.setNull(1, Types.INTEGER);
+                }
+                ps.setString(2, categoria.getNome());
+                ps.setString(3, categoria.getDescricao());
+                ps.setBytes(4, categoria.getFoto());
+                if (categoria.getDataCriacao() != null) {
+                    ps.setDate(5, Date.valueOf(categoria.getDataCriacao()));
+                } else {
+                    ps.setNull(5, Types.DATE);
                 }
                 ps.executeUpdate();
             }
@@ -63,21 +69,26 @@ public class CategoriaDaoNativeImpl implements CategoriaDao {
     @Override
     public Categoria update(Categoria categoria) throws CategoriaException {
         Logger.info("CategoriaDaoNativeImpl.update - inicio");
-        String sql = "UPDATE Categoria SET nome=?, descricao=?, foto=?, data_criacao=? WHERE id_categoria=?";
+        String sql = "UPDATE Categoria SET status=?, nome=?, descricao=?, foto=?, data_criacao=? WHERE id_categoria=?";
         Connection conn = null;
         try {
             conn = ConnectionFactory.getConnection();
             conn.setAutoCommit(false);
             try (PreparedStatement ps = conn.prepareStatement(sql)) {
-                ps.setString(1, categoria.getNome());
-                ps.setString(2, categoria.getDescricao());
-                ps.setBytes(3, categoria.getFoto());
-                if (categoria.getDataCriacao() != null) {
-                    ps.setDate(4, Date.valueOf(categoria.getDataCriacao()));
+                if (categoria.getStatus() != null) {
+                    ps.setInt(1, categoria.getStatus());
                 } else {
-                    ps.setNull(4, Types.DATE);
+                    ps.setNull(1, Types.INTEGER);
                 }
-                ps.setInt(5, categoria.getIdCategoria());
+                ps.setString(2, categoria.getNome());
+                ps.setString(3, categoria.getDescricao());
+                ps.setBytes(4, categoria.getFoto());
+                if (categoria.getDataCriacao() != null) {
+                    ps.setDate(5, Date.valueOf(categoria.getDataCriacao()));
+                } else {
+                    ps.setNull(5, Types.DATE);
+                }
+                ps.setInt(6, categoria.getIdCategoria());
                 int updated = ps.executeUpdate();
                 if (updated == 0) {
                     throw new CategoriaException("Categoria não encontrada: id=" + categoria.getIdCategoria());
@@ -132,7 +143,7 @@ public class CategoriaDaoNativeImpl implements CategoriaDao {
     @Override
     public Categoria findById(Integer id) throws CategoriaException {
         Logger.info("CategoriaDaoNativeImpl.findById - inicio");
-        String sql = "SELECT id_categoria, nome, descricao, data_criacao FROM Categoria WHERE id_categoria=?";
+        String sql = "SELECT id_categoria, status, nome, descricao, data_criacao FROM Categoria WHERE id_categoria=?";
         try (Connection conn = ConnectionFactory.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
             ps.setInt(1, id);
@@ -152,7 +163,7 @@ public class CategoriaDaoNativeImpl implements CategoriaDao {
     @Override
     public Categoria findWithBlobsById(Integer id) throws CategoriaException {
         Logger.info("CategoriaDaoNativeImpl.findWithBlobsById - inicio");
-        String sql = "SELECT id_categoria, nome, descricao, foto, data_criacao FROM Categoria WHERE id_categoria=?";
+        String sql = "SELECT id_categoria, status, nome, descricao, foto, data_criacao FROM Categoria WHERE id_categoria=?";
         try (Connection conn = ConnectionFactory.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
             ps.setInt(1, id);
@@ -172,7 +183,7 @@ public class CategoriaDaoNativeImpl implements CategoriaDao {
     @Override
     public List<Categoria> findAll() {
         Logger.info("CategoriaDaoNativeImpl.findAll - inicio");
-        String sql = "SELECT id_categoria, nome, descricao, data_criacao FROM Categoria";
+        String sql = "SELECT id_categoria, status, nome, descricao, data_criacao FROM Categoria";
         List<Categoria> list = new ArrayList<>();
         try (Connection conn = ConnectionFactory.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql);
@@ -190,7 +201,7 @@ public class CategoriaDaoNativeImpl implements CategoriaDao {
     @Override
     public List<Categoria> findAll(int page, int size) {
         Logger.info("CategoriaDaoNativeImpl.findAll(page) - inicio");
-        String sql = "SELECT id_categoria, nome, descricao, data_criacao FROM Categoria LIMIT ? OFFSET ?";
+        String sql = "SELECT id_categoria, status, nome, descricao, data_criacao FROM Categoria LIMIT ? OFFSET ?";
         List<Categoria> list = new ArrayList<>();
         try (Connection conn = ConnectionFactory.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -211,7 +222,7 @@ public class CategoriaDaoNativeImpl implements CategoriaDao {
     @Override
     public List<Categoria> findByNome(String nome) {
         Logger.info("CategoriaDaoNativeImpl.findByNome - inicio");
-        String sql = "SELECT id_categoria, nome, descricao, data_criacao FROM Categoria WHERE nome=?";
+        String sql = "SELECT id_categoria, status, nome, descricao, data_criacao FROM Categoria WHERE nome=?";
         List<Categoria> list = new ArrayList<>();
         try (Connection conn = ConnectionFactory.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -231,7 +242,7 @@ public class CategoriaDaoNativeImpl implements CategoriaDao {
     @Override
     public List<Categoria> findByDescricao(String descricao) {
         Logger.info("CategoriaDaoNativeImpl.findByDescricao - inicio");
-        String sql = "SELECT id_categoria, nome, descricao, data_criacao FROM Categoria WHERE descricao=?";
+        String sql = "SELECT id_categoria, status, nome, descricao, data_criacao FROM Categoria WHERE descricao=?";
         List<Categoria> list = new ArrayList<>();
         try (Connection conn = ConnectionFactory.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -251,7 +262,7 @@ public class CategoriaDaoNativeImpl implements CategoriaDao {
     @Override
     public List<Categoria> findByDataCriacao(java.time.LocalDate dataCriacao) {
         Logger.info("CategoriaDaoNativeImpl.findByDataCriacao - inicio");
-        String sql = "SELECT id_categoria, nome, descricao, data_criacao FROM Categoria WHERE data_criacao=?";
+        String sql = "SELECT id_categoria, status, nome, descricao, data_criacao FROM Categoria WHERE data_criacao=?";
         List<Categoria> list = new ArrayList<>();
         try (Connection conn = ConnectionFactory.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -271,7 +282,7 @@ public class CategoriaDaoNativeImpl implements CategoriaDao {
     @Override
     public List<Categoria> findByFoto(byte[] foto) {
         Logger.info("CategoriaDaoNativeImpl.findByFoto - inicio");
-        String sql = "SELECT id_categoria, nome, descricao, foto, data_criacao FROM Categoria WHERE foto=?";
+        String sql = "SELECT id_categoria, status, nome, descricao, foto, data_criacao FROM Categoria WHERE foto=?";
         List<Categoria> list = new ArrayList<>();
         try (Connection conn = ConnectionFactory.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -296,7 +307,7 @@ public class CategoriaDaoNativeImpl implements CategoriaDao {
     @Override
     public List<Categoria> search(Categoria filtro, int page, int size) {
         Logger.info("CategoriaDaoNativeImpl.search - inicio");
-        StringBuilder sb = new StringBuilder("SELECT id_categoria, nome, descricao, data_criacao FROM Categoria WHERE 1=1");
+        StringBuilder sb = new StringBuilder("SELECT id_categoria, status, nome, descricao, data_criacao FROM Categoria WHERE 1=1");
         List<Object> params = new ArrayList<>();
         if (filtro.getNome() != null && !filtro.getNome().isEmpty()) {
             sb.append(" AND nome=?");
@@ -305,6 +316,10 @@ public class CategoriaDaoNativeImpl implements CategoriaDao {
         if (filtro.getDescricao() != null && !filtro.getDescricao().isEmpty()) {
             sb.append(" AND descricao=?");
             params.add(filtro.getDescricao());
+        }
+        if (filtro.getStatus() != null) {
+            sb.append(" AND status=?");
+            params.add(filtro.getStatus());
         }
         if (filtro.getDataCriacao() != null) {
             sb.append(" AND data_criacao=?");

--- a/src/main/java/dao/impl/EventoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/EventoDaoNativeImpl.java
@@ -16,6 +16,7 @@ public class EventoDaoNativeImpl implements EventoDao {
         Evento e = new Evento();
         e.setIdEvento(rs.getInt("id_evento"));
         e.setVantagem((Boolean) rs.getObject("vantagem"));
+        e.setStatus((Integer) rs.getObject("status"));
         if (withFoto) {
             e.setFoto(rs.getBytes("foto"));
         }
@@ -37,29 +38,34 @@ public class EventoDaoNativeImpl implements EventoDao {
     @Override
     public void create(Evento evento) throws EventoException {
         Logger.info("EventoDaoNativeImpl.create - inicio");
-        String sql = "INSERT INTO Evento (vantagem, foto, nome, descricao, data_criacao, id_categoria) VALUES (?,?,?,?,?,?)";
+        String sql = "INSERT INTO Evento (status, vantagem, foto, nome, descricao, data_criacao, id_categoria) VALUES (?,?,?,?,?,?,?)";
         Connection conn = null;
         try {
             conn = ConnectionFactory.getConnection();
             conn.setAutoCommit(false);
             try (PreparedStatement ps = conn.prepareStatement(sql)) {
-                if (evento.getVantagem() != null) {
-                    ps.setBoolean(1, evento.getVantagem());
+                if (evento.getStatus() != null) {
+                    ps.setInt(1, evento.getStatus());
                 } else {
-                    ps.setNull(1, Types.BOOLEAN);
+                    ps.setNull(1, Types.INTEGER);
                 }
-                ps.setBytes(2, evento.getFoto());
-                ps.setString(3, evento.getNome());
-                ps.setString(4, evento.getDescricao());
-                if (evento.getDataCriacao() != null) {
-                    ps.setDate(5, Date.valueOf(evento.getDataCriacao()));
+                if (evento.getVantagem() != null) {
+                    ps.setBoolean(2, evento.getVantagem());
                 } else {
-                    ps.setNull(5, Types.DATE);
+                    ps.setNull(2, Types.BOOLEAN);
+                }
+                ps.setBytes(3, evento.getFoto());
+                ps.setString(4, evento.getNome());
+                ps.setString(5, evento.getDescricao());
+                if (evento.getDataCriacao() != null) {
+                    ps.setDate(6, Date.valueOf(evento.getDataCriacao()));
+                } else {
+                    ps.setNull(6, Types.DATE);
                 }
                 if (evento.getCategoria() != null && evento.getCategoria().getIdCategoria() != null) {
-                    ps.setInt(6, evento.getCategoria().getIdCategoria());
+                    ps.setInt(7, evento.getCategoria().getIdCategoria());
                 } else {
-                    ps.setNull(6, Types.INTEGER);
+                    ps.setNull(7, Types.INTEGER);
                 }
                 ps.executeUpdate();
             }
@@ -81,31 +87,36 @@ public class EventoDaoNativeImpl implements EventoDao {
     @Override
     public Evento update(Evento evento) throws EventoException {
         Logger.info("EventoDaoNativeImpl.update - inicio");
-        String sql = "UPDATE Evento SET vantagem=?, foto=?, nome=?, descricao=?, data_criacao=?, id_categoria=? WHERE id_evento=?";
+        String sql = "UPDATE Evento SET status=?, vantagem=?, foto=?, nome=?, descricao=?, data_criacao=?, id_categoria=? WHERE id_evento=?";
         Connection conn = null;
         try {
             conn = ConnectionFactory.getConnection();
             conn.setAutoCommit(false);
             try (PreparedStatement ps = conn.prepareStatement(sql)) {
-                if (evento.getVantagem() != null) {
-                    ps.setBoolean(1, evento.getVantagem());
+                if (evento.getStatus() != null) {
+                    ps.setInt(1, evento.getStatus());
                 } else {
-                    ps.setNull(1, Types.BOOLEAN);
+                    ps.setNull(1, Types.INTEGER);
                 }
-                ps.setBytes(2, evento.getFoto());
-                ps.setString(3, evento.getNome());
-                ps.setString(4, evento.getDescricao());
-                if (evento.getDataCriacao() != null) {
-                    ps.setDate(5, Date.valueOf(evento.getDataCriacao()));
+                if (evento.getVantagem() != null) {
+                    ps.setBoolean(2, evento.getVantagem());
                 } else {
-                    ps.setNull(5, Types.DATE);
+                    ps.setNull(2, Types.BOOLEAN);
+                }
+                ps.setBytes(3, evento.getFoto());
+                ps.setString(4, evento.getNome());
+                ps.setString(5, evento.getDescricao());
+                if (evento.getDataCriacao() != null) {
+                    ps.setDate(6, Date.valueOf(evento.getDataCriacao()));
+                } else {
+                    ps.setNull(6, Types.DATE);
                 }
                 if (evento.getCategoria() != null && evento.getCategoria().getIdCategoria() != null) {
-                    ps.setInt(6, evento.getCategoria().getIdCategoria());
+                    ps.setInt(7, evento.getCategoria().getIdCategoria());
                 } else {
-                    ps.setNull(6, Types.INTEGER);
+                    ps.setNull(7, Types.INTEGER);
                 }
-                ps.setInt(7, evento.getIdEvento());
+                ps.setInt(8, evento.getIdEvento());
                 int updated = ps.executeUpdate();
                 if (updated == 0) {
                     throw new EventoException("Evento não encontrado: id=" + evento.getIdEvento());
@@ -160,7 +171,7 @@ public class EventoDaoNativeImpl implements EventoDao {
     @Override
     public Evento findById(Integer id) throws EventoException {
         Logger.info("EventoDaoNativeImpl.findById - inicio");
-        String sql = "SELECT id_evento, vantagem, nome, descricao, data_criacao, id_categoria FROM Evento WHERE id_evento=?";
+        String sql = "SELECT id_evento, status, vantagem, nome, descricao, data_criacao, id_categoria FROM Evento WHERE id_evento=?";
         try (Connection conn = ConnectionFactory.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
             ps.setInt(1, id);
@@ -180,7 +191,7 @@ public class EventoDaoNativeImpl implements EventoDao {
     @Override
     public Evento findWithBlobsById(Integer id) throws EventoException {
         Logger.info("EventoDaoNativeImpl.findWithBlobsById - inicio");
-        String sql = "SELECT id_evento, vantagem, foto, nome, descricao, data_criacao, id_categoria FROM Evento WHERE id_evento=?";
+        String sql = "SELECT id_evento, status, vantagem, foto, nome, descricao, data_criacao, id_categoria FROM Evento WHERE id_evento=?";
         try (Connection conn = ConnectionFactory.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
             ps.setInt(1, id);
@@ -200,7 +211,7 @@ public class EventoDaoNativeImpl implements EventoDao {
     @Override
     public List<Evento> findAll() {
         Logger.info("EventoDaoNativeImpl.findAll - inicio");
-        String sql = "SELECT id_evento, vantagem, nome, descricao, data_criacao, id_categoria FROM Evento";
+        String sql = "SELECT id_evento, status, vantagem, nome, descricao, data_criacao, id_categoria FROM Evento";
         List<Evento> list = new ArrayList<>();
         try (Connection conn = ConnectionFactory.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql);
@@ -218,7 +229,7 @@ public class EventoDaoNativeImpl implements EventoDao {
     @Override
     public List<Evento> findAll(int page, int size) {
         Logger.info("EventoDaoNativeImpl.findAll(page) - inicio");
-        String sql = "SELECT id_evento, vantagem, nome, descricao, data_criacao, id_categoria FROM Evento LIMIT ? OFFSET ?";
+        String sql = "SELECT id_evento, status, vantagem, nome, descricao, data_criacao, id_categoria FROM Evento LIMIT ? OFFSET ?";
         List<Evento> list = new ArrayList<>();
         try (Connection conn = ConnectionFactory.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -239,7 +250,7 @@ public class EventoDaoNativeImpl implements EventoDao {
     @Override
     public List<Evento> findByVantagem(Boolean vantagem) {
         Logger.info("EventoDaoNativeImpl.findByVantagem - inicio");
-        String sql = "SELECT id_evento, vantagem, nome, descricao, data_criacao, id_categoria FROM Evento WHERE vantagem=?";
+        String sql = "SELECT id_evento, status, vantagem, nome, descricao, data_criacao, id_categoria FROM Evento WHERE vantagem=?";
         List<Evento> list = new ArrayList<>();
         try (Connection conn = ConnectionFactory.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -263,7 +274,7 @@ public class EventoDaoNativeImpl implements EventoDao {
     @Override
     public List<Evento> findByFoto(byte[] foto) {
         Logger.info("EventoDaoNativeImpl.findByFoto - inicio");
-        String sql = "SELECT id_evento, vantagem, foto, nome, descricao, data_criacao, id_categoria FROM Evento WHERE foto=?";
+        String sql = "SELECT id_evento, status, vantagem, foto, nome, descricao, data_criacao, id_categoria FROM Evento WHERE foto=?";
         List<Evento> list = new ArrayList<>();
         try (Connection conn = ConnectionFactory.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -283,7 +294,7 @@ public class EventoDaoNativeImpl implements EventoDao {
     @Override
     public List<Evento> findByNome(String nome) {
         Logger.info("EventoDaoNativeImpl.findByNome - inicio");
-        String sql = "SELECT id_evento, vantagem, nome, descricao, data_criacao, id_categoria FROM Evento WHERE nome=?";
+        String sql = "SELECT id_evento, status, vantagem, nome, descricao, data_criacao, id_categoria FROM Evento WHERE nome=?";
         List<Evento> list = new ArrayList<>();
         try (Connection conn = ConnectionFactory.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -303,7 +314,7 @@ public class EventoDaoNativeImpl implements EventoDao {
     @Override
     public List<Evento> findByDescricao(String descricao) {
         Logger.info("EventoDaoNativeImpl.findByDescricao - inicio");
-        String sql = "SELECT id_evento, vantagem, nome, descricao, data_criacao, id_categoria FROM Evento WHERE descricao=?";
+        String sql = "SELECT id_evento, status, vantagem, nome, descricao, data_criacao, id_categoria FROM Evento WHERE descricao=?";
         List<Evento> list = new ArrayList<>();
         try (Connection conn = ConnectionFactory.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -323,7 +334,7 @@ public class EventoDaoNativeImpl implements EventoDao {
     @Override
     public List<Evento> findByDataCriacao(java.time.LocalDate dataCriacao) {
         Logger.info("EventoDaoNativeImpl.findByDataCriacao - inicio");
-        String sql = "SELECT id_evento, vantagem, nome, descricao, data_criacao, id_categoria FROM Evento WHERE data_criacao=?";
+        String sql = "SELECT id_evento, status, vantagem, nome, descricao, data_criacao, id_categoria FROM Evento WHERE data_criacao=?";
         List<Evento> list = new ArrayList<>();
         try (Connection conn = ConnectionFactory.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -343,7 +354,7 @@ public class EventoDaoNativeImpl implements EventoDao {
     @Override
     public List<Evento> findByIdCategoria(Integer idCategoria) {
         Logger.info("EventoDaoNativeImpl.findByIdCategoria - inicio");
-        String sql = "SELECT id_evento, vantagem, nome, descricao, data_criacao, id_categoria FROM Evento WHERE id_categoria=?";
+        String sql = "SELECT id_evento, status, vantagem, nome, descricao, data_criacao, id_categoria FROM Evento WHERE id_categoria=?";
         List<Evento> list = new ArrayList<>();
         try (Connection conn = ConnectionFactory.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -368,7 +379,7 @@ public class EventoDaoNativeImpl implements EventoDao {
     @Override
     public List<Evento> search(Evento filtro, int page, int size) {
         Logger.info("EventoDaoNativeImpl.search - inicio");
-        StringBuilder sb = new StringBuilder("SELECT id_evento, vantagem, nome, descricao, data_criacao, id_categoria FROM Evento WHERE 1=1");
+        StringBuilder sb = new StringBuilder("SELECT id_evento, status, vantagem, nome, descricao, data_criacao, id_categoria FROM Evento WHERE 1=1");
         List<Object> params = new ArrayList<>();
         if (filtro.getVantagem() != null) {
             sb.append(" AND vantagem=?");
@@ -381,6 +392,10 @@ public class EventoDaoNativeImpl implements EventoDao {
         if (filtro.getDescricao() != null && !filtro.getDescricao().isEmpty()) {
             sb.append(" AND descricao=?");
             params.add(filtro.getDescricao());
+        }
+        if (filtro.getStatus() != null) {
+            sb.append(" AND status=?");
+            params.add(filtro.getStatus());
         }
         if (filtro.getDataCriacao() != null) {
             sb.append(" AND data_criacao=?");

--- a/src/main/java/form/CategoriaForm.java
+++ b/src/main/java/form/CategoriaForm.java
@@ -52,7 +52,7 @@ import util.ImageUtils;
 public class CategoriaForm extends JPanel {
 
     private final CategoriaController controller;
-    private final String PLACEHOLDER = "Search categories...";
+    private final String PLACEHOLDER = "Search by description...";
 
     private JTextField txtSearch;
     private JButton btnToggleView;
@@ -167,10 +167,10 @@ public class CategoriaForm extends JPanel {
 
         // List view
         table = new Table();
-        table.setModel(new DefaultTableModel(new Object[][]{}, new String[]{"ID", "Nome", "Descrição", ""}) {
+        table.setModel(new DefaultTableModel(new Object[][]{}, new String[]{"ID", "Nome", "Descrição", "Status", ""}) {
             @Override
             public boolean isCellEditable(int row, int column) {
-                return column == 3;
+                return column == 4;
             }
         });
         table.addMouseListener(new MouseAdapter() {
@@ -227,8 +227,7 @@ public class CategoriaForm extends JPanel {
     private void applyFilter() {
         String text = getFilterText().toLowerCase();
         filteredCategorias = allCategorias.stream()
-                .filter(c -> c.getNome().toLowerCase().contains(text)
-                        || (c.getDescricao() != null && c.getDescricao().toLowerCase().contains(text)))
+                .filter(c -> c.getDescricao() != null && c.getDescricao().toLowerCase().contains(text))
                 .collect(Collectors.toList());
 
         if (filteredCategorias.isEmpty()) {
@@ -279,7 +278,7 @@ public class CategoriaForm extends JPanel {
             }
         };
         for (Categoria c : getCurrentPageCategorias()) {
-            model.addRow(new Object[]{c.getIdCategoria(), c.getNome(), c.getDescricao(), new ModelAction<>(c, eventAction)});
+            model.addRow(new Object[]{c.getIdCategoria(), c.getNome(), c.getDescricao(), c.getStatus(), new ModelAction<>(c, eventAction)});
         }
     }
 
@@ -363,6 +362,9 @@ public class CategoriaForm extends JPanel {
 
         JLabel lblDescricao = new JLabel(c.getDescricao() != null ? c.getDescricao() : "");
         infoPanel.add(lblDescricao);
+        infoPanel.add(Box.createVerticalStrut(5));
+        JLabel lblStatus = new JLabel("Status: " + (c.getStatus() != null ? c.getStatus() : ""));
+        infoPanel.add(lblStatus);
 
         body.add(infoPanel, BorderLayout.CENTER);
         card.add(body, BorderLayout.CENTER);

--- a/src/main/java/form/EventoForm.java
+++ b/src/main/java/form/EventoForm.java
@@ -52,7 +52,7 @@ import util.ImageUtils;
 public class EventoForm extends JPanel {
 
     private final EventoController controller;
-    private final String PLACEHOLDER = "Search events...";
+    private final String PLACEHOLDER = "Search by name...";
 
     private JTextField txtSearch;
     private JButton btnToggleView;
@@ -167,10 +167,10 @@ public class EventoForm extends JPanel {
 
         // List view
         table = new Table();
-        table.setModel(new DefaultTableModel(new Object[][]{}, new String[]{"ID", "Nome", "Descrição", "Vantagem", ""}) {
+        table.setModel(new DefaultTableModel(new Object[][]{}, new String[]{"ID", "Nome", "Descrição", "Vantagem", "Status", ""}) {
             @Override
             public boolean isCellEditable(int row, int column) {
-                return column == 4;
+                return column == 5;
             }
         });
         table.addMouseListener(new MouseAdapter() {
@@ -227,8 +227,7 @@ public class EventoForm extends JPanel {
     private void applyFilter() {
         String text = getFilterText().toLowerCase();
         filteredEventos = allEventos.stream()
-                .filter(e -> e.getNome().toLowerCase().contains(text)
-                        || (e.getDescricao() != null && e.getDescricao().toLowerCase().contains(text)))
+                .filter(e -> e.getNome().toLowerCase().contains(text))
                 .collect(Collectors.toList());
 
         if (filteredEventos.isEmpty()) {
@@ -279,7 +278,7 @@ public class EventoForm extends JPanel {
             }
         };
         for (Evento e : getCurrentPageEventos()) {
-            model.addRow(new Object[]{e.getIdEvento(), e.getNome(), e.getDescricao(), e.getVantagem(), new ModelAction<>(e, eventAction)});
+            model.addRow(new Object[]{e.getIdEvento(), e.getNome(), e.getDescricao(), e.getVantagem(), e.getStatus(), new ModelAction<>(e, eventAction)});
         }
     }
 
@@ -366,6 +365,9 @@ public class EventoForm extends JPanel {
         infoPanel.add(Box.createVerticalStrut(5));
         JLabel lblVantagem = new JLabel("Vantagem: " + (Boolean.TRUE.equals(e.getVantagem()) ? "Sim" : "Não"));
         infoPanel.add(lblVantagem);
+        infoPanel.add(Box.createVerticalStrut(5));
+        JLabel lblStatus = new JLabel("Status: " + (e.getStatus() != null ? e.getStatus() : ""));
+        infoPanel.add(lblStatus);
 
         body.add(infoPanel, BorderLayout.CENTER);
         card.add(body, BorderLayout.CENTER);

--- a/src/main/java/model/Categoria.java
+++ b/src/main/java/model/Categoria.java
@@ -29,6 +29,9 @@ public class Categoria {
     @Column(name = "descricao")
     private String descricao;
 
+    @Column(name = "status")
+    private Integer status;
+
     @Column(name = "foto")
     private byte[] foto;
 
@@ -60,6 +63,14 @@ public class Categoria {
 
     public void setDescricao(String descricao) {
         this.descricao = descricao;
+    }
+
+    public Integer getStatus() {
+        return status;
+    }
+
+    public void setStatus(Integer status) {
+        this.status = status;
     }
 
     public byte[] getFoto() {
@@ -105,6 +116,7 @@ public class Categoria {
                 "idCategoria=" + idCategoria +
                 ", nome='" + nome + '\'' +
                 ", descricao='" + descricao + '\'' +
+                ", status=" + status +
                 ", dataCriacao=" + dataCriacao +
                 '}';
     }

--- a/src/main/java/model/Evento.java
+++ b/src/main/java/model/Evento.java
@@ -38,6 +38,9 @@ public class Evento {
     @Column(name = "descricao")
     private String descricao;
 
+    @Column(name = "status")
+    private Integer status;
+
     @Column(name = "data_criacao")
     private LocalDate dataCriacao;
 
@@ -88,6 +91,14 @@ public class Evento {
         this.descricao = descricao;
     }
 
+    public Integer getStatus() {
+        return status;
+    }
+
+    public void setStatus(Integer status) {
+        this.status = status;
+    }
+
     public LocalDate getDataCriacao() {
         return dataCriacao;
     }
@@ -132,6 +143,7 @@ public class Evento {
                 ", vantagem=" + vantagem +
                 ", nome='" + nome + '\'' +
                 ", descricao='" + descricao + '\'' +
+                ", status=" + status +
                 ", dataCriacao=" + dataCriacao +
                 ", categoria=" + categoria +
                 '}';


### PR DESCRIPTION
## Summary
- add status field to Categoria and Evento entities with DAO persistence
- search categories by description and events by name, showing status in tables and cards

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c37460505c832582695046bcf08b96