### PR TITLE
docs: document embedded postgres toggle

### DIFF
--- a/Help.txt
+++ b/Help.txt
@@ -1,10 +1,18 @@
-Para executar o aplicativo com o PostgreSQL embutido:
+Para executar o aplicativo é possível utilizar um PostgreSQL embutido ou um
+servidor PostgreSQL externo instalado na sua máquina. Esta escolha é feita no
+arquivo `database.properties` através da propriedade `db.embedded`:
+
+- `db.embedded=true`: inicia um PostgreSQL embutido utilizando a biblioteca
+  Zonky Embedded Postgres.
+- `db.embedded=false`: utiliza um servidor PostgreSQL externo conforme as
+  configurações definidas no próprio arquivo.
+
+Passos gerais para executar o aplicativo:
 
 1. Certifique-se de possuir o Java 8 instalado.
 2. Execute `mvn clean package` para compilar o projeto.
-3. Inicie o aplicativo pela classe `main.Main` ou pelo jar gerado. O
-   servidor PostgreSQL será iniciado automaticamente utilizando a
-   biblioteca Zonky Embedded Postgres.
+3. Inicie o aplicativo pela classe `main.Main` ou pelo jar gerado. Se
+   `db.embedded=true`, o servidor PostgreSQL será iniciado automaticamente.
 4. O arquivo `database.properties` contém as configurações de conexão. Ele
    é criado automaticamente na primeira execução caso não exista.
 5. As migrações do banco de dados são executadas pelo Flyway na inicialização.

--- a/README.txt
+++ b/README.txt
@@ -17,6 +17,18 @@ dependências Jakarta Persistence 3.x e Hibernate 6.x.
 - Gere um executável com todas as dependências usando `mvn package`.
 - O arquivo resultante estará em `target/rotinamais-desktop-*-jar-with-dependencies.jar` e pode ser executado com `java -jar`.
 
+Configuração do PostgreSQL
+------------------------------
+O arquivo `database.properties` define as credenciais de conexão do banco e
+permite escolher entre usar um PostgreSQL embutido ou um servidor externo:
+
+- `db.embedded=true`: o aplicativo iniciará um servidor PostgreSQL embutido.
+- `db.embedded=false`: utiliza um servidor PostgreSQL já instalado na máquina
+  ou em outra máquina acessível.
+
+Altere também as demais propriedades (`db.port`, `db.name`, `db.user`, etc.) de
+acordo com o ambiente utilizado.
+
 - Exemplos de entidades JPA e DAOs nativos adicionados para Meta, Cofre,
   TreinoExercicio, RotinaPeriodo, AlimentacaoIngrediente, IngredienteFornecedor,
   SiteObjeto, MonitoramentoObjeto, Papel, Carteira e Operacao.

--- a/database.properties
+++ b/database.properties
@@ -3,4 +3,7 @@ db.name=rotinamais
 db.schema=rotinamais
 db.user=kadu
 db.password=123
+# Define se o PostgreSQL embutido da aplicação será utilizado.
+# Altere para "false" para usar um servidor PostgreSQL externo
+# (por exemplo, o PostgreSQL instalado na sua máquina).
 db.embedded=true

--- a/src/main/resources/database.properties
+++ b/src/main/resources/database.properties
@@ -3,4 +3,7 @@ db.name=rotinamais
 db.schema=rotinamais
 db.user=kadu
 db.password=123
+# Define se o PostgreSQL embutido da aplicação será utilizado.
+# Altere para "false" para usar um servidor PostgreSQL externo
+# (por exemplo, o PostgreSQL instalado na sua máquina).
 db.embedded=true


### PR DESCRIPTION
## Summary
- document how to switch between embedded and external PostgreSQL via `db.embedded`
- explain PostgreSQL configuration in `Help.txt` and `README`

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-enforcer-plugin:3.5.0 or one of its dependencies could not be resolved: The following artifacts could not be resolved: org.apache.maven.plugins:maven-enforcer-plugin:pom:3.5.0 (absent): Could not transfer artifact org.apache.maven.plugins:maven-enforcer-plugin:pom:3.5.0 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c610975cf083259b0051fc8d45e8fc