### PR TITLE
Add explicit job_status casts in JobDao SQL

### DIFF
--- a/src/main/java/dao/JobDao.java
+++ b/src/main/java/dao/JobDao.java
@@ -21,16 +21,16 @@ public class JobDao {
             "select * from job_step where id_job = ? and habilitado = true order by ordem";
 
     private static final String SQL_INSERT_RUN =
-            "insert into job_run(id_job, fila_em, status) values(?, now(), ?) returning id_run";
+            "insert into job_run(id_job, fila_em, status) values(?, now(), ?::job_status) returning id_run";
 
     private static final String SQL_UPDATE_RUN_STATUS =
-            "update job_run set iniciou_em=?, terminou_em=?, status=?, erro_msg=?, pid_subprocess=?, duration_ms=? where id_run=?";
+            "update job_run set iniciou_em=?, terminou_em=?, status=?::job_status, erro_msg=?, pid_subprocess=?, duration_ms=? where id_run=?";
 
     private static final String SQL_INSERT_STEP_RUN =
-            "insert into step_run(id_run, id_step, ordem_cache, iniciou_em, status) values(?,?,?,?,?) returning id_step_run";
+            "insert into step_run(id_run, id_step, ordem_cache, iniciou_em, status) values(?,?,?,?,?::job_status) returning id_step_run";
 
     private static final String SQL_UPDATE_STEP_RUN =
-            "update step_run set iniciou_em=?, terminou_em=?, status=?, erro_msg=?, log_path=?, duration_ms=? where id_step_run=?";
+            "update step_run set iniciou_em=?, terminou_em=?, status=?::job_status, erro_msg=?, log_path=?, duration_ms=? where id_step_run=?";
 
     /** Lists active jobs. */
     public List<Job> listJobsAtivos() throws SQLException {


### PR DESCRIPTION
## Summary
- cast job_run and step_run status parameters to `job_status`

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-enforcer-plugin:3.5.0 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c765609fe88325ba5970bc5a36fe91