### PR TITLE
Persist embedded Postgres data between runs

### DIFF
--- a/src/main/java/conexao/EmbeddedPostgresServer.java
+++ b/src/main/java/conexao/EmbeddedPostgresServer.java
@@ -33,6 +33,8 @@ public final class EmbeddedPostgresServer {
             POSTGRES = EmbeddedPostgres.builder()
                     .setPort(cfg.getPort())
                     .setDataDirectory(dataDir)
+                    // desabilita limpeza para persistir dados entre reinicializações
+                    .setCleanDataDirectory(false)
                     .start();
             createUserAndDatabase(cfg);
         } catch (IOException | SQLException e) {


### PR DESCRIPTION
## Summary
- keep embedded PostgreSQL data directory between runs to retain user data

## Testing
- `mvn -q -e -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-enforcer-plugin:3.5.0 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68c5fa33ebe48325b036f945f4672337