### PR TITLE
Padroniza agendamento e integra menu de jobs

### DIFF
--- a/src/main/java/agendamento/BuildProjeto.java
+++ b/src/main/java/agendamento/BuildProjeto.java
@@ -1,14 +1,14 @@
-package Agendamento;
+package agendamento;
 
 import java.util.Map;
 
 /**
- * Final step that logs publication of artifacts.
+ * Step example that just logs a compilation message.
  */
-public class PublicarArtefatos implements JobTask {
+public class BuildProjeto implements JobTask {
     @Override
     public void execute(Map<String, Object> params, JobContext ctx) throws Exception {
-        ctx.log("Publicando artefatos...");
+        ctx.log("Compilando projeto...");
         Thread.sleep(500);
     }
 }

--- a/src/main/java/agendamento/ExemploTask.java
+++ b/src/main/java/agendamento/ExemploTask.java
@@ -1,4 +1,4 @@
-package Agendamento;
+package agendamento;
 
 import java.util.Map;
 

--- a/src/main/java/agendamento/GerarRelatorioJob.java
+++ b/src/main/java/agendamento/GerarRelatorioJob.java
@@ -1,4 +1,4 @@
-package Agendamento;
+package agendamento;
 
 import java.io.File;
 import java.io.FileWriter;

--- a/src/main/java/agendamento/JobContext.java
+++ b/src/main/java/agendamento/JobContext.java
@@ -1,4 +1,4 @@
-package Agendamento;
+package agendamento;
 
 import java.io.Closeable;
 import java.io.IOException;

--- a/src/main/java/agendamento/JobTask.java
+++ b/src/main/java/agendamento/JobTask.java
@@ -1,4 +1,4 @@
-package Agendamento;
+package agendamento;
 
 import java.util.Map;
 

--- a/src/main/java/agendamento/LimparCacheJob.java
+++ b/src/main/java/agendamento/LimparCacheJob.java
@@ -1,4 +1,4 @@
-package Agendamento;
+package agendamento;
 
 import java.io.File;
 import java.util.Map;

--- a/src/main/java/agendamento/PublicarArtefatos.java
+++ b/src/main/java/agendamento/PublicarArtefatos.java
@@ -1,14 +1,14 @@
-package Agendamento;
+package agendamento;
 
 import java.util.Map;
 
 /**
- * Step example that just logs a compilation message.
+ * Final step that logs publication of artifacts.
  */
-public class BuildProjeto implements JobTask {
+public class PublicarArtefatos implements JobTask {
     @Override
     public void execute(Map<String, Object> params, JobContext ctx) throws Exception {
-        ctx.log("Compilando projeto...");
+        ctx.log("Publicando artefatos...");
         Thread.sleep(500);
     }
 }

--- a/src/main/java/agendamento/RodarTestes.java
+++ b/src/main/java/agendamento/RodarTestes.java
@@ -1,4 +1,4 @@
-package Agendamento;
+package agendamento;
 
 import java.util.Map;
 import java.util.Random;

--- a/src/main/java/agendamento/service/JobRunnerService.java
+++ b/src/main/java/agendamento/service/JobRunnerService.java
@@ -1,7 +1,7 @@
-package Agendamento.service;
+package agendamento.service;
 
-import Agendamento.JobContext;
-import Agendamento.JobTask;
+import agendamento.JobContext;
+import agendamento.JobTask;
 import dao.JobDao;
 import model.*;
 

--- a/src/main/java/agendamento/util/DurationUtil.java
+++ b/src/main/java/agendamento/util/DurationUtil.java
@@ -1,4 +1,4 @@
-package Agendamento.util;
+package agendamento.util;
 
 import java.time.Duration;
 

--- a/src/main/java/component/Menu.java
+++ b/src/main/java/component/Menu.java
@@ -56,6 +56,7 @@ public class Menu extends javax.swing.JPanel {
     public void initMenuItem() {
         addMenu(new ModelMenu(new ImageIcon(getClass().getResource("/icon/1.png")), "Dashboard", "Home", "Usuario", "Categoria", "Evento", "Caixa", "Movimentacao", "Cofre"));
         addMenu(new ModelMenu(new ImageIcon(getClass().getResource("/icon/3.png")), "Configuração", "Backup"));
+        addMenu(new ModelMenu(new ImageIcon(getClass().getResource("/icon/4.png")), "Agendamento", "Jobs"));
         addMenu(new ModelMenu(new ImageIcon(getClass().getResource("/icon/2.png")), "Sair"));
     }
 

--- a/src/main/java/controller/AgendamentosController.java
+++ b/src/main/java/controller/AgendamentosController.java
@@ -2,7 +2,7 @@ package controller;
 
 import dao.JobDao;
 import model.*;
-import Agendamento.service.JobRunnerService;
+import agendamento.service.JobRunnerService;
 
 import java.io.IOException;
 import java.nio.file.Files;

--- a/src/main/java/form/DemoAgendamentos.java
+++ b/src/main/java/form/DemoAgendamentos.java
@@ -2,7 +2,7 @@ package form;
 
 import controller.AgendamentosController;
 import dao.JobDao;
-import Agendamento.service.JobRunnerService;
+import agendamento.service.JobRunnerService;
 
 import javax.swing.*;
 import java.awt.*;

--- a/src/main/java/main/Main.java
+++ b/src/main/java/main/Main.java
@@ -13,6 +13,10 @@ import form.MovimentacaoForm;
 import form.CaixaForm;
 import form.CofreForm;
 import form.BackupForm;
+import form.AgendamentosView;
+import controller.AgendamentosController;
+import dao.JobDao;
+import agendamento.service.JobRunnerService;
 import swing.MenuItem;
 import swing.PopupMenu;
 import swing.icon.GoogleMaterialDesignIcons;
@@ -87,6 +91,13 @@ public class Main extends javax.swing.JFrame {
                         main.showForm(new BackupForm());
                     }
                 } else if (menuIndex == 2) {
+                    if (subMenuIndex == 0) {
+                        JobDao dao = new JobDao();
+                        JobRunnerService service = new JobRunnerService(dao);
+                        AgendamentosController controller = new AgendamentosController(dao, service);
+                        main.showForm(new AgendamentosView(controller));
+                    }
+                } else if (menuIndex == 3) {
                     System.exit(0);
                 }
             }


### PR DESCRIPTION
## Summary
- Renomeia pacote `Agendamento` para `agendamento` e ajusta todas as referências
- Adiciona menu **Agendamento** com sub‑menu *Jobs* e integração do `AgendamentosView`

## Testing
- `mvn -q test` *(falhou: Plugin org.apache.maven.plugins:maven-enforcer-plugin:3.5.0 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c75c87c5b48325a17e059f4bbe5be1