### PR TITLE
Fix Java 8 compatibility for embedded Postgres server

### DIFF
--- a/src/main/java/conexao/EmbeddedPostgresServer.java
+++ b/src/main/java/conexao/EmbeddedPostgresServer.java
@@ -4,6 +4,7 @@ import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -27,7 +28,7 @@ public final class EmbeddedPostgresServer {
             return;
         }
         try {
-            Path dataDir = Path.of("embedded-pg-data");
+            Path dataDir = Paths.get("embedded-pg-data");
             Files.createDirectories(dataDir);
             POSTGRES = EmbeddedPostgres.builder()
                     .setPort(cfg.getPort())


### PR DESCRIPTION
## Summary
- Use `Paths.get` instead of `Path.of` in `EmbeddedPostgresServer` for Java 8 support

## Testing
- `mvn -q -e -DskipTests compile` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c45f0db28083258a27158e353e7cf2