### PR TITLE
Atualiza commons-io para evitar NoSuchMethodError

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,11 +75,11 @@
       <version>1.26.1</version>
     </dependency>
 
-    <!-- Evita NoSuchMethodError para IOUtils.byteArray -->
+    <!-- Atualiza para evitar NoSuchMethodError em IOUtils.skip ao usar commons-compress 1.26+ -->
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.11.0</version>
+      <version>2.16.1</version>
     </dependency>
 
       <!-- PostgreSQL real embutido -->


### PR DESCRIPTION
## Summary
- Atualiza commons-io para uma versão compatível com o commons-compress utilizado pelo embedded-postgres

## Testing
- `mvn -q test` *(falhou: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f15f9270832598695336fff46f65