### PR TITLE
Add config guard for embedded PostgreSQL startup

### DIFF
--- a/src/main/java/conexao/EmbeddedPostgresServer.java
+++ b/src/main/java/conexao/EmbeddedPostgresServer.java
@@ -24,7 +24,10 @@ public final class EmbeddedPostgresServer {
      * Inicia o servidor PostgreSQL se ainda não estiver em execução.
      */
     public static synchronized void start(DatabaseConfig cfg) {
-        if (POSTGRES != null) {
+        // Se o uso do PostgreSQL embutido estiver desabilitado nas configurações,
+        // apenas retorna sem iniciar nada. Isso evita tentativas de inicialização
+        // indevidas caso o método seja chamado inadvertidamente.
+        if (!cfg.isEmbedded() || POSTGRES != null) {
             return;
         }
         try {


### PR DESCRIPTION
## Summary
- avoid starting embedded PostgreSQL when `db.embedded` is false

## Testing
- `mvn -q -e -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-enforcer-plugin:3.5.0 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c611c3a26c8325946be95653709190