### PR TITLE
Support separate ports for embedded PostgreSQL

### DIFF
--- a/Help.txt
+++ b/Help.txt
@@ -3,9 +3,11 @@ servidor PostgreSQL externo instalado na sua máquina. Esta escolha é feita no
 arquivo `database.properties` através da propriedade `db.embedded`:
 
 - `db.embedded=true`: inicia um PostgreSQL embutido utilizando a biblioteca
-  Zonky Embedded Postgres.
+  Zonky Embedded Postgres e utiliza a porta definida em `db.port.embedded`
+  (padrão `15432`).
 - `db.embedded=false`: utiliza um servidor PostgreSQL externo conforme as
-  configurações definidas no próprio arquivo.
+  configurações definidas no próprio arquivo, usando a porta `db.port` (padrão
+  `5432`).
 
 Passos gerais para executar o aplicativo:
 

--- a/README.txt
+++ b/README.txt
@@ -24,12 +24,13 @@ deve estar presente na mesma pasta em que o aplicativo é executado. Caso o
 arquivo não seja encontrado, a aplicação será encerrada. Ele permite escolher
 entre usar um PostgreSQL embutido ou um servidor externo:
 
-- `db.embedded=true`: o aplicativo iniciará um servidor PostgreSQL embutido.
+- `db.embedded=true`: o aplicativo iniciará um servidor PostgreSQL embutido e
+  utilizará a porta definida em `db.port.embedded` (padrão `15432`).
 - `db.embedded=false`: utiliza um servidor PostgreSQL já instalado na máquina
-  ou em outra máquina acessível.
+  ou em outra máquina acessível usando a porta `db.port` (padrão `5432`).
 
-Altere também as demais propriedades (`db.port`, `db.name`, `db.user`, etc.) de
-acordo com o ambiente utilizado.
+Altere também as demais propriedades (`db.port`, `db.port.embedded`, `db.name`,
+`db.user`, etc.) de acordo com o ambiente utilizado.
 
 - Exemplos de entidades JPA e DAOs nativos adicionados para Meta, Cofre,
   TreinoExercicio, RotinaPeriodo, AlimentacaoIngrediente, IngredienteFornecedor,

--- a/database.properties
+++ b/database.properties
@@ -1,4 +1,7 @@
+# Porta utilizada quando db.embedded=false (PostgreSQL externo)
 db.port=5432
+# Porta utilizada quando db.embedded=true (PostgreSQL embutido)
+db.port.embedded=15432
 db.name=rotinamais
 db.schema=rotinamais
 db.user=kadu

--- a/src/main/java/conexao/DatabaseConfig.java
+++ b/src/main/java/conexao/DatabaseConfig.java
@@ -45,7 +45,8 @@ public final class DatabaseConfig {
     }
 
     public int getPort() {
-        return Integer.parseInt(props.getProperty("db.port"));
+        String key = isEmbedded() ? "db.port.embedded" : "db.port";
+        return Integer.parseInt(props.getProperty(key));
     }
 
     public String getSchema() {


### PR DESCRIPTION
## Summary
- add distinct `db.port` and `db.port.embedded` properties for external and embedded PostgreSQL
- select port dynamically based on `db.embedded`
- document port usage in README and Help

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c63130f8d48325949e99edd253c0f4