### PR TITLE
Add database backup and restore menu

### DIFF
--- a/src/main/java/component/Menu.java
+++ b/src/main/java/component/Menu.java
@@ -55,6 +55,7 @@ public class Menu extends javax.swing.JPanel {
 
     public void initMenuItem() {
         addMenu(new ModelMenu(new ImageIcon(getClass().getResource("/icon/1.png")), "Dashboard", "Home", "Usuario", "Categoria", "Evento", "Caixa", "Movimentacao", "Cofre"));
+        addMenu(new ModelMenu(new ImageIcon(getClass().getResource("/icon/3.png")), "Configuração", "Backup"));
         addMenu(new ModelMenu(new ImageIcon(getClass().getResource("/icon/2.png")), "Sair"));
     }
 

--- a/src/main/java/form/BackupForm.java
+++ b/src/main/java/form/BackupForm.java
@@ -1,0 +1,66 @@
+package form;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.io.IOException;
+
+/**
+ * Simple form to execute database backup and restore commands.
+ */
+public class BackupForm extends JPanel {
+
+    private final JTextField txtPath;
+
+    public BackupForm() {
+        setLayout(new BorderLayout());
+        setBackground(Color.WHITE);
+
+        JPanel inputPanel = new JPanel();
+        inputPanel.setBackground(Color.WHITE);
+        JLabel lblPath = new JLabel("Caminho do arquivo:");
+        txtPath = new JTextField(25);
+        JButton btnBackup = new JButton("Gerar Backup");
+        JButton btnRestore = new JButton("Restaurar Backup");
+
+        inputPanel.add(lblPath);
+        inputPanel.add(txtPath);
+        inputPanel.add(btnBackup);
+        inputPanel.add(btnRestore);
+
+        add(inputPanel, BorderLayout.NORTH);
+
+        btnBackup.addActionListener((ActionEvent e) -> executeCommand(true));
+        btnRestore.addActionListener((ActionEvent e) -> executeCommand(false));
+    }
+
+    private void executeCommand(boolean backup) {
+        String path = txtPath.getText().trim();
+        if (path.isEmpty()) {
+            JOptionPane.showMessageDialog(this, "Informe o caminho do arquivo.");
+            return;
+        }
+        new Thread(() -> {
+            try {
+                ProcessBuilder pb;
+                if (backup) {
+                    pb = new ProcessBuilder("pg_dump", "-U", "kadu", "-h", "localhost", "-d", "rotinamais", "-f", path);
+                } else {
+                    pb = new ProcessBuilder("psql", "-U", "kadu", "-h", "localhost", "-d", "rotinamais", "-f", path);
+                }
+                pb.redirectErrorStream(true);
+                Process p = pb.start();
+                int exit = p.waitFor();
+                SwingUtilities.invokeLater(() -> {
+                    if (exit == 0) {
+                        JOptionPane.showMessageDialog(this, "Comando executado com sucesso.");
+                    } else {
+                        JOptionPane.showMessageDialog(this, "Falha ao executar comando.");
+                    }
+                });
+            } catch (IOException | InterruptedException ex) {
+                SwingUtilities.invokeLater(() -> JOptionPane.showMessageDialog(this, "Erro: " + ex.getMessage()));
+            }
+        }).start();
+    }
+}

--- a/src/main/java/main/Main.java
+++ b/src/main/java/main/Main.java
@@ -12,6 +12,7 @@ import form.MainForm;
 import form.MovimentacaoForm;
 import form.CaixaForm;
 import form.CofreForm;
+import form.BackupForm;
 import swing.MenuItem;
 import swing.PopupMenu;
 import swing.icon.GoogleMaterialDesignIcons;
@@ -82,6 +83,10 @@ public class Main extends javax.swing.JFrame {
                         main.showForm(new CofreForm());
                     }
                 } else if (menuIndex == 1) {
+                    if (subMenuIndex == 0) {
+                        main.showForm(new BackupForm());
+                    }
+                } else if (menuIndex == 2) {
                     System.exit(0);
                 }
             }


### PR DESCRIPTION
## Summary
- add Configuração menu with Backup option
- implement BackupForm to run pg_dump and psql for backup/restore
- wire backup screen into main menu

## Testing
- `mvn -q -e -DskipTests compile` *(fails: Could not transfer plugin org.apache.maven.plugins:maven-enforcer-plugin due to Network is unreachable)*
- `mvn -q -e test` *(fails: Could not transfer plugin org.apache.maven.plugins:maven-enforcer-plugin due to Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c7039339e083258760cad0c1ebdeca