### PR TITLE
feat: add scheduling module with sample tasks and UI

### DIFF
--- a/src/main/java/Agendamento/BuildProjeto.java
+++ b/src/main/java/Agendamento/BuildProjeto.java
@@ -1,0 +1,14 @@
+package Agendamento;
+
+import java.util.Map;
+
+/**
+ * Step example that just logs a compilation message.
+ */
+public class BuildProjeto implements JobTask {
+    @Override
+    public void execute(Map<String, Object> params, JobContext ctx) throws Exception {
+        ctx.log("Compilando projeto...");
+        Thread.sleep(500);
+    }
+}

--- a/src/main/java/Agendamento/ExemploTask.java
+++ b/src/main/java/Agendamento/ExemploTask.java
@@ -1,0 +1,23 @@
+package Agendamento;
+
+import java.util.Map;
+
+/**
+ * Simple task used for demonstration. It prints a message, sleeps for a while
+ * and checks for cancellation between iterations.
+ */
+public class ExemploTask implements JobTask {
+
+    @Override
+    public void execute(Map<String, Object> params, JobContext ctx) throws Exception {
+        String mensagem = String.valueOf(params.getOrDefault("mensagem", "Executando ExemploTask"));
+        for (int i = 0; i < 5; i++) {
+            if (ctx.isCancelled()) {
+                ctx.log("Execução cancelada");
+                return;
+            }
+            ctx.log(mensagem + " - passo " + i);
+            Thread.sleep(500);
+        }
+    }
+}

--- a/src/main/java/Agendamento/GerarRelatorioJob.java
+++ b/src/main/java/Agendamento/GerarRelatorioJob.java
@@ -1,0 +1,22 @@
+package Agendamento;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.util.Map;
+
+/**
+ * Simulates the generation of a CSV report, writing a simple file to the
+ * temporary directory and logging the path.
+ */
+public class GerarRelatorioJob implements JobTask {
+
+    @Override
+    public void execute(Map<String, Object> params, JobContext ctx) throws Exception {
+        String baseDir = System.getProperty("java.io.tmpdir");
+        File out = new File(baseDir, "relatorio-" + System.currentTimeMillis() + ".csv");
+        try (FileWriter w = new FileWriter(out)) {
+            w.write("coluna1;coluna2\nvalor1;valor2\n");
+        }
+        ctx.log("Relatório gerado em: " + out.getAbsolutePath());
+    }
+}

--- a/src/main/java/Agendamento/JobContext.java
+++ b/src/main/java/Agendamento/JobContext.java
@@ -1,0 +1,40 @@
+package Agendamento;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+/**
+ * Context passed to every job execution. Allows logging, accessing log files
+ * and checking for cancellation requests.
+ */
+public interface JobContext extends Closeable {
+
+    /**
+     * Appends a line to the execution log.
+     *
+     * @param message message to log
+     */
+    void log(String message);
+
+    /**
+     * @return true if the execution was requested to cancel
+     */
+    boolean isCancelled();
+
+    /**
+     * Requests cooperative cancellation. Implementations should set an
+     * internal flag that can be checked via {@link #isCancelled()}.
+     */
+    void cancel();
+
+    /**
+     * Define a file to which all subsequent logs will also be written.
+     *
+     * @param writer print writer for the file
+     */
+    void setLogFile(PrintWriter writer);
+
+    @Override
+    void close() throws IOException;
+}

--- a/src/main/java/Agendamento/JobTask.java
+++ b/src/main/java/Agendamento/JobTask.java
@@ -1,0 +1,19 @@
+package Agendamento;
+
+import java.util.Map;
+
+/**
+ * Contract for executable tasks in the scheduling module. Implementations
+ * receive a map of parameters and a {@link JobContext} to interact with the
+ * engine.
+ */
+public interface JobTask {
+    /**
+     * Executes the task.
+     *
+     * @param params parameters provided in the job configuration
+     * @param ctx    context with logging and cancellation utilities
+     * @throws Exception in case of any error during execution
+     */
+    void execute(Map<String, Object> params, JobContext ctx) throws Exception;
+}

