### PR TITLE
Use Flyway 7.15.0 for Java 8 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,8 @@
     <selenium.version>3.141.59</selenium.version>
     <!-- WebDriverManager 4.4.3 ainda suporta Java 8 -->
     <webdrivermanager.version>4.4.3</webdrivermanager.version>
+    <!-- Flyway 7.15.0 é a última versão que suporta Java 8 -->
+    <flyway.version>7.15.0</flyway.version>
 </properties>
 
 
@@ -78,7 +80,7 @@
   <dependency>
     <groupId>org.flywaydb</groupId>
     <artifactId>flyway-core</artifactId>
-    <version>10.16.0</version>
+    <version>${flyway.version}</version>
   </dependency>
 
     


### PR DESCRIPTION
## Summary
- pin Flyway to 7.15.0, the last version compatible with Java 8

## Testing
- `mvn -q -e -DskipTests compile` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c468fd64708325bda59dac6c2c8bc2