### PR TITLE
Clean embedded Postgres data directory before starting server

### DIFF
--- a/src/main/java/conexao/EmbeddedPostgresServer.java
+++ b/src/main/java/conexao/EmbeddedPostgresServer.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Comparator;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -29,6 +30,24 @@ public final class EmbeddedPostgresServer {
         }
         try {
             Path dataDir = Paths.get("embedded-pg-data");
+
+            // A biblioteca embutida falha ao executar o initdb quando o
+            // diretório de dados já existe e contém arquivos de uma
+            // inicialização anterior. Para evitar o erro "directory exists but
+            // is not empty" limpamos o diretório manualmente antes de iniciar
+            // um novo banco.
+            if (Files.exists(dataDir)) {
+                try (java.util.stream.Stream<Path> walk = Files.walk(dataDir)) {
+                    walk.sorted(Comparator.reverseOrder()).forEach(p -> {
+                        try {
+                            Files.delete(p);
+                        } catch (IOException ex) {
+                            throw new IllegalStateException("Falha ao limpar diretório de dados", ex);
+                        }
+                    });
+                }
+            }
+
             Files.createDirectories(dataDir);
             POSTGRES = EmbeddedPostgres.builder()
                     .setPort(cfg.getPort())


### PR DESCRIPTION
## Summary
- clear leftover files in the embedded Postgres data directory before initialization

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c5fd8316d48325a3ec5d0e877b3045