### PR TITLE
Improve scheduling view layout

### DIFF
--- a/src/main/java/agendamento/util/DurationUtil.java
+++ b/src/main/java/agendamento/util/DurationUtil.java
@@ -7,20 +7,25 @@ public final class DurationUtil {
     private DurationUtil() {}
 
     /**
-     * Formats the given duration in milliseconds as "735ms/2m 12s" style.
+     * Formats the given duration in milliseconds using a short human readable
+     * representation such as "2m 5s" or "734ms".
      */
     public static String format(long ms) {
+        if (ms < 1000) {
+            return ms + "ms";
+        }
         Duration d = Duration.ofMillis(ms);
         long minutes = d.toMinutes();
         long seconds = d.minusMinutes(minutes).getSeconds();
-        long millis = d.minusMinutes(minutes).minusSeconds(seconds).toMillis();
         StringBuilder sb = new StringBuilder();
         if (minutes > 0) {
-            sb.append(minutes).append("m ");
-        }
-        if (seconds > 0) {
+            sb.append(minutes).append("m");
+            if (seconds > 0) {
+                sb.append(' ').append(seconds).append("s");
+            }
+        } else {
             sb.append(seconds).append("s");
         }
-        return ms + "ms/" + sb.toString().trim();
+        return sb.toString();
     }
 }

--- a/src/main/java/model/Job.java
+++ b/src/main/java/model/Job.java
@@ -53,4 +53,9 @@ public class Job {
     public void setTimeout(int timeout) { this.timeout = timeout; }
     public Instant getCreatedAt() { return createdAt; }
     public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+
+    @Override
+    public String toString() {
+        return nome;
+    }
 }


### PR DESCRIPTION
## Summary
- Show job names in selector
- Display stage durations in Jenkins-like colored cells
- Simplify duration formatting for short human-friendly times

## Testing
- ❌ `mvn -q -e -DskipTests package` *(failed: Network is unreachable)*
- ❌ `mvn -q -e -o -DskipTests package` *(failed: Cannot access central in offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68c76843cd4483259d57d1e31083dcea