### PR TITLE
Fix embedded Postgres startup error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,14 @@
       <artifactId>webdrivermanager</artifactId>
       <version>${webdrivermanager.version}</version>
     </dependency>
-    
+
+    <!-- Evita erro "NoSuchMethodError: IOUtils.skip" ao carregar embedded-postgres -->
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>1.26.1</version>
+    </dependency>
+
       <!-- PostgreSQL real embutido -->
   <dependency>
     <groupId>io.zonky.test</groupId>


### PR DESCRIPTION
## Summary
- include Apache Commons Compress 1.26.1 to provide required IOUtils.skip for embedded Postgres

## Testing
- `mvn -q -e -DskipTests package` *(failed: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c48c1c29fc83258e626c294320cede