### PR TITLE
Add commons-io dependency to support embedded Postgres

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,13 @@
       <version>1.26.1</version>
     </dependency>
 
+    <!-- Evita NoSuchMethodError para IOUtils.byteArray -->
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.11.0</version>
+    </dependency>
+
       <!-- PostgreSQL real embutido -->
   <dependency>
     <groupId>io.zonky.test</groupId>


### PR DESCRIPTION
## Summary
- add Apache Commons IO dependency to satisfy IOUtils.byteArray used by commons-compress

## Testing
- `mvn -q -e -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c556fd1d288325b8cfaee9c98788ee