### PR TITLE
Ensure embedded Postgres data directory is fully cleaned

### DIFF
--- a/src/main/java/conexao/EmbeddedPostgresServer.java
+++ b/src/main/java/conexao/EmbeddedPostgresServer.java
@@ -29,7 +29,17 @@ public final class EmbeddedPostgresServer {
             return;
         }
         try {
-            Path dataDir = Paths.get("embedded-pg-data");
+            // Usa um caminho absoluto para garantir que a limpeza ocorra no
+            // mesmo diretório que será utilizado pelo processo do PostgreSQL
+            // embutido. A biblioteca `EmbeddedPostgres` interpreta caminhos
+            // relativos em relação ao diretório interno onde extrai os
+            // binários, o que pode diferir do diretório de trabalho da
+            // aplicação. Isso fazia com que a limpeza ocorresse em um local
+            // diferente daquele passado ao `initdb`, ocasionando o erro
+            // "directory exists but is not empty". Ao resolver o caminho para
+            // absoluto, garantimos que tanto a limpeza quanto a inicialização
+            // utilizem o mesmo diretório.
+            Path dataDir = Paths.get("embedded-pg-data").toAbsolutePath();
 
             // A biblioteca embutida falha ao executar o initdb quando o
             // diretório de dados já existe e contém arquivos de uma


### PR DESCRIPTION
## Summary
- resolve data directory path to absolute path before starting embedded Postgres
- document why absolute path is needed for proper cleanup

## Testing
- `mvn -q -e -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-enforcer-plugin:3.5.0 or one of its dependencies could not be resolved: Could not transfer artifact ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c602290b8c8325b38e2dd459f589d8