--- a/src/main/java/Agendamento/LimparCacheJob.java
+++ b/src/main/java/Agendamento/LimparCacheJob.java
@@ -1,0 +1,29 @@
+package Agendamento;
+
+import java.io.File;
+import java.util.Map;
+
+/**
+ * Deletes temporary files from a directory provided by parameter 'dirTemp'.
+ */
+public class LimparCacheJob implements JobTask {
+
+    @Override
+    public void execute(Map<String, Object> params, JobContext ctx) throws Exception {
+        String dir = String.valueOf(params.getOrDefault("dirTemp", System.getProperty("java.io.tmpdir")));
+        File tmp = new File(dir);
+        ctx.log("Limpando diretório " + tmp.getAbsolutePath());
+        File[] files = tmp.listFiles();
+        if (files != null) {
+            for (File f : files) {
+                if (ctx.isCancelled()) {
+                    ctx.log("Cancelado durante limpeza");
+                    return;
+                }
+                if (f.delete()) {
+                    ctx.log("Removido: " + f.getName());
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/Agendamento/PublicarArtefatos.java
+++ b/src/main/java/Agendamento/PublicarArtefatos.java
@@ -1,0 +1,14 @@
+package Agendamento;
+
+import java.util.Map;
+
+/**
+ * Final step that logs publication of artifacts.
+ */
+public class PublicarArtefatos implements JobTask {
+    @Override
+    public void execute(Map<String, Object> params, JobContext ctx) throws Exception {
+        ctx.log("Publicando artefatos...");
+        Thread.sleep(500);
+    }
+}

--- a/src/main/java/Agendamento/RodarTestes.java
+++ b/src/main/java/Agendamento/RodarTestes.java
@@ -1,0 +1,21 @@
+package Agendamento;
+
+import java.util.Map;
+import java.util.Random;
+
+/**
+ * Step that simulates running tests. It randomly fails to demonstrate UI
+ * behaviour on failures.
+ */
+public class RodarTestes implements JobTask {
+    private final Random rnd = new Random();
+
+    @Override
+    public void execute(Map<String, Object> params, JobContext ctx) throws Exception {
+        ctx.log("Rodando testes...");
+        Thread.sleep(500);
+        if (rnd.nextInt(10) == 0) {
+            throw new RuntimeException("Falha aleatória nos testes");
+        }
+    }
+}

--- a/src/main/java/agendamento/controller/AgendamentosController.java
+++ b/src/main/java/agendamento/controller/AgendamentosController.java
@@ -1,0 +1,66 @@
+package agendamento.controller;
+
+import agendamento.dao.JobDao;
+import agendamento.model.*;
+import agendamento.service.JobRunnerService;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Controller layer used by the UI to interact with the scheduling service and
+ * DAO.
+ */
+public class AgendamentosController {
+    private final JobDao dao;
+    private final JobRunnerService service;
+
+    public AgendamentosController(JobDao dao, JobRunnerService service) {
+        this.dao = dao;
+        this.service = service;
+    }
+
+    public List<Job> listJobs() throws SQLException {
+        return dao.listJobsAtivos();
+    }
+
+    public List<JobStep> listSteps(long jobId) throws SQLException {
+        return dao.listSteps(jobId);
+    }
+
+    public long executarAgora(long jobId) throws Exception {
+        return service.executarAgora(jobId);
+    }
+
+    public void cancelarRun(long runId) {
+        service.cancelar(runId);
+    }
+
+    public List<JobRun> listRuns(long jobId, int limit, int offset) throws SQLException {
+        return dao.listRuns(jobId, limit, offset);
+    }
+
+    public Map<Long, StepRun> mapStepRuns(long runId) throws SQLException {
+        return dao.mapStepRuns(runId);
+    }
+
+    /** Opens a log file if present, otherwise reads from run_log table. */
+    public String abrirLog(StepRun sr) throws Exception {
+        if (sr.getLogPath() != null) {
+            try {
+                return new String(Files.readAllBytes(Paths.get(sr.getLogPath())));
+            } catch (IOException e) {
+                return "Erro ao ler log: " + e.getMessage();
+            }
+        }
+        // fallback: no file, so read from run_log (simplified)
+        StringBuilder sb = new StringBuilder();
+        // In a full implementation we'd query run_log; simplified here.
+        sb.append("(log não disponível)");
+        return sb.toString();
+    }
+}

--- a/src/main/java/agendamento/dao/ConnectionFactory.java
+++ b/src/main/java/agendamento/dao/ConnectionFactory.java
@@ -1,0 +1,50 @@
+package agendamento.dao;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Properties;
+
+/**
+ * Simple JDBC connection factory that reads configuration from
+ * <code>application.properties</code> located in the classpath.
+ */
+public final class ConnectionFactory {
+
+    private static final String URL;
+    private static final String USER;
+    private static final String PASSWORD;
+    private static final String DRIVER;
+
+    static {
+        Properties props = new Properties();
+        try (InputStream in = ConnectionFactory.class.getClassLoader()
+                .getResourceAsStream("application.properties")) {
+            if (in != null) {
+                props.load(in);
+            }
+        } catch (IOException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+        URL = props.getProperty("db.url", "jdbc:postgresql://localhost/test");
+        USER = props.getProperty("db.user", "postgres");
+        PASSWORD = props.getProperty("db.password", "postgres");
+        DRIVER = props.getProperty("db.driver", "org.postgresql.Driver");
+        try {
+            Class.forName(DRIVER);
+        } catch (ClassNotFoundException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private ConnectionFactory() {}
+
+    /**
+     * Obtains a new JDBC connection. The caller is responsible for closing it.
+     */
+    public static Connection getConnection() throws SQLException {
+        return DriverManager.getConnection(URL, USER, PASSWORD);
+    }
+}

--- a/src/main/java/agendamento/dao/JobDao.java
+++ b/src/main/java/agendamento/dao/JobDao.java
@@ -1,0 +1,242 @@
+package agendamento.dao;
+
+import agendamento.model.*;
+
+import java.sql.*;
+import java.time.Instant;
+import java.util.*;
+
+/**
+ * Data access object handling all queries for the scheduling module. SQL
+ * statements are centralized in this class and use {@link PreparedStatement} to
+ * avoid SQL injection.
+ */
+public class JobDao {
+
+    private static final String SQL_LIST_JOBS =
+            "select id_job, nome, handler_class, handler_method, handler_static, run_in_subprocess, working_dir, jvm_args, env_vars, politica_concorr, max_retries, retry_backoff_s, timeout_s " +
+            "from job where ativo = true order by nome";
+
+    private static final String SQL_LIST_STEPS =
+            "select * from job_step where id_job = ? and habilitado = true order by ordem";
+
+    private static final String SQL_INSERT_RUN =
+            "insert into job_run(id_job, fila_em, status) values(?, now(), ?) returning id_run";
+
+    private static final String SQL_UPDATE_RUN_STATUS =
+            "update job_run set iniciou_em=?, terminou_em=?, status=?, erro_msg=?, pid_subprocess=?, duration_ms=? where id_run=?";
+
+    private static final String SQL_INSERT_STEP_RUN =
+            "insert into step_run(id_run, id_step, ordem_cache, iniciou_em, status) values(?,?,?,?,?) returning id_step_run";
+
+    private static final String SQL_UPDATE_STEP_RUN =
+            "update step_run set iniciou_em=?, terminou_em=?, status=?, erro_msg=?, log_path=?, duration_ms=? where id_step_run=?";
+
+    /** Lists active jobs. */
+    public List<Job> listJobsAtivos() throws SQLException {
+        try (Connection c = ConnectionFactory.getConnection();
+             PreparedStatement ps = c.prepareStatement(SQL_LIST_JOBS);
+             ResultSet rs = ps.executeQuery()) {
+            List<Job> out = new ArrayList<>();
+            while (rs.next()) {
+                Job j = new Job();
+                j.setId(rs.getLong("id_job"));
+                j.setNome(rs.getString("nome"));
+                j.setHandlerClass(rs.getString("handler_class"));
+                j.setHandlerMethod(rs.getString("handler_method"));
+                j.setHandlerStatic(rs.getBoolean("handler_static"));
+                j.setRunInSubprocess(rs.getBoolean("run_in_subprocess"));
+                j.setWorkingDir(rs.getString("working_dir"));
+                j.setJvmArgs(rs.getString("jvm_args"));
+                j.setEnvVars(rs.getString("env_vars"));
+                j.setPolicy(ConcurrencyPolicy.fromString(rs.getString("politica_concorr")));
+                j.setMaxRetries(rs.getInt("max_retries"));
+                j.setRetryBackoff(rs.getInt("retry_backoff_s"));
+                j.setTimeout(rs.getInt("timeout_s"));
+                out.add(j);
+            }
+            return out;
+        }
+    }
+
+    /** Returns steps of the given job. */
+    public List<JobStep> listSteps(long jobId) throws SQLException {
+        try (Connection c = ConnectionFactory.getConnection();
+             PreparedStatement ps = c.prepareStatement(SQL_LIST_STEPS)) {
+            ps.setLong(1, jobId);
+            try (ResultSet rs = ps.executeQuery()) {
+                List<JobStep> out = new ArrayList<>();
+                while (rs.next()) {
+                    JobStep s = new JobStep();
+                    s.setId(rs.getLong("id_step"));
+                    s.setJobId(jobId);
+                    s.setOrdem(rs.getInt("ordem"));
+                    s.setNome(rs.getString("nome"));
+                    s.setHabilitado(rs.getBoolean("habilitado"));
+                    s.setHandlerClass(rs.getString("handler_class"));
+                    s.setHandlerMethod(rs.getString("handler_method"));
+                    s.setHandlerStatic(rs.getBoolean("handler_static"));
+                    s.setRunInSubprocess(rs.getBoolean("run_in_subprocess"));
+                    s.setWorkingDir(rs.getString("working_dir"));
+                    s.setJvmArgs(rs.getString("jvm_args"));
+                    s.setEnvVars(rs.getString("env_vars"));
+                    s.setParametros(rs.getString("parametros"));
+                    s.setCondicaoExpr(rs.getString("condicao_expr"));
+                    s.setContinueOnFail(rs.getBoolean("continue_on_fail"));
+                    s.setTimeout(rs.getInt("timeout_s"));
+                    s.setMaxRetries(rs.getInt("max_retries"));
+                    s.setRetryBackoff(rs.getInt("retry_backoff_s"));
+                    out.add(s);
+                }
+                return out;
+            }
+        }
+    }
+
+    /**
+     * Lists recent runs for a job using simple pagination.
+     */
+    public List<JobRun> listRuns(long jobId, int limit, int offset) throws SQLException {
+        String sql = "select * from job_run where id_job=? order by id_run desc limit ? offset ?";
+        try (Connection c = ConnectionFactory.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setLong(1, jobId);
+            ps.setInt(2, limit);
+            ps.setInt(3, offset);
+            try (ResultSet rs = ps.executeQuery()) {
+                List<JobRun> out = new ArrayList<>();
+                while (rs.next()) {
+                    JobRun r = new JobRun();
+                    r.setId(rs.getLong("id_run"));
+                    r.setJobId(jobId);
+                    r.setFilaEm(rs.getTimestamp("fila_em").toInstant());
+                    Timestamp ini = rs.getTimestamp("iniciou_em");
+                    if (ini != null) r.setIniciouEm(ini.toInstant());
+                    Timestamp fim = rs.getTimestamp("terminou_em");
+                    if (fim != null) r.setTerminouEm(fim.toInstant());
+                    r.setStatus(RunStatus.valueOf(rs.getString("status")));
+                    r.setErroMsg(rs.getString("erro_msg"));
+                    r.setPidSubprocess((Long) rs.getObject("pid_subprocess"));
+                    r.setDurationMs(rs.getLong("duration_ms"));
+                    out.add(r);
+                }
+                return out;
+            }
+        }
+    }
+
+    /** Maps step runs for a given job run by step id. */
+    public Map<Long, StepRun> mapStepRuns(long runId) throws SQLException {
+        String sql = "select * from step_run where id_run=?";
+        try (Connection c = ConnectionFactory.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setLong(1, runId);
+            try (ResultSet rs = ps.executeQuery()) {
+                Map<Long, StepRun> map = new HashMap<>();
+                while (rs.next()) {
+                    StepRun sr = new StepRun();
+                    sr.setId(rs.getLong("id_step_run"));
+                    sr.setRunId(runId);
+                    long stepId = rs.getLong("id_step");
+                    sr.setStepId(stepId);
+                    sr.setOrdemCache(rs.getInt("ordem_cache"));
+                    Timestamp ini = rs.getTimestamp("iniciou_em");
+                    if (ini != null) sr.setIniciouEm(ini.toInstant());
+                    Timestamp fim = rs.getTimestamp("terminou_em");
+                    if (fim != null) sr.setTerminouEm(fim.toInstant());
+                    sr.setStatus(RunStatus.valueOf(rs.getString("status")));
+                    sr.setErroMsg(rs.getString("erro_msg"));
+                    sr.setLogPath(rs.getString("log_path"));
+                    sr.setDurationMs(rs.getLong("duration_ms"));
+                    map.put(stepId, sr);
+                }
+                return map;
+            }
+        }
+    }
+
+    /** Inserts a new run in QUEUED status and returns its id. */
+    public long insertRunQueued(long jobId) throws SQLException {
+        try (Connection c = ConnectionFactory.getConnection();
+             PreparedStatement ps = c.prepareStatement(SQL_INSERT_RUN)) {
+            ps.setLong(1, jobId);
+            ps.setString(2, RunStatus.QUEUED.name());
+            try (ResultSet rs = ps.executeQuery()) {
+                rs.next();
+                return rs.getLong(1);
+            }
+        }
+    }
+
+    /** Updates job run status and timestamps. */
+    public void updateRunStatus(JobRun run) throws SQLException {
+        try (Connection c = ConnectionFactory.getConnection();
+             PreparedStatement ps = c.prepareStatement(SQL_UPDATE_RUN_STATUS)) {
+            ps.setTimestamp(1, run.getIniciouEm() != null ? Timestamp.from(run.getIniciouEm()) : null);
+            ps.setTimestamp(2, run.getTerminouEm() != null ? Timestamp.from(run.getTerminouEm()) : null);
+            ps.setString(3, run.getStatus().name());
+            ps.setString(4, run.getErroMsg());
+            if (run.getPidSubprocess() != null) {
+                ps.setLong(5, run.getPidSubprocess());
+            } else {
+                ps.setNull(5, Types.BIGINT);
+            }
+            ps.setLong(6, run.getDurationMs());
+            ps.setLong(7, run.getId());
+            ps.executeUpdate();
+        }
+    }
+
+    /** Ensures a step run record exists, creating one if necessary. */
+    public long ensureStepRunQueued(long runId, JobStep step) throws SQLException {
+        String sql = "select id_step_run from step_run where id_run=? and id_step=?";
+        try (Connection c = ConnectionFactory.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setLong(1, runId);
+            ps.setLong(2, step.getId());
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getLong(1);
+                }
+            }
+        }
+        try (Connection c = ConnectionFactory.getConnection();
+             PreparedStatement ps = c.prepareStatement(SQL_INSERT_STEP_RUN)) {
+            ps.setLong(1, runId);
+            ps.setLong(2, step.getId());
+            ps.setInt(3, step.getOrdem());
+            ps.setTimestamp(4, Timestamp.from(Instant.now()));
+            ps.setString(5, RunStatus.QUEUED.name());
+            try (ResultSet rs = ps.executeQuery()) {
+                rs.next();
+                return rs.getLong(1);
+            }
+        }
+    }
+
+    /** Updates status info for a step run. */
+    public void updateStepRunStatus(StepRun sr) throws SQLException {
+        try (Connection c = ConnectionFactory.getConnection();
+             PreparedStatement ps = c.prepareStatement(SQL_UPDATE_STEP_RUN)) {
+            ps.setTimestamp(1, sr.getIniciouEm() != null ? Timestamp.from(sr.getIniciouEm()) : null);
+            ps.setTimestamp(2, sr.getTerminouEm() != null ? Timestamp.from(sr.getTerminouEm()) : null);
+            ps.setString(3, sr.getStatus().name());
+            ps.setString(4, sr.getErroMsg());
+            ps.setString(5, sr.getLogPath());
+            ps.setLong(6, sr.getDurationMs());
+            ps.setLong(7, sr.getId());
+            ps.executeUpdate();
+        }
+    }
+
+    /** Appends a line to a run log table. Simplified implementation storing only text. */
+    public void appendRunLog(long runId, String line) throws SQLException {
+        String sql = "insert into run_log(id_run, momento, linha) values(?, now(), ?)";
+        try (Connection c = ConnectionFactory.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setLong(1, runId);
+            ps.setString(2, line);
+            ps.executeUpdate();
+        }
+    }
+}

--- a/src/main/java/agendamento/model/ConcurrencyPolicy.java
+++ b/src/main/java/agendamento/model/ConcurrencyPolicy.java
@@ -1,0 +1,23 @@
+package agendamento.model;
+
+/**
+ * How the scheduler should behave when a job is triggered while another run is
+ * already in progress.
+ */
+public enum ConcurrencyPolicy {
+    /** Allow concurrent executions */
+    ALLOW,
+    /** Forbid new run while one is executing */
+    FORBID,
+    /** Cancel current run and replace with new */
+    REPLACE;
+
+    public static ConcurrencyPolicy fromString(String s) {
+        for (ConcurrencyPolicy p : values()) {
+            if (p.name().equalsIgnoreCase(s)) {
+                return p;
+            }
+        }
+        return ALLOW;
+    }
+}

--- a/src/main/java/agendamento/model/Job.java
+++ b/src/main/java/agendamento/model/Job.java
@@ -1,0 +1,56 @@
+package agendamento.model;
+
+import java.time.Instant;
+
+/**
+ * Representation of a job loaded from the database.
+ */
+public class Job {
+    private long id;
+    private String nome;
+    private boolean ativo;
+    private String handlerClass;
+    private String handlerMethod;
+    private boolean handlerStatic;
+    private boolean runInSubprocess;
+    private String workingDir;
+    private String jvmArgs;
+    private String envVars;
+    private ConcurrencyPolicy policy = ConcurrencyPolicy.ALLOW;
+    private int maxRetries;
+    private int retryBackoff;
+    private int timeout;
+    private Instant createdAt;
+
+    // getters and setters
+    public long getId() { return id; }
+    public void setId(long id) { this.id = id; }
+    public String getNome() { return nome; }
+    public void setNome(String nome) { this.nome = nome; }
+    public boolean isAtivo() { return ativo; }
+    public void setAtivo(boolean ativo) { this.ativo = ativo; }
+    public String getHandlerClass() { return handlerClass; }
+    public void setHandlerClass(String handlerClass) { this.handlerClass = handlerClass; }
+    public String getHandlerMethod() { return handlerMethod; }
+    public void setHandlerMethod(String handlerMethod) { this.handlerMethod = handlerMethod; }
+    public boolean isHandlerStatic() { return handlerStatic; }
+    public void setHandlerStatic(boolean handlerStatic) { this.handlerStatic = handlerStatic; }
+    public boolean isRunInSubprocess() { return runInSubprocess; }
+    public void setRunInSubprocess(boolean runInSubprocess) { this.runInSubprocess = runInSubprocess; }
+    public String getWorkingDir() { return workingDir; }
+    public void setWorkingDir(String workingDir) { this.workingDir = workingDir; }
+    public String getJvmArgs() { return jvmArgs; }
+    public void setJvmArgs(String jvmArgs) { this.jvmArgs = jvmArgs; }
+    public String getEnvVars() { return envVars; }
+    public void setEnvVars(String envVars) { this.envVars = envVars; }
+    public ConcurrencyPolicy getPolicy() { return policy; }
+    public void setPolicy(ConcurrencyPolicy policy) { this.policy = policy; }
+    public int getMaxRetries() { return maxRetries; }
+    public void setMaxRetries(int maxRetries) { this.maxRetries = maxRetries; }
+    public int getRetryBackoff() { return retryBackoff; }
+    public void setRetryBackoff(int retryBackoff) { this.retryBackoff = retryBackoff; }
+    public int getTimeout() { return timeout; }
+    public void setTimeout(int timeout) { this.timeout = timeout; }
+    public Instant getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+}

--- a/src/main/java/agendamento/model/JobRun.java
+++ b/src/main/java/agendamento/model/JobRun.java
@@ -1,0 +1,38 @@
+package agendamento.model;
+
+import java.time.Instant;
+
+/**
+ * Represents an execution of a job.
+ */
+public class JobRun {
+    private long id;
+    private long jobId;
+    private Instant filaEm;
+    private Instant iniciouEm;
+    private Instant terminouEm;
+    private RunStatus status = RunStatus.QUEUED;
+    private String erroMsg;
+    private Long pidSubprocess;
+    private long durationMs;
+
+    // getters and setters
+    public long getId() { return id; }
+    public void setId(long id) { this.id = id; }
+    public long getJobId() { return jobId; }
+    public void setJobId(long jobId) { this.jobId = jobId; }
+    public Instant getFilaEm() { return filaEm; }
+    public void setFilaEm(Instant filaEm) { this.filaEm = filaEm; }
+    public Instant getIniciouEm() { return iniciouEm; }
+    public void setIniciouEm(Instant iniciouEm) { this.iniciouEm = iniciouEm; }
+    public Instant getTerminouEm() { return terminouEm; }
+    public void setTerminouEm(Instant terminouEm) { this.terminouEm = terminouEm; }
+    public RunStatus getStatus() { return status; }
+    public void setStatus(RunStatus status) { this.status = status; }
+    public String getErroMsg() { return erroMsg; }
+    public void setErroMsg(String erroMsg) { this.erroMsg = erroMsg; }
+    public Long getPidSubprocess() { return pidSubprocess; }
+    public void setPidSubprocess(Long pidSubprocess) { this.pidSubprocess = pidSubprocess; }
+    public long getDurationMs() { return durationMs; }
+    public void setDurationMs(long durationMs) { this.durationMs = durationMs; }
+}

--- a/src/main/java/agendamento/model/JobStep.java
+++ b/src/main/java/agendamento/model/JobStep.java
@@ -1,0 +1,63 @@
+package agendamento.model;
+
+/**
+ * Step definition belonging to a job.
+ */
+public class JobStep {
+    private long id;
+    private long jobId;
+    private int ordem;
+    private String nome;
+    private boolean habilitado;
+    private String handlerClass;
+    private String handlerMethod;
+    private boolean handlerStatic;
+    private boolean runInSubprocess;
+    private String workingDir;
+    private String jvmArgs;
+    private String envVars;
+    private String parametros;
+    private String condicaoExpr;
+    private boolean continueOnFail;
+    private int timeout;
+    private int maxRetries;
+    private int retryBackoff;
+
+    // getters and setters omitted for brevity
+    public long getId() { return id; }
+    public void setId(long id) { this.id = id; }
+    public long getJobId() { return jobId; }
+    public void setJobId(long jobId) { this.jobId = jobId; }
+    public int getOrdem() { return ordem; }
+    public void setOrdem(int ordem) { this.ordem = ordem; }
+    public String getNome() { return nome; }
+    public void setNome(String nome) { this.nome = nome; }
+    public boolean isHabilitado() { return habilitado; }
+    public void setHabilitado(boolean habilitado) { this.habilitado = habilitado; }
+    public String getHandlerClass() { return handlerClass; }
+    public void setHandlerClass(String handlerClass) { this.handlerClass = handlerClass; }
+    public String getHandlerMethod() { return handlerMethod; }
+    public void setHandlerMethod(String handlerMethod) { this.handlerMethod = handlerMethod; }
+    public boolean isHandlerStatic() { return handlerStatic; }
+    public void setHandlerStatic(boolean handlerStatic) { this.handlerStatic = handlerStatic; }
+    public boolean isRunInSubprocess() { return runInSubprocess; }
+    public void setRunInSubprocess(boolean runInSubprocess) { this.runInSubprocess = runInSubprocess; }
+    public String getWorkingDir() { return workingDir; }
+    public void setWorkingDir(String workingDir) { this.workingDir = workingDir; }
+    public String getJvmArgs() { return jvmArgs; }
+    public void setJvmArgs(String jvmArgs) { this.jvmArgs = jvmArgs; }
+    public String getEnvVars() { return envVars; }
+    public void setEnvVars(String envVars) { this.envVars = envVars; }
+    public String getParametros() { return parametros; }
+    public void setParametros(String parametros) { this.parametros = parametros; }
+    public String getCondicaoExpr() { return condicaoExpr; }
+    public void setCondicaoExpr(String condicaoExpr) { this.condicaoExpr = condicaoExpr; }
+    public boolean isContinueOnFail() { return continueOnFail; }
+    public void setContinueOnFail(boolean continueOnFail) { this.continueOnFail = continueOnFail; }
+    public int getTimeout() { return timeout; }
+    public void setTimeout(int timeout) { this.timeout = timeout; }
+    public int getMaxRetries() { return maxRetries; }
+    public void setMaxRetries(int maxRetries) { this.maxRetries = maxRetries; }
+    public int getRetryBackoff() { return retryBackoff; }
+    public void setRetryBackoff(int retryBackoff) { this.retryBackoff = retryBackoff; }
+}

--- a/src/main/java/agendamento/model/RunStatus.java
+++ b/src/main/java/agendamento/model/RunStatus.java
@@ -1,0 +1,13 @@
+package agendamento.model;
+
+/**
+ * Possible statuses for a job or step run.
+ */
+public enum RunStatus {
+    QUEUED,
+    RUNNING,
+    SUCCESS,
+    FAILED,
+    ABORTED,
+    SKIPPED
+}

--- a/src/main/java/agendamento/model/StepRun.java
+++ b/src/main/java/agendamento/model/StepRun.java
@@ -1,0 +1,41 @@
+package agendamento.model;
+
+import java.time.Instant;
+
+/**
+ * Execution status for a single step inside a job run.
+ */
+public class StepRun {
+    private long id;
+    private long runId;
+    private long stepId;
+    private int ordemCache;
+    private Instant iniciouEm;
+    private Instant terminouEm;
+    private RunStatus status = RunStatus.QUEUED;
+    private String erroMsg;
+    private String logPath;
+    private long durationMs;
+
+    // getters and setters
+    public long getId() { return id; }
+    public void setId(long id) { this.id = id; }
+    public long getRunId() { return runId; }
+    public void setRunId(long runId) { this.runId = runId; }
+    public long getStepId() { return stepId; }
+    public void setStepId(long stepId) { this.stepId = stepId; }
+    public int getOrdemCache() { return ordemCache; }
+    public void setOrdemCache(int ordemCache) { this.ordemCache = ordemCache; }
+    public Instant getIniciouEm() { return iniciouEm; }
+    public void setIniciouEm(Instant iniciouEm) { this.iniciouEm = iniciouEm; }
+    public Instant getTerminouEm() { return terminouEm; }
+    public void setTerminouEm(Instant terminouEm) { this.terminouEm = terminouEm; }
+    public RunStatus getStatus() { return status; }
+    public void setStatus(RunStatus status) { this.status = status; }
+    public String getErroMsg() { return erroMsg; }
+    public void setErroMsg(String erroMsg) { this.erroMsg = erroMsg; }
+    public String getLogPath() { return logPath; }
+    public void setLogPath(String logPath) { this.logPath = logPath; }
+    public long getDurationMs() { return durationMs; }
+    public void setDurationMs(long durationMs) { this.durationMs = durationMs; }
+}

--- a/src/main/java/agendamento/service/JobRunnerService.java
+++ b/src/main/java/agendamento/service/JobRunnerService.java
@@ -1,0 +1,228 @@
+package agendamento.service;
+
+import Agendamento.JobContext;
+import Agendamento.JobTask;
+import agendamento.dao.JobDao;
+import agendamento.model.*;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.*;
+import java.util.concurrent.*;
+import java.sql.SQLException;
+
+/**
+ * Executes jobs defined in the database. The service uses a
+ * {@link ScheduledExecutorService} to perform asynchronous executions.
+ */
+public class JobRunnerService {
+
+    private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(
+            Runtime.getRuntime().availableProcessors(), r -> {
+                Thread t = new Thread(r);
+                t.setName(String.format("agendamento-%d", t.getId()));
+                t.setDaemon(true);
+                return t;
+            });
+    private final JobDao dao;
+    private final Map<Long, Future<?>> runs = new ConcurrentHashMap<>();
+
+    public JobRunnerService(JobDao dao) {
+        this.dao = dao;
+    }
+
+    /**
+     * Triggers execution of a job immediately.
+     *
+     * @return id of the created job_run record
+     */
+    public long executarAgora(long jobId) throws Exception {
+        Job job = dao.listJobsAtivos().stream().filter(j -> j.getId() == jobId).findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Job não encontrado: " + jobId));
+        long runId = dao.insertRunQueued(jobId);
+        Future<?> f = executor.submit(() -> runJob(job, runId));
+        runs.put(runId, f);
+        return runId;
+    }
+
+    /** Cancels a running job. */
+    public void cancelar(long runId) {
+        Future<?> f = runs.get(runId);
+        if (f != null) {
+            f.cancel(true);
+        }
+    }
+
+    private void runJob(Job job, long runId) {
+        JobRun run = new JobRun();
+        run.setId(runId);
+        run.setJobId(job.getId());
+        run.setIniciouEm(Instant.now());
+        run.setStatus(RunStatus.RUNNING);
+        try {
+            dao.updateRunStatus(run);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        try {
+            List<JobStep> steps = dao.listSteps(job.getId());
+            Map<Long, StepRun> stepRuns = new HashMap<>();
+            for (JobStep step : steps) {
+                long srId = dao.ensureStepRunQueued(runId, step);
+                StepRun sr = new StepRun();
+                sr.setId(srId);
+                sr.setRunId(runId);
+                sr.setStepId(step.getId());
+                sr.setOrdemCache(step.getOrdem());
+                sr.setIniciouEm(Instant.now());
+                sr.setStatus(RunStatus.RUNNING);
+                dao.updateStepRunStatus(sr);
+                RunStatus st = executeStep(job, step, sr, runId);
+                sr.setStatus(st);
+                sr.setTerminouEm(Instant.now());
+                sr.setDurationMs(Duration.between(sr.getIniciouEm(), sr.getTerminouEm()).toMillis());
+                dao.updateStepRunStatus(sr);
+                stepRuns.put(step.getId(), sr);
+                if (st != RunStatus.SUCCESS && !step.isContinueOnFail()) {
+                    throw new RuntimeException("Step falhou: " + step.getNome());
+                }
+            }
+            run.setStatus(RunStatus.SUCCESS);
+        } catch (Exception e) {
+            run.setStatus(RunStatus.FAILED);
+            run.setErroMsg(e.getMessage());
+        } finally {
+            run.setTerminouEm(Instant.now());
+            run.setDurationMs(Duration.between(run.getIniciouEm(), run.getTerminouEm()).toMillis());
+            try {
+                dao.updateRunStatus(run);
+            } catch (Exception ex) {
+                ex.printStackTrace();
+            }
+        }
+    }
+
+    private RunStatus executeStep(Job job, JobStep step, StepRun sr, long runId) {
+        try (DefaultJobContext ctx = new DefaultJobContext(runId, dao, sr)) {
+            Map<String, Object> params = parseParams(step.getParametros());
+            String className = step.getHandlerClass() != null ? step.getHandlerClass() : job.getHandlerClass();
+            String methodName = step.getHandlerMethod() != null ? step.getHandlerMethod() : job.getHandlerMethod();
+            boolean handlerStatic = step.isHandlerStatic() || job.isHandlerStatic();
+            boolean runSub = step.isRunInSubprocess() || job.isRunInSubprocess();
+            if (runSub) {
+                return runSubprocess(className, params, ctx, sr);
+            } else {
+                runReflection(className, methodName, handlerStatic, params, ctx);
+                return RunStatus.SUCCESS;
+            }
+        } catch (Exception e) {
+            sr.setErroMsg(e.getMessage());
+            return RunStatus.FAILED;
+        }
+    }
+
+    private void runReflection(String className, String methodName, boolean isStatic,
+                               Map<String, Object> params, JobContext ctx) throws Exception {
+        Class<?> clazz = Class.forName(className);
+        if (JobTask.class.isAssignableFrom(clazz)) {
+            JobTask task = (JobTask) clazz.getDeclaredConstructor().newInstance();
+            task.execute(params, ctx);
+            return;
+        }
+        if (methodName == null || methodName.isEmpty()) {
+            methodName = "execute";
+        }
+        Method m = clazz.getMethod(methodName, Map.class, JobContext.class);
+        Object target = isStatic ? null : clazz.getDeclaredConstructor().newInstance();
+        m.invoke(target, params, ctx);
+    }
+
+    private RunStatus runSubprocess(String className, Map<String, Object> params, JobContext ctx, StepRun sr)
+            throws Exception {
+        List<String> cmd = new ArrayList<>();
+        cmd.add("java");
+        cmd.add("-cp");
+        cmd.add(System.getProperty("java.class.path"));
+        cmd.add(className);
+        ProcessBuilder pb = new ProcessBuilder(cmd);
+        File logFile = File.createTempFile("step-", ".log");
+        sr.setLogPath(logFile.getAbsolutePath());
+        pb.redirectErrorStream(true);
+        pb.redirectOutput(logFile);
+        Process p = pb.start();
+        int exit = p.waitFor();
+        return exit == 0 ? RunStatus.SUCCESS : RunStatus.FAILED;
+    }
+
+    private Map<String, Object> parseParams(String parametros) {
+        Map<String, Object> map = new HashMap<>();
+        if (parametros == null || parametros.trim().isEmpty()) {
+            return map;
+        }
+        // very small parser: key1=value1;key2=value2
+        for (String part : parametros.split(";")) {
+            int idx = part.indexOf('=');
+            if (idx > 0) {
+                String k = part.substring(0, idx).trim();
+                String v = part.substring(idx + 1).trim();
+                map.put(k, v);
+            }
+        }
+        return map;
+    }
+
+    /**
+     * Default implementation of {@link JobContext} used by the runner.
+     */
+    private static class DefaultJobContext implements JobContext {
+        private final long runId;
+        private final JobDao dao;
+        private final StepRun stepRun;
+        private volatile boolean cancelled;
+        private PrintWriter fileWriter;
+
+        DefaultJobContext(long runId, JobDao dao, StepRun stepRun) {
+            this.runId = runId;
+            this.dao = dao;
+            this.stepRun = stepRun;
+        }
+
+        @Override
+        public void log(String message) {
+            try {
+                dao.appendRunLog(runId, message);
+            } catch (SQLException e) {
+                e.printStackTrace();
+            }
+            if (fileWriter != null) {
+                fileWriter.println(message);
+                fileWriter.flush();
+            }
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return cancelled;
+        }
+
+        @Override
+        public void cancel() {
+            cancelled = true;
+        }
+
+        @Override
+        public void setLogFile(PrintWriter writer) {
+            this.fileWriter = writer;
+        }
+
+        @Override
+        public void close() {
+            if (fileWriter != null) {
+                fileWriter.close();
+            }
+        }
+    }
+}

--- a/src/main/java/agendamento/ui/AgendamentosView.java
+++ b/src/main/java/agendamento/ui/AgendamentosView.java
@@ -1,0 +1,179 @@
+package agendamento.ui;
+
+import agendamento.controller.AgendamentosController;
+import agendamento.model.*;
+
+import javax.swing.*;
+import javax.swing.table.AbstractTableModel;
+import javax.swing.table.DefaultTableCellRenderer;
+import java.awt.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Swing panel showing jobs and their executions in a Jenkins-like stage view.
+ */
+public class AgendamentosView extends JPanel {
+    private final AgendamentosController controller;
+    private final JComboBox<Job> comboJobs = new JComboBox<>();
+    private final JButton btnExecutar = new JButton("Executar agora");
+    private final JButton btnAtualizar = new JButton("Atualizar");
+    private final JTextField txtQtd = new JTextField("10", 3);
+    private final StageTableModel tableModel = new StageTableModel();
+    private final JTable table = new JTable(tableModel);
+
+    public AgendamentosView(AgendamentosController controller) {
+        super(new BorderLayout());
+        this.controller = controller;
+        initTop();
+        initCenter();
+        loadJobs();
+    }
+
+    private void initTop() {
+        JPanel top = new JPanel();
+        top.add(new JLabel("Job:"));
+        top.add(comboJobs);
+        top.add(btnExecutar);
+        top.add(btnAtualizar);
+        top.add(new JLabel("Qtd runs:"));
+        top.add(txtQtd);
+        add(top, BorderLayout.NORTH);
+
+        btnAtualizar.addActionListener(e -> refresh());
+        btnExecutar.addActionListener(e -> executarAgora());
+    }
+
+    private void initCenter() {
+        table.setDefaultRenderer(Object.class, new StageCellRenderer());
+        table.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                if (e.getClickCount() == 2) {
+                    int row = table.rowAtPoint(e.getPoint());
+                    int col = table.columnAtPoint(e.getPoint());
+                    tableModel.openLog(row, col, controller, AgendamentosView.this);
+                }
+            }
+        });
+        add(new JScrollPane(table), BorderLayout.CENTER);
+    }
+
+    private void loadJobs() {
+        try {
+            List<Job> jobs = controller.listJobs();
+            for (Job j : jobs) {
+                comboJobs.addItem(j);
+            }
+        } catch (SQLException e) {
+            JOptionPane.showMessageDialog(this, "Erro ao carregar jobs: " + e.getMessage());
+        }
+    }
+
+    private void executarAgora() {
+        Job job = (Job) comboJobs.getSelectedItem();
+        if (job == null) return;
+        try {
+            controller.executarAgora(job.getId());
+            refresh();
+        } catch (Exception e) {
+            JOptionPane.showMessageDialog(this, "Erro ao executar: " + e.getMessage());
+        }
+    }
+
+    private void refresh() {
+        Job job = (Job) comboJobs.getSelectedItem();
+        if (job == null) return;
+        try {
+            int qtd = Integer.parseInt(txtQtd.getText());
+            List<JobRun> runs = controller.listRuns(job.getId(), qtd, 0);
+            List<JobStep> steps = controller.listSteps(job.getId());
+            List<Map<Long, StepRun>> maps = new ArrayList<>();
+            for (JobRun r : runs) {
+                maps.add(controller.mapStepRuns(r.getId()));
+            }
+            tableModel.setData(runs, steps, maps);
+        } catch (Exception e) {
+            JOptionPane.showMessageDialog(this, "Erro ao atualizar: " + e.getMessage());
+        }
+    }
+
+    /** Table model for stage view. */
+    private static class StageTableModel extends AbstractTableModel {
+        private final List<JobRun> runs = new ArrayList<>();
+        private final List<JobStep> steps = new ArrayList<>();
+        private final List<Map<Long, StepRun>> mapStepRuns = new ArrayList<>();
+
+        public void setData(List<JobRun> runs, List<JobStep> steps, List<Map<Long, StepRun>> maps) {
+            this.runs.clear();
+            this.steps.clear();
+            this.mapStepRuns.clear();
+            this.runs.addAll(runs);
+            this.steps.addAll(steps);
+            this.mapStepRuns.addAll(maps);
+            fireTableStructureChanged();
+        }
+
+        public void openLog(int row, int col, AgendamentosController controller, Component parent) {
+            if (row < 0 || col <= 0) return;
+            StepRun sr = mapStepRuns.get(row).get(steps.get(col - 1).getId());
+            if (sr == null) return;
+            try {
+                String text = controller.abrirLog(sr);
+                LogViewerDialog.show(parent, text);
+            } catch (Exception e) {
+                JOptionPane.showMessageDialog(parent, e.getMessage());
+            }
+        }
+
+        @Override
+        public int getRowCount() { return runs.size(); }
+
+        @Override
+        public int getColumnCount() { return steps.size() + 1; }
+
+        @Override
+        public String getColumnName(int column) {
+            return column == 0 ? "Run" : steps.get(column - 1).getNome();
+        }
+
+        @Override
+        public Object getValueAt(int rowIndex, int columnIndex) {
+            JobRun run = runs.get(rowIndex);
+            if (columnIndex == 0) {
+                return "#" + run.getId() + " " + DateTimeFormatter.ISO_LOCAL_TIME
+                        .format(run.getIniciouEm() != null ? run.getIniciouEm() : run.getFilaEm());
+            }
+            StepRun sr = mapStepRuns.get(rowIndex).get(steps.get(columnIndex - 1).getId());
+            return sr != null ? sr.getStatus() : RunStatus.QUEUED;
+        }
+    }
+
+    /** Cell renderer coloring background based on status. */
+    private static class StageCellRenderer extends DefaultTableCellRenderer {
+        @Override
+        public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,
+                                                       boolean hasFocus, int row, int column) {
+            Component c = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
+            if (column == 0) {
+                c.setBackground(Color.WHITE);
+                return c;
+            }
+            RunStatus status = (RunStatus) value;
+            Color bg;
+            switch (status) {
+                case SUCCESS: bg = Color.GREEN; break;
+                case FAILED:
+                case ABORTED: bg = Color.RED; break;
+                case RUNNING: bg = Color.YELLOW; break;
+                default: bg = Color.LIGHT_GRAY; break;
+            }
+            c.setBackground(bg);
+            return c;
+        }
+    }
+}

--- a/src/main/java/agendamento/ui/DemoAgendamentos.java
+++ b/src/main/java/agendamento/ui/DemoAgendamentos.java
@@ -1,0 +1,28 @@
+package agendamento.ui;
+
+import agendamento.controller.AgendamentosController;
+import agendamento.dao.JobDao;
+import agendamento.service.JobRunnerService;
+
+import javax.swing.*;
+import java.awt.*;
+
+/**
+ * Small demo application that opens the AgendamentosView in a frame.
+ */
+public class DemoAgendamentos {
+    public static void main(String[] args) {
+        SwingUtilities.invokeLater(() -> {
+            JobDao dao = new JobDao();
+            JobRunnerService service = new JobRunnerService(dao);
+            AgendamentosController controller = new AgendamentosController(dao, service);
+            JFrame f = new JFrame("Agendamentos Demo");
+            f.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+            f.setLayout(new BorderLayout());
+            f.add(new AgendamentosView(controller), BorderLayout.CENTER);
+            f.pack();
+            f.setLocationRelativeTo(null);
+            f.setVisible(true);
+        });
+    }
+}

--- a/src/main/java/agendamento/ui/LogViewerDialog.java
+++ b/src/main/java/agendamento/ui/LogViewerDialog.java
@@ -1,0 +1,15 @@
+package agendamento.ui;
+
+import javax.swing.*;
+import java.awt.*;
+
+/** Simple dialog to show logs of a step run. */
+public class LogViewerDialog {
+    public static void show(Component parent, String text) {
+        JTextArea area = new JTextArea(text);
+        area.setEditable(false);
+        JScrollPane sp = new JScrollPane(area);
+        sp.setPreferredSize(new Dimension(600, 400));
+        JOptionPane.showMessageDialog(parent, sp, "Log", JOptionPane.PLAIN_MESSAGE);
+    }
+}

--- a/src/main/java/agendamento/util/DurationUtil.java
+++ b/src/main/java/agendamento/util/DurationUtil.java
@@ -1,0 +1,26 @@
+package agendamento.util;
+
+import java.time.Duration;
+
+/** Utility class to format durations in a human readable form. */
+public final class DurationUtil {
+    private DurationUtil() {}
+
+    /**
+     * Formats the given duration in milliseconds as "735ms/2m 12s" style.
+     */
+    public static String format(long ms) {
+        Duration d = Duration.ofMillis(ms);
+        long minutes = d.toMinutes();
+        long seconds = d.minusMinutes(minutes).getSeconds();
+        long millis = d.minusMinutes(minutes).minusSeconds(seconds).toMillis();
+        StringBuilder sb = new StringBuilder();
+        if (minutes > 0) {
+            sb.append(minutes).append("m ");
+        }
+        if (seconds > 0) {
+            sb.append(seconds).append("s");
+        }
+        return ms + "ms/" + sb.toString().trim();
+    }
+}


### PR DESCRIPTION
## Summary
- add JobTask/JobContext contracts and example task implementations
- implement JDBC DAO, job runner service, and swing-based stage view UI
- provide DemoAgendamentos main to launch scheduling panel

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable retrieving maven-enforcer-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68c746bc8eb88325906e9fbd06324ae4