### PR TITLE
Handle generated duration column and format run times

### DIFF
--- a/src/main/java/dao/JobDao.java
+++ b/src/main/java/dao/JobDao.java
@@ -24,13 +24,13 @@ public class JobDao {
             "insert into job_run(id_job, fila_em, status) values(?, now(), ?::job_status) returning id_run";
 
     private static final String SQL_UPDATE_RUN_STATUS =
-            "update job_run set iniciou_em=?, terminou_em=?, status=?::job_status, erro_msg=?, pid_subprocess=?, duration_ms=? where id_run=?";
+            "update job_run set iniciou_em=?, terminou_em=?, status=?::job_status, erro_msg=?, pid_subprocess=? where id_run=?";
 
     private static final String SQL_INSERT_STEP_RUN =
             "insert into step_run(id_run, id_step, ordem_cache, iniciou_em, status) values(?,?,?,?,?::job_status) returning id_step_run";
 
     private static final String SQL_UPDATE_STEP_RUN =
-            "update step_run set iniciou_em=?, terminou_em=?, status=?::job_status, erro_msg=?, log_path=?, duration_ms=? where id_step_run=?";
+            "update step_run set iniciou_em=?, terminou_em=?, status=?::job_status, erro_msg=?, log_path=? where id_step_run=?";
 
     /** Lists active jobs. */
     public List<Job> listJobsAtivos() throws SQLException {
@@ -181,8 +181,7 @@ public class JobDao {
             } else {
                 ps.setNull(5, Types.BIGINT);
             }
-            ps.setLong(6, run.getDurationMs());
-            ps.setLong(7, run.getId());
+            ps.setLong(6, run.getId());
             ps.executeUpdate();
         }
     }
@@ -223,8 +222,7 @@ public class JobDao {
             ps.setString(3, sr.getStatus().name());
             ps.setString(4, sr.getErroMsg());
             ps.setString(5, sr.getLogPath());
-            ps.setLong(6, sr.getDurationMs());
-            ps.setLong(7, sr.getId());
+            ps.setLong(6, sr.getId());
             ps.executeUpdate();
         }
     }

--- a/src/main/java/form/AgendamentosView.java
+++ b/src/main/java/form/AgendamentosView.java
@@ -9,6 +9,9 @@ import javax.swing.table.DefaultTableCellRenderer;
 import java.awt.*;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.time.Instant;
+import java.time.LocalTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
@@ -146,8 +149,9 @@ public class AgendamentosView extends JPanel {
         public Object getValueAt(int rowIndex, int columnIndex) {
             JobRun run = runs.get(rowIndex);
             if (columnIndex == 0) {
-                return "#" + run.getId() + " " + DateTimeFormatter.ISO_LOCAL_TIME
-                        .format(run.getIniciouEm() != null ? run.getIniciouEm() : run.getFilaEm());
+                Instant instant = run.getIniciouEm() != null ? run.getIniciouEm() : run.getFilaEm();
+                LocalTime time = instant.atZone(ZoneId.systemDefault()).toLocalTime();
+                return "#" + run.getId() + " " + DateTimeFormatter.ISO_LOCAL_TIME.format(time);
             }
             StepRun sr = mapStepRuns.get(rowIndex).get(steps.get(columnIndex - 1).getId());
             return sr != null ? sr.getStatus() : RunStatus.QUEUED;


### PR DESCRIPTION
## Summary
- avoid updating generated `duration_ms` column when persisting job or step run status
- format instants in AgendamentosView using system zone to avoid UnsupportedTemporalTypeException

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c76663e5508325ae24bdf2e168ad5a