### PR TITLE
Fail fast when database.properties is missing

### DIFF
--- a/Help.txt
+++ b/Help.txt
@@ -13,8 +13,9 @@ Passos gerais para executar o aplicativo:
 2. Execute `mvn clean package` para compilar o projeto.
 3. Inicie o aplicativo pela classe `main.Main` ou pelo jar gerado. Se
    `db.embedded=true`, o servidor PostgreSQL será iniciado automaticamente.
-4. O arquivo `database.properties` contém as configurações de conexão. Ele
-   é criado automaticamente na primeira execução caso não exista.
+4. O arquivo `database.properties` contém as configurações de conexão e deve
+   existir antes da primeira execução. Se não for encontrado, o aplicativo
+   será encerrado.
 5. As migrações do banco de dados são executadas pelo Flyway na inicialização.
    Se o schema ainda não existir, o script `V1__init.sql` será aplicado para
    criar toda a estrutura necessária.

--- a/README.txt
+++ b/README.txt
@@ -20,7 +20,9 @@ dependências Jakarta Persistence 3.x e Hibernate 6.x.
 Configuração do PostgreSQL
 ------------------------------
 O arquivo `database.properties` define as credenciais de conexão do banco e
-permite escolher entre usar um PostgreSQL embutido ou um servidor externo:
+deve estar presente na mesma pasta em que o aplicativo é executado. Caso o
+arquivo não seja encontrado, a aplicação será encerrada. Ele permite escolher
+entre usar um PostgreSQL embutido ou um servidor externo:
 
 - `db.embedded=true`: o aplicativo iniciará um servidor PostgreSQL embutido.
 - `db.embedded=false`: utiliza um servidor PostgreSQL já instalado na máquina

--- a/src/main/java/conexao/DatabaseConfig.java
+++ b/src/main/java/conexao/DatabaseConfig.java
@@ -2,7 +2,6 @@ package conexao;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -10,8 +9,6 @@ import java.util.Properties;
 
 /**
  * Carrega as configurações de conexão com o banco de dados.
- * Caso o arquivo {@code database.properties} não exista na
- * pasta de trabalho, ele é criado com valores padrão.
  */
 public final class DatabaseConfig {
 
@@ -21,28 +18,11 @@ public final class DatabaseConfig {
 
     private DatabaseConfig() {
         Path path = Paths.get(FILE_NAME);
-        try {
-            if (Files.notExists(path)) {
-                // Copia do classpath ou cria um arquivo novo com valores padrão
-                try (InputStream in = getClass().getClassLoader().getResourceAsStream(FILE_NAME)) {
-                    if (in != null) {
-                        Files.copy(in, path);
-                    } else {
-                        props.setProperty("db.port", "5432");
-                        props.setProperty("db.name", "rotinamais");
-                        props.setProperty("db.schema", "rotinamais");
-                        props.setProperty("db.user", "kadu");
-                        props.setProperty("db.password", "123");
-                        props.setProperty("db.embedded", "false");
-                        try (OutputStream out = Files.newOutputStream(path)) {
-                            props.store(out, "Database configuration");
-                        }
-                    }
-                }
-            }
-            try (InputStream in = Files.newInputStream(path)) {
-                props.load(in);
-            }
+        if (Files.notExists(path)) {
+            throw new IllegalStateException("Arquivo de configuração " + FILE_NAME + " não encontrado");
+        }
+        try (InputStream in = Files.newInputStream(path)) {
+            props.load(in);
         } catch (IOException e) {
             throw new IllegalStateException("Não foi possível carregar o arquivo de configuração do banco", e);
         }


### PR DESCRIPTION
## Summary
- Simplify `DatabaseConfig` to load existing `database.properties` and abort if it is missing
- Document the requirement for `database.properties` in README and help guide

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-enforcer-plugin:3.5.0 or one of its dependencies could not be resolved: The following artifacts could not be resolved: org.apache.maven.plugins:maven-enforcer-plugin:pom:3.5.0 (absent): Could not transfer artifact org.apache.maven.plugins:maven-enforcer-plugin:pom:3.5.0 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68c62e6a42748325be17bc4f13ab7bcf