### PR TITLE
Add UI and persistence support for new dashboard entities

### DIFF
--- a/src/main/java/component/Menu.java
+++ b/src/main/java/component/Menu.java
@@ -54,7 +54,7 @@ public class Menu extends javax.swing.JPanel {
     }
 
     public void initMenuItem() {
-        addMenu(new ModelMenu(new ImageIcon(getClass().getResource("/icon/1.png")), "Dashboard", "Home", "Usuario", "Categoria", "Evento", "Caixa", "Movimentacao", "Cofre", "Papel"));
+        addMenu(new ModelMenu(new ImageIcon(getClass().getResource("/icon/1.png")), "Dashboard", "Home", "Usuario", "Categoria", "Evento", "Caixa", "Movimentacao", "Cofre", "Carteira", "Caderno", "Meta", "Site", "Objeto", "Papel"));
         addMenu(new ModelMenu(new ImageIcon(getClass().getResource("/icon/3.png")), "Configuração", "Backup"));
         addMenu(new ModelMenu(new ImageIcon(getClass().getResource("/icon/4.png")), "Agendamento", "Job"));
         addMenu(new ModelMenu(new ImageIcon(getClass().getResource("/icon/2.png")), "Sair"));

--- a/src/main/java/controller/CadernoController.java
+++ b/src/main/java/controller/CadernoController.java
@@ -1,0 +1,82 @@
+package controller;
+
+import dao.api.CadernoDao;
+import exception.CadernoException;
+import infra.Logger;
+import model.Caderno;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class CadernoController {
+    private final CadernoDao dao;
+
+    public CadernoController(CadernoDao dao) { this.dao = dao; }
+
+    public void criar(Caderno caderno) {
+        if (caderno == null) throw new CadernoException("Caderno não pode ser nulo");
+        if (caderno.getTitulo() == null || caderno.getTitulo().isEmpty()) throw new CadernoException("titulo obrigatorio");
+        if (caderno.getComando() == null || caderno.getComando().isEmpty()) throw new CadernoException("comando obrigatorio");
+        if (caderno.getData() == null) throw new CadernoException("data obrigatoria");
+        Logger.info("CadernoController.criar");
+        dao.create(caderno);
+    }
+
+    public void atualizar(Caderno caderno) {
+        if (caderno == null || caderno.getIdCaderno() == null) throw new CadernoException("Id obrigatorio");
+        Logger.info("CadernoController.atualizar");
+        dao.update(caderno);
+    }
+
+    public void remover(Integer id) {
+        if (id == null) throw new CadernoException("Id obrigatorio");
+        Logger.info("CadernoController.remover");
+        dao.deleteById(id);
+    }
+
+    public Caderno buscarPorId(Integer id) {
+        if (id == null) throw new CadernoException("Id obrigatorio");
+        Logger.info("CadernoController.buscarPorId");
+        return dao.findById(id);
+    }
+
+    public List<Caderno> listar() {
+        Logger.info("CadernoController.listar");
+        return dao.findAll();
+    }
+
+    public List<Caderno> listar(int page, int size) {
+        Logger.info("CadernoController.listarPaginado");
+        return dao.findAll(page, size);
+    }
+
+    public List<Caderno> buscarPorTitulo(String titulo) {
+        Logger.info("CadernoController.buscarPorTitulo");
+        return dao.findByTitulo(titulo);
+    }
+
+    public List<Caderno> buscarPorData(LocalDate data) {
+        Logger.info("CadernoController.buscarPorData");
+        return dao.findByData(data);
+    }
+
+    public List<Caderno> buscarPorIdUsuario(Integer idUsuario) {
+        Logger.info("CadernoController.buscarPorIdUsuario");
+        return dao.findByIdUsuario(idUsuario);
+    }
+
+    public List<Caderno> buscarPorIdCategoria(Integer idCategoria) {
+        Logger.info("CadernoController.buscarPorIdCategoria");
+        return dao.findByIdCategoria(idCategoria);
+    }
+
+    public List<Caderno> pesquisar(Caderno filtro) {
+        Logger.info("CadernoController.pesquisar");
+        return dao.search(filtro);
+    }
+
+    public List<Caderno> pesquisar(Caderno filtro, int page, int size) {
+        Logger.info("CadernoController.pesquisarPaginado");
+        return dao.search(filtro, page, size);
+    }
+}

--- a/src/main/java/dao/api/CadernoDao.java
+++ b/src/main/java/dao/api/CadernoDao.java
@@ -1,0 +1,21 @@
+package dao.api;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import model.Caderno;
+
+public interface CadernoDao {
+    void create(Caderno caderno);
+    void update(Caderno caderno);
+    void deleteById(Integer id);
+    Caderno findById(Integer id);
+    List<Caderno> findAll();
+    List<Caderno> findAll(int page, int size);
+    List<Caderno> findByTitulo(String titulo);
+    List<Caderno> findByData(LocalDate data);
+    List<Caderno> findByIdUsuario(Integer idUsuario);
+    List<Caderno> findByIdCategoria(Integer idCategoria);
+    List<Caderno> search(Caderno filtro);
+    List<Caderno> search(Caderno filtro, int page, int size);
+}

--- a/src/main/java/dao/impl/CadernoDaoNativeImpl.java
+++ b/src/main/java/dao/impl/CadernoDaoNativeImpl.java
@@ -1,0 +1,243 @@
+package dao.impl;
+
+import conexao.ConnectionFactory;
+import dao.api.CadernoDao;
+import exception.CadernoException;
+import infra.Logger;
+import model.Caderno;
+
+import java.sql.Connection;
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CadernoDaoNativeImpl implements CadernoDao {
+
+    private Caderno map(ResultSet rs) throws SQLException {
+        Caderno c = new Caderno();
+        c.setIdCaderno(rs.getInt("id_caderno"));
+        c.setNomeIa(rs.getString("nome_ia"));
+        c.setTitulo(rs.getString("titulo"));
+        c.setObjetivo(rs.getString("objetivo"));
+        c.setComando(rs.getString("comando"));
+        c.setResultado(rs.getString("resultado"));
+        Date d = rs.getDate("data");
+        c.setData(d != null ? d.toLocalDate() : null);
+        c.setResultadoImagem(rs.getBytes("resultado_imagem"));
+        c.setResultadoVideo(rs.getBytes("resultado_video"));
+        int idUsuario = rs.getInt("id_usuario");
+        c.setIdUsuario(rs.wasNull() ? null : idUsuario);
+        int idCategoria = rs.getInt("id_categoria");
+        c.setIdCategoria(rs.wasNull() ? null : idCategoria);
+        return c;
+    }
+
+    @Override
+    public void create(Caderno caderno) {
+        Logger.info("CadernoDao.create");
+        String sql = "INSERT INTO Caderno (nome_ia, titulo, objetivo, comando, resultado, data, resultado_imagem, resultado_video, id_usuario, id_categoria) VALUES (?,?,?,?,?,?,?,?,?,?)";
+        Connection conn = null;
+        try {
+            conn = ConnectionFactory.getConnection();
+            conn.setAutoCommit(false);
+            try (PreparedStatement ps = conn.prepareStatement(sql)) {
+                ps.setString(1, caderno.getNomeIa());
+                ps.setString(2, caderno.getTitulo());
+                ps.setString(3, caderno.getObjetivo());
+                ps.setString(4, caderno.getComando());
+                ps.setString(5, caderno.getResultado());
+                if (caderno.getData() != null) ps.setDate(6, Date.valueOf(caderno.getData())); else ps.setNull(6, java.sql.Types.DATE);
+                if (caderno.getResultadoImagem() != null) ps.setBytes(7, caderno.getResultadoImagem()); else ps.setNull(7, java.sql.Types.BINARY);
+                if (caderno.getResultadoVideo() != null) ps.setBytes(8, caderno.getResultadoVideo()); else ps.setNull(8, java.sql.Types.BINARY);
+                if (caderno.getIdUsuario() != null) ps.setInt(9, caderno.getIdUsuario()); else ps.setNull(9, java.sql.Types.INTEGER);
+                if (caderno.getIdCategoria() != null) ps.setInt(10, caderno.getIdCategoria()); else ps.setNull(10, java.sql.Types.INTEGER);
+                ps.executeUpdate();
+            }
+            conn.commit();
+        } catch (SQLException ex) {
+            if (conn != null) {
+                try { conn.rollback(); } catch (SQLException re) { Logger.error("Rollback create", re); }
+            }
+            Logger.error("CadernoDao.create - erro", ex);
+            throw new CadernoException("Erro ao criar Caderno", ex);
+        } finally {
+            if (conn != null) {
+                try { conn.close(); } catch (SQLException ignore) { }
+            }
+        }
+    }
+
+    @Override
+    public void update(Caderno caderno) {
+        Logger.info("CadernoDao.update");
+        String sql = "UPDATE Caderno SET nome_ia=?, titulo=?, objetivo=?, comando=?, resultado=?, data=?, resultado_imagem=?, resultado_video=?, id_usuario=?, id_categoria=? WHERE id_caderno=?";
+        Connection conn = null;
+        try {
+            conn = ConnectionFactory.getConnection();
+            conn.setAutoCommit(false);
+            try (PreparedStatement ps = conn.prepareStatement(sql)) {
+                ps.setString(1, caderno.getNomeIa());
+                ps.setString(2, caderno.getTitulo());
+                ps.setString(3, caderno.getObjetivo());
+                ps.setString(4, caderno.getComando());
+                ps.setString(5, caderno.getResultado());
+                if (caderno.getData() != null) ps.setDate(6, Date.valueOf(caderno.getData())); else ps.setNull(6, java.sql.Types.DATE);
+                if (caderno.getResultadoImagem() != null) ps.setBytes(7, caderno.getResultadoImagem()); else ps.setNull(7, java.sql.Types.BINARY);
+                if (caderno.getResultadoVideo() != null) ps.setBytes(8, caderno.getResultadoVideo()); else ps.setNull(8, java.sql.Types.BINARY);
+                if (caderno.getIdUsuario() != null) ps.setInt(9, caderno.getIdUsuario()); else ps.setNull(9, java.sql.Types.INTEGER);
+                if (caderno.getIdCategoria() != null) ps.setInt(10, caderno.getIdCategoria()); else ps.setNull(10, java.sql.Types.INTEGER);
+                ps.setInt(11, caderno.getIdCaderno());
+                int upd = ps.executeUpdate();
+                if (upd == 0) throw new CadernoException("Caderno nao encontrado: id=" + caderno.getIdCaderno());
+            }
+            conn.commit();
+        } catch (SQLException ex) {
+            if (conn != null) {
+                try { conn.rollback(); } catch (SQLException re) { Logger.error("Rollback update", re); }
+            }
+            Logger.error("CadernoDao.update - erro", ex);
+            throw new CadernoException("Erro ao atualizar Caderno", ex);
+        } finally {
+            if (conn != null) {
+                try { conn.close(); } catch (SQLException ignore) { }
+            }
+        }
+    }
+
+    @Override
+    public void deleteById(Integer id) {
+        Logger.info("CadernoDao.deleteById");
+        String sql = "DELETE FROM Caderno WHERE id_caderno=?";
+        Connection conn = null;
+        try {
+            conn = ConnectionFactory.getConnection();
+            conn.setAutoCommit(false);
+            try (PreparedStatement ps = conn.prepareStatement(sql)) {
+                ps.setInt(1, id);
+                int del = ps.executeUpdate();
+                if (del == 0) throw new CadernoException("Caderno nao encontrado: id=" + id);
+            }
+            conn.commit();
+        } catch (SQLException ex) {
+            if (conn != null) {
+                try { conn.rollback(); } catch (SQLException re) { Logger.error("Rollback delete", re); }
+            }
+            Logger.error("CadernoDao.delete - erro", ex);
+            throw new CadernoException("Erro ao deletar Caderno", ex);
+        } finally {
+            if (conn != null) {
+                try { conn.close(); } catch (SQLException ignore) { }
+            }
+        }
+    }
+
+    @Override
+    public Caderno findById(Integer id) {
+        String sql = "SELECT id_caderno, nome_ia, titulo, objetivo, comando, resultado, data, resultado_imagem, resultado_video, id_usuario, id_categoria FROM Caderno WHERE id_caderno = ?";
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return map(rs);
+                }
+            }
+        } catch (SQLException ex) {
+            Logger.error("CadernoDao.findById - erro", ex);
+        }
+        return null;
+    }
+
+    private List<Caderno> listBySql(String sql, Object... params) {
+        List<Caderno> list = new ArrayList<>();
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            for (int i = 0; i < params.length; i++) {
+                ps.setObject(i + 1, params[i]);
+            }
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    list.add(map(rs));
+                }
+            }
+        } catch (SQLException ex) {
+            Logger.error("CadernoDao.listBySql - erro", ex);
+        }
+        return list;
+    }
+
+    @Override
+    public List<Caderno> findAll() {
+        String sql = "SELECT id_caderno, nome_ia, titulo, objetivo, comando, resultado, data, resultado_imagem, resultado_video, id_usuario, id_categoria FROM Caderno";
+        return listBySql(sql);
+    }
+
+    @Override
+    public List<Caderno> findAll(int page, int size) {
+        String sql = "SELECT id_caderno, nome_ia, titulo, objetivo, comando, resultado, data, resultado_imagem, resultado_video, id_usuario, id_categoria FROM Caderno LIMIT ? OFFSET ?";
+        return listBySql(sql, size, page * size);
+    }
+
+    @Override
+    public List<Caderno> findByTitulo(String titulo) {
+        String sql = "SELECT id_caderno, nome_ia, titulo, objetivo, comando, resultado, data, resultado_imagem, resultado_video, id_usuario, id_categoria FROM Caderno WHERE titulo = ?";
+        return listBySql(sql, titulo);
+    }
+
+    @Override
+    public List<Caderno> findByData(LocalDate data) {
+        String sql = "SELECT id_caderno, nome_ia, titulo, objetivo, comando, resultado, data, resultado_imagem, resultado_video, id_usuario, id_categoria FROM Caderno WHERE data = ?";
+        return listBySql(sql, Date.valueOf(data));
+    }
+
+    @Override
+    public List<Caderno> findByIdUsuario(Integer idUsuario) {
+        String sql = "SELECT id_caderno, nome_ia, titulo, objetivo, comando, resultado, data, resultado_imagem, resultado_video, id_usuario, id_categoria FROM Caderno WHERE id_usuario = ?";
+        return listBySql(sql, idUsuario);
+    }
+
+    @Override
+    public List<Caderno> findByIdCategoria(Integer idCategoria) {
+        String sql = "SELECT id_caderno, nome_ia, titulo, objetivo, comando, resultado, data, resultado_imagem, resultado_video, id_usuario, id_categoria FROM Caderno WHERE id_categoria = ?";
+        return listBySql(sql, idCategoria);
+    }
+
+    @Override
+    public List<Caderno> search(Caderno filtro) {
+        return search(filtro, 0, Integer.MAX_VALUE);
+    }
+
+    @Override
+    public List<Caderno> search(Caderno filtro, int page, int size) {
+        StringBuilder sb = new StringBuilder("SELECT id_caderno, nome_ia, titulo, objetivo, comando, resultado, data, resultado_imagem, resultado_video, id_usuario, id_categoria FROM Caderno WHERE 1=1");
+        List<Object> params = new ArrayList<>();
+        if (filtro.getTitulo() != null && !filtro.getTitulo().isEmpty()) {
+            sb.append(" AND titulo = ?");
+            params.add(filtro.getTitulo());
+        }
+        if (filtro.getNomeIa() != null && !filtro.getNomeIa().isEmpty()) {
+            sb.append(" AND nome_ia = ?");
+            params.add(filtro.getNomeIa());
+        }
+        if (filtro.getData() != null) {
+            sb.append(" AND data = ?");
+            params.add(Date.valueOf(filtro.getData()));
+        }
+        if (filtro.getIdUsuario() != null) {
+            sb.append(" AND id_usuario = ?");
+            params.add(filtro.getIdUsuario());
+        }
+        if (filtro.getIdCategoria() != null) {
+            sb.append(" AND id_categoria = ?");
+            params.add(filtro.getIdCategoria());
+        }
+        sb.append(" LIMIT ? OFFSET ?");
+        params.add(size);
+        params.add(page * size);
+        return listBySql(sb.toString(), params.toArray());
+    }
+}

--- a/src/main/java/exception/CadernoException.java
+++ b/src/main/java/exception/CadernoException.java
@@ -1,0 +1,11 @@
+package exception;
+
+public class CadernoException extends RuntimeException {
+    public CadernoException(String message) {
+        super(message);
+    }
+
+    public CadernoException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/form/CadernoDialog.java
+++ b/src/main/java/form/CadernoDialog.java
@@ -1,0 +1,219 @@
+package form;
+
+import java.awt.Color;
+import java.awt.Frame;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import javax.swing.JDialog;
+import javax.swing.JFileChooser;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import javax.swing.JTextField;
+import model.Caderno;
+import swing.Button;
+
+public class CadernoDialog extends JDialog {
+
+    private final Caderno caderno;
+    private boolean confirmed = false;
+
+    private JTextField txtId;
+    private JTextField txtNomeIa;
+    private JTextField txtTitulo;
+    private JTextArea txtObjetivo;
+    private JTextArea txtComando;
+    private JTextArea txtResultado;
+    private JTextField txtData;
+    private JTextField txtIdUsuario;
+    private JTextField txtIdCategoria;
+    private byte[] imagem;
+    private byte[] video;
+
+    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    public CadernoDialog(Frame parent, Caderno caderno) {
+        super(parent, true);
+        this.caderno = caderno != null ? caderno : new Caderno();
+        initComponents();
+        setLocationRelativeTo(parent);
+        preencherCampos();
+    }
+
+    private void preencherCampos() {
+        if (caderno.getIdCaderno() != null) {
+            txtId.setText(String.valueOf(caderno.getIdCaderno()));
+        }
+        txtNomeIa.setText(caderno.getNomeIa());
+        txtTitulo.setText(caderno.getTitulo());
+        txtObjetivo.setText(caderno.getObjetivo());
+        txtComando.setText(caderno.getComando());
+        txtResultado.setText(caderno.getResultado());
+        if (caderno.getData() != null) {
+            txtData.setText(formatter.format(caderno.getData()));
+        }
+        if (caderno.getIdUsuario() != null) {
+            txtIdUsuario.setText(String.valueOf(caderno.getIdUsuario()));
+        }
+        if (caderno.getIdCategoria() != null) {
+            txtIdCategoria.setText(String.valueOf(caderno.getIdCategoria()));
+        }
+        imagem = caderno.getResultadoImagem();
+        video = caderno.getResultadoVideo();
+    }
+
+    private void initComponents() {
+        setTitle("Caderno");
+        JPanel panel = new JPanel(new GridBagLayout());
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.insets = new Insets(5,5,5,5);
+        gbc.anchor = GridBagConstraints.WEST;
+        int y = 0;
+
+        txtId = new JTextField(10);
+        txtId.setEditable(false);
+        addRow(panel, gbc, y++, "ID", txtId);
+
+        txtNomeIa = new JTextField(20);
+        addRow(panel, gbc, y++, "Nome IA", txtNomeIa);
+
+        txtTitulo = new JTextField(20);
+        addRow(panel, gbc, y++, "Título", txtTitulo);
+
+        txtObjetivo = new JTextArea(3, 20);
+        addRow(panel, gbc, y++, "Objetivo", new JScrollPane(txtObjetivo));
+
+        txtComando = new JTextArea(3, 20);
+        addRow(panel, gbc, y++, "Comando", new JScrollPane(txtComando));
+
+        txtResultado = new JTextArea(3, 20);
+        addRow(panel, gbc, y++, "Resultado", new JScrollPane(txtResultado));
+
+        txtData = new JTextField(20);
+        addRow(panel, gbc, y++, "Data (yyyy-MM-dd)", txtData);
+
+        txtIdUsuario = new JTextField(20);
+        addRow(panel, gbc, y++, "ID Usuário", txtIdUsuario);
+
+        txtIdCategoria = new JTextField(20);
+        addRow(panel, gbc, y++, "ID Categoria", txtIdCategoria);
+
+        Button btnImagem = new Button();
+        btnImagem.setText("Selecionar Imagem");
+        btnImagem.setBackground(new Color(63,81,181));
+        btnImagem.setForeground(Color.WHITE);
+        btnImagem.addActionListener(e -> selecionarArquivo(true));
+        addRow(panel, gbc, y++, "Imagem", btnImagem);
+
+        Button btnVideo = new Button();
+        btnVideo.setText("Selecionar Vídeo");
+        btnVideo.setBackground(new Color(0,150,136));
+        btnVideo.setForeground(Color.WHITE);
+        btnVideo.addActionListener(e -> selecionarArquivo(false));
+        addRow(panel, gbc, y++, "Vídeo", btnVideo);
+
+        Button btnSalvar = new Button();
+        btnSalvar.setText("Salvar");
+        btnSalvar.setBackground(new Color(75,134,253));
+        btnSalvar.setForeground(Color.WHITE);
+        btnSalvar.addActionListener(e -> salvar());
+
+        Button btnCancelar = new Button();
+        btnCancelar.setText("Cancelar");
+        btnCancelar.addActionListener(e -> dispose());
+
+        gbc.gridx = 0; gbc.gridy = y; panel.add(btnSalvar, gbc);
+        gbc.gridx = 1; panel.add(btnCancelar, gbc);
+
+        getContentPane().add(panel);
+        pack();
+        getRootPane().setDefaultButton(btnSalvar);
+    }
+
+    private void addRow(JPanel panel, GridBagConstraints gbc, int y, String label, java.awt.Component component) {
+        gbc.gridx = 0; gbc.gridy = y;
+        panel.add(new JLabel(label), gbc);
+        gbc.gridx = 1;
+        panel.add(component, gbc);
+    }
+
+    private void selecionarArquivo(boolean imagem) {
+        JFileChooser chooser = new JFileChooser();
+        int opt = chooser.showOpenDialog(this);
+        if (opt == JFileChooser.APPROVE_OPTION) {
+            File file = chooser.getSelectedFile();
+            try {
+                byte[] data = Files.readAllBytes(file.toPath());
+                if (imagem) {
+                    this.imagem = data;
+                } else {
+                    this.video = data;
+                }
+            } catch (IOException ex) {
+                JOptionPane.showMessageDialog(this, "Erro ao ler arquivo: " + ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+
+    private void salvar() {
+        caderno.setNomeIa(txtNomeIa.getText());
+        caderno.setTitulo(txtTitulo.getText());
+        caderno.setObjetivo(txtObjetivo.getText());
+        caderno.setComando(txtComando.getText());
+        caderno.setResultado(txtResultado.getText());
+        String dataTxt = txtData.getText();
+        if (dataTxt != null && !dataTxt.isEmpty()) {
+            try {
+                caderno.setData(LocalDate.parse(dataTxt, formatter));
+            } catch (DateTimeParseException ex) {
+                JOptionPane.showMessageDialog(this, "Data inválida. Use o formato yyyy-MM-dd.", "Erro", JOptionPane.ERROR_MESSAGE);
+                return;
+            }
+        } else {
+            caderno.setData(null);
+        }
+        caderno.setResultadoImagem(imagem);
+        caderno.setResultadoVideo(video);
+        String usuario = txtIdUsuario.getText();
+        if (usuario != null && !usuario.isEmpty()) {
+            try {
+                caderno.setIdUsuario(Integer.parseInt(usuario));
+            } catch (NumberFormatException ex) {
+                JOptionPane.showMessageDialog(this, "ID de usuário inválido.", "Erro", JOptionPane.ERROR_MESSAGE);
+                return;
+            }
+        } else {
+            caderno.setIdUsuario(null);
+        }
+        String categoria = txtIdCategoria.getText();
+        if (categoria != null && !categoria.isEmpty()) {
+            try {
+                caderno.setIdCategoria(Integer.parseInt(categoria));
+            } catch (NumberFormatException ex) {
+                JOptionPane.showMessageDialog(this, "ID de categoria inválido.", "Erro", JOptionPane.ERROR_MESSAGE);
+                return;
+            }
+        } else {
+            caderno.setIdCategoria(null);
+        }
+        confirmed = true;
+        dispose();
+    }
+
+    public boolean isConfirmed() {
+        return confirmed;
+    }
+
+    public Caderno getCaderno() {
+        return caderno;
+    }
+}

--- a/src/main/java/form/CadernoForm.java
+++ b/src/main/java/form/CadernoForm.java
@@ -1,0 +1,387 @@
+package form;
+
+import component.Card;
+import controller.CadernoController;
+import dao.impl.CadernoDaoNativeImpl;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.JTextArea;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+import javax.swing.JOptionPane;
+import javax.swing.border.EmptyBorder;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableCellRenderer;
+import model.Caderno;
+import model.ModelCard;
+import swing.Button;
+import swing.ImageAvatar;
+import swing.icon.GoogleMaterialDesignIcons;
+import swing.icon.IconFontSwing;
+import swing.table.EventAction;
+import swing.table.ModelAction;
+import swing.table.Table;
+import util.ImageUtils;
+
+public class CadernoForm extends JPanel {
+
+    private final CadernoController controller;
+    private Card cardNotas;
+    private Card cardIas;
+    private Card cardCategorias;
+    private Table table;
+    private JTextField txtBusca;
+    private Button btnIa1;
+    private Button btnIa2;
+    private Button btnIa3;
+    private Button btnNovo;
+    private String filtroIa;
+    private List<Caderno> cadernos;
+    private List<Caderno> filtrados;
+    private JButton btnPrevPage;
+    private JButton btnNextPage;
+    private int currentPage = 0;
+    private static final int PAGE_SIZE = 6;
+    private final String[] iaBotoes = new String[3];
+    private javax.swing.Icon iconNotas;
+    private javax.swing.Icon iconIas;
+    private javax.swing.Icon iconCategorias;
+    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+
+    public CadernoForm() {
+        controller = new CadernoController(new CadernoDaoNativeImpl());
+        initComponents();
+        carregarCadernos();
+    }
+
+    private void initComponents() {
+        setLayout(new BorderLayout());
+        setBackground(Color.WHITE);
+
+        JPanel top = new JPanel(new BorderLayout());
+        top.setBackground(Color.WHITE);
+
+        JPanel cards = new JPanel(new java.awt.GridLayout(1,3,18,0));
+        cards.setBackground(Color.WHITE);
+
+        iconNotas = IconFontSwing.buildIcon(GoogleMaterialDesignIcons.BOOK, 60, Color.WHITE,
+                new Color(255,255,255,15));
+        cardNotas = new Card();
+        cardNotas.setBackground(new Color(33,150,243));
+        cardNotas.setColorGradient(new Color(30,136,229));
+        cardNotas.setData(new ModelCard("Anotações",0,0,iconNotas));
+        cards.add(cardNotas);
+
+        iconIas = IconFontSwing.buildIcon(GoogleMaterialDesignIcons.ASSIGNMENT, 60, Color.WHITE,
+                new Color(255,255,255,15));
+        cardIas = new Card();
+        cardIas.setBackground(new Color(121,134,203));
+        cardIas.setColorGradient(new Color(92,107,192));
+        cardIas.setData(new ModelCard("Assistentes",0,0,iconIas));
+        cards.add(cardIas);
+
+        iconCategorias = IconFontSwing.buildIcon(GoogleMaterialDesignIcons.CATEGORY, 60, Color.WHITE,
+                new Color(255,255,255,15));
+        cardCategorias = new Card();
+        cardCategorias.setBackground(new Color(0,150,136));
+        cardCategorias.setColorGradient(new Color(38,166,154));
+        cardCategorias.setData(new ModelCard("Categorias",0,0,iconCategorias));
+        cards.add(cardCategorias);
+
+        top.add(cards, BorderLayout.NORTH);
+
+        JPanel filtroWrapper = new JPanel(new BorderLayout());
+        filtroWrapper.setBackground(Color.WHITE);
+
+        JPanel filtro = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        filtro.setBackground(Color.WHITE);
+
+        btnIa1 = criarBotaoFiltro(0);
+        filtro.add(btnIa1);
+
+        btnIa2 = criarBotaoFiltro(1);
+        filtro.add(btnIa2);
+
+        btnIa3 = criarBotaoFiltro(2);
+        filtro.add(btnIa3);
+
+        txtBusca = new JTextField(15);
+        txtBusca.getDocument().addDocumentListener(new DocumentListener() {
+            @Override public void insertUpdate(DocumentEvent e) { aplicarFiltros(); }
+            @Override public void removeUpdate(DocumentEvent e) { aplicarFiltros(); }
+            @Override public void changedUpdate(DocumentEvent e) { aplicarFiltros(); }
+        });
+        filtro.add(new JLabel("Pesquisar:"));
+        filtro.add(txtBusca);
+
+        btnNovo = new Button();
+        btnNovo.setBackground(new Color(33,150,243));
+        btnNovo.setForeground(Color.WHITE);
+        btnNovo.setIcon(IconFontSwing.buildIcon(GoogleMaterialDesignIcons.ADD,20,Color.WHITE));
+        btnNovo.setPreferredSize(new Dimension(30,30));
+        btnNovo.addActionListener(e -> adicionarCaderno());
+        filtro.add(btnNovo);
+
+        filtroWrapper.add(filtro, BorderLayout.CENTER);
+        top.add(filtroWrapper, BorderLayout.CENTER);
+        add(top, BorderLayout.NORTH);
+
+        table = new Table();
+        table.setModel(new DefaultTableModel(new Object[][]{}, new String[]{
+            "Imagem", "Título", "Assistente", "Data", "Resultado", "Ações"
+        }) {
+            @Override
+            public boolean isCellEditable(int row, int column) {
+                return column == 5;
+            }
+
+            @Override
+            public Class<?> getColumnClass(int columnIndex) {
+                return columnIndex == 0 ? ImageIcon.class : Object.class;
+            }
+        });
+        table.setRowHeight(60);
+        JScrollPane scroll = new JScrollPane(table);
+        table.fixTable(scroll);
+        table.setRowSelectionAllowed(false);
+        add(scroll, BorderLayout.CENTER);
+
+        btnPrevPage = new JButton("Anterior");
+        btnNextPage = new JButton("Próximo");
+        btnPrevPage.addActionListener(e -> {
+            if (currentPage > 0) {
+                currentPage--;
+                updatePage();
+            }
+        });
+        btnNextPage.addActionListener(e -> {
+            if ((currentPage + 1) * PAGE_SIZE < (filtrados != null ? filtrados.size() : 0)) {
+                currentPage++;
+                updatePage();
+            }
+        });
+        JPanel pagination = new JPanel(new FlowLayout(FlowLayout.CENTER));
+        pagination.setBackground(Color.WHITE);
+        pagination.add(btnPrevPage);
+        pagination.add(btnNextPage);
+        add(pagination, BorderLayout.SOUTH);
+    }
+
+    private Button criarBotaoFiltro(int index) {
+        Button button = new Button();
+        button.setPreferredSize(new Dimension(120,30));
+        button.setBackground(new Color(121,134,203));
+        button.setForeground(Color.WHITE);
+        button.addActionListener(e -> aplicarFiltroIa(index));
+        button.setEnabled(false);
+        button.setText("Assistente " + (index + 1));
+        return button;
+    }
+
+    private void aplicarFiltroIa(int index) {
+        filtroIa = iaBotoes[index];
+        aplicarFiltros();
+    }
+
+    private void carregarCadernos() {
+        cadernos = controller.listar();
+        atualizarIaBotoes();
+        filtroIa = null;
+        aplicarFiltros();
+    }
+
+    private void atualizarIaBotoes() {
+        for (int i = 0; i < iaBotoes.length; i++) {
+            iaBotoes[i] = null;
+        }
+        if (cadernos != null) {
+            Set<String> ias = cadernos.stream()
+                    .map(Caderno::getNomeIa)
+                    .filter(s -> s != null && !s.isEmpty())
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+            int idx = 0;
+            for (String ia : ias) {
+                if (idx >= iaBotoes.length) break;
+                iaBotoes[idx++] = ia;
+            }
+        }
+        atualizarTextoBotoes();
+    }
+
+    private void atualizarTextoBotoes() {
+        Button[] botoes = {btnIa1, btnIa2, btnIa3};
+        for (int i = 0; i < botoes.length; i++) {
+            Button b = botoes[i];
+            String texto = iaBotoes[i];
+            if (texto != null) {
+                b.setText(texto);
+                b.setEnabled(true);
+            } else {
+                b.setText("Todos");
+                b.setEnabled(true);
+            }
+        }
+    }
+
+    private void aplicarFiltros() {
+        if (cadernos == null) return;
+        String busca = txtBusca.getText();
+        String filtro = (busca != null && !busca.isEmpty()) ? busca.toLowerCase() : null;
+        filtrados = cadernos.stream()
+                .filter(c -> filtroIa == null || filtroIa.equals(c.getNomeIa()) || "Todos".equals(filtroIa))
+                .filter(c -> filtro == null ||
+                        (c.getTitulo() != null && c.getTitulo().toLowerCase().contains(filtro)) ||
+                        (c.getNomeIa() != null && c.getNomeIa().toLowerCase().contains(filtro)))
+                .collect(Collectors.toList());
+        atualizarCards(filtrados);
+        currentPage = 0;
+        updatePage();
+    }
+
+    private void atualizarCards(List<Caderno> lista) {
+        int total = lista != null ? lista.size() : 0;
+        Set<String> ias = new LinkedHashSet<>();
+        Set<Integer> categorias = new LinkedHashSet<>();
+        for (Caderno c : lista) {
+            if (c.getNomeIa() != null && !c.getNomeIa().isEmpty()) ias.add(c.getNomeIa());
+            if (c.getIdCategoria() != null) categorias.add(c.getIdCategoria());
+        }
+        cardNotas.setData(new ModelCard("Anotações", total, 0, iconNotas));
+        cardIas.setData(new ModelCard("Assistentes", ias.size(), 0, iconIas));
+        cardCategorias.setData(new ModelCard("Categorias", categorias.size(), 0, iconCategorias));
+    }
+
+    private void atualizarTabela(List<Caderno> lista) {
+        DefaultTableModel model = (DefaultTableModel) table.getModel();
+        model.setRowCount(0);
+        EventAction<Caderno> eventAction = new EventAction<Caderno>() {
+            @Override
+            public void delete(Caderno c) { excluirCaderno(c); }
+            @Override
+            public void update(Caderno c) { editarCaderno(c); }
+        };
+        for (Caderno c : lista) {
+            ImageIcon icon = ImageUtils.bytesToImageIcon(c.getResultadoImagem());
+            model.addRow(new Object[]{
+                icon,
+                c.getTitulo(),
+                c.getNomeIa(),
+                c.getData() != null ? formatter.format(c.getData()) : "",
+                resumo(c.getResultado()),
+                new ModelAction<>(c, eventAction)
+            });
+        }
+        table.getColumnModel().getColumn(0).setCellRenderer(new TableCellRenderer() {
+            @Override
+            public Component getTableCellRendererComponent(JTable tbl, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+                ImageAvatar avatar = new ImageAvatar();
+                avatar.setPreferredSize(new Dimension(50, 50));
+                if (value instanceof ImageIcon) {
+                    avatar.setIcon((ImageIcon) value);
+                }
+                return avatar;
+            }
+        });
+        table.getColumnModel().getColumn(4).setCellRenderer(new TableCellRenderer() {
+            @Override
+            public Component getTableCellRendererComponent(JTable tbl, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+                JTextArea area = new JTextArea(value == null ? "" : value.toString());
+                area.setWrapStyleWord(true);
+                area.setLineWrap(true);
+                area.setOpaque(false);
+                area.setBorder(new EmptyBorder(5,5,5,5));
+                return area;
+            }
+        });
+    }
+
+    private String resumo(String texto) {
+        if (texto == null) return "";
+        if (texto.length() <= 60) return texto;
+        return texto.substring(0, 57) + "...";
+    }
+
+    private void updatePage() {
+        List<Caderno> page = getCurrentPageCadernos();
+        atualizarTabela(page);
+        updatePaginationButtons();
+    }
+
+    private List<Caderno> getCurrentPageCadernos() {
+        if (filtrados == null) {
+            return Collections.emptyList();
+        }
+        int start = currentPage * PAGE_SIZE;
+        int end = Math.min(start + PAGE_SIZE, filtrados.size());
+        if (start > end) {
+            return new ArrayList<>();
+        }
+        return filtrados.subList(start, end);
+    }
+
+    private void updatePaginationButtons() {
+        int size = filtrados != null ? filtrados.size() : 0;
+        btnPrevPage.setEnabled(currentPage > 0);
+        btnNextPage.setEnabled((currentPage + 1) * PAGE_SIZE < size);
+    }
+
+    private void adicionarCaderno() {
+        Frame frame = (Frame) SwingUtilities.getWindowAncestor(this);
+        CadernoDialog dialog = new CadernoDialog(frame, null);
+        dialog.setVisible(true);
+        if (dialog.isConfirmed()) {
+            try {
+                controller.criar(dialog.getCaderno());
+                carregarCadernos();
+            } catch (Exception ex) {
+                JOptionPane.showMessageDialog(this, ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+
+    private void editarCaderno(Caderno caderno) {
+        try {
+            Caderno completo = controller.buscarPorId(caderno.getIdCaderno());
+            Frame frame = (Frame) SwingUtilities.getWindowAncestor(this);
+            CadernoDialog dialog = new CadernoDialog(frame, completo);
+            dialog.setVisible(true);
+            if (dialog.isConfirmed()) {
+                controller.atualizar(dialog.getCaderno());
+                carregarCadernos();
+            }
+        } catch (Exception ex) {
+            JOptionPane.showMessageDialog(this, ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+        }
+    }
+
+    private void excluirCaderno(Caderno caderno) {
+        int opt = JOptionPane.showConfirmDialog(this, "Excluir caderno?", "Confirmação", JOptionPane.YES_NO_OPTION);
+        if (opt == JOptionPane.YES_OPTION) {
+            try {
+                controller.remover(caderno.getIdCaderno());
+                carregarCadernos();
+            } catch (Exception ex) {
+                JOptionPane.showMessageDialog(this, ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+}

--- a/src/main/java/form/CarteiraDialog.java
+++ b/src/main/java/form/CarteiraDialog.java
@@ -1,0 +1,146 @@
+package form;
+
+import java.awt.Color;
+import java.awt.Frame;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import model.Carteira;
+import swing.Button;
+
+public class CarteiraDialog extends JDialog {
+
+    private final Carteira carteira;
+    private boolean confirmed = false;
+
+    private JTextField txtId;
+    private JTextField txtNome;
+    private JTextField txtTipo;
+    private JTextField txtDataInicio;
+    private JTextField txtIdUsuario;
+
+    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    public CarteiraDialog(Frame parent, Carteira carteira) {
+        super(parent, true);
+        this.carteira = carteira != null ? carteira : new Carteira();
+        initComponents();
+        setLocationRelativeTo(parent);
+        preencherCampos();
+    }
+
+    private void preencherCampos() {
+        if (carteira.getIdCarteira() != null) {
+            txtId.setText(String.valueOf(carteira.getIdCarteira()));
+        }
+        if (carteira.getNome() != null) {
+            txtNome.setText(carteira.getNome());
+        }
+        if (carteira.getTipo() != null) {
+            txtTipo.setText(carteira.getTipo());
+        }
+        if (carteira.getDataInicio() != null) {
+            txtDataInicio.setText(formatter.format(carteira.getDataInicio()));
+        }
+        if (carteira.getIdUsuario() != null) {
+            txtIdUsuario.setText(String.valueOf(carteira.getIdUsuario()));
+        }
+    }
+
+    private void initComponents() {
+        setTitle("Carteira");
+        JPanel panel = new JPanel(new GridBagLayout());
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.insets = new Insets(5,5,5,5);
+        gbc.anchor = GridBagConstraints.WEST;
+        int y = 0;
+
+        JLabel lblId = new JLabel("ID");
+        txtId = new JTextField(10);
+        txtId.setEditable(false);
+        gbc.gridx = 0; gbc.gridy = y; panel.add(lblId, gbc);
+        gbc.gridx = 1; panel.add(txtId, gbc); y++;
+
+        JLabel lblNome = new JLabel("Nome");
+        txtNome = new JTextField(20);
+        gbc.gridx = 0; gbc.gridy = y; panel.add(lblNome, gbc);
+        gbc.gridx = 1; panel.add(txtNome, gbc); y++;
+
+        JLabel lblTipo = new JLabel("Tipo");
+        txtTipo = new JTextField(20);
+        gbc.gridx = 0; gbc.gridy = y; panel.add(lblTipo, gbc);
+        gbc.gridx = 1; panel.add(txtTipo, gbc); y++;
+
+        JLabel lblData = new JLabel("Data Início (yyyy-MM-dd)");
+        txtDataInicio = new JTextField(20);
+        gbc.gridx = 0; gbc.gridy = y; panel.add(lblData, gbc);
+        gbc.gridx = 1; panel.add(txtDataInicio, gbc); y++;
+
+        JLabel lblUsuario = new JLabel("ID Usuário");
+        txtIdUsuario = new JTextField(20);
+        gbc.gridx = 0; gbc.gridy = y; panel.add(lblUsuario, gbc);
+        gbc.gridx = 1; panel.add(txtIdUsuario, gbc); y++;
+
+        Button btnSalvar = new Button();
+        btnSalvar.setText("Salvar");
+        btnSalvar.setBackground(new Color(75,134,253));
+        btnSalvar.setForeground(Color.WHITE);
+        btnSalvar.addActionListener(e -> salvar());
+
+        Button btnCancelar = new Button();
+        btnCancelar.setText("Cancelar");
+        btnCancelar.addActionListener(e -> dispose());
+
+        gbc.gridx = 0; gbc.gridy = y; panel.add(btnSalvar, gbc);
+        gbc.gridx = 1; panel.add(btnCancelar, gbc);
+
+        getContentPane().add(panel);
+        pack();
+        getRootPane().setDefaultButton(btnSalvar);
+    }
+
+    private void salvar() {
+        carteira.setNome(txtNome.getText());
+        carteira.setTipo(txtTipo.getText());
+        String data = txtDataInicio.getText();
+        if (data != null && !data.isEmpty()) {
+            try {
+                carteira.setDataInicio(LocalDate.parse(data, formatter));
+            } catch (DateTimeParseException ex) {
+                JOptionPane.showMessageDialog(this, "Data inválida. Use o formato yyyy-MM-dd.", "Erro", JOptionPane.ERROR_MESSAGE);
+                return;
+            }
+        } else {
+            carteira.setDataInicio(null);
+        }
+        String usuario = txtIdUsuario.getText();
+        if (usuario != null && !usuario.isEmpty()) {
+            try {
+                carteira.setIdUsuario(Integer.parseInt(usuario));
+            } catch (NumberFormatException ex) {
+                JOptionPane.showMessageDialog(this, "ID de usuário inválido.", "Erro", JOptionPane.ERROR_MESSAGE);
+                return;
+            }
+        } else {
+            carteira.setIdUsuario(null);
+        }
+        confirmed = true;
+        dispose();
+    }
+
+    public boolean isConfirmed() {
+        return confirmed;
+    }
+
+    public Carteira getCarteira() {
+        return carteira;
+    }
+}

--- a/src/main/java/form/CarteiraForm.java
+++ b/src/main/java/form/CarteiraForm.java
@@ -1,0 +1,368 @@
+package form;
+
+import controller.CarteiraController;
+import dao.impl.CarteiraDaoNativeImpl;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+import javax.swing.JOptionPane;
+import javax.swing.border.EmptyBorder;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableCellRenderer;
+import model.Carteira;
+import model.ModelCard;
+import swing.Button;
+import swing.icon.GoogleMaterialDesignIcons;
+import swing.icon.IconFontSwing;
+import swing.table.EventAction;
+import swing.table.ModelAction;
+import swing.table.Table;
+import component.Card;
+
+public class CarteiraForm extends JPanel {
+
+    private final CarteiraController controller;
+    private Card cardCarteiras;
+    private Card cardTipos;
+    private Card cardUsuarios;
+    private Table table;
+    private JTextField txtBusca;
+    private Button btnTipo1;
+    private Button btnTipo2;
+    private Button btnTipo3;
+    private Button btnNovo;
+    private String filtroTipo;
+    private List<Carteira> carteiras;
+    private List<Carteira> filtradas;
+    private JButton btnPrevPage;
+    private JButton btnNextPage;
+    private int currentPage = 0;
+    private static final int PAGE_SIZE = 6;
+    private final String[] tiposBotoes = new String[3];
+    private javax.swing.Icon iconCarteiras;
+    private javax.swing.Icon iconTipos;
+    private javax.swing.Icon iconUsuarios;
+    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+
+    public CarteiraForm() {
+        controller = new CarteiraController(new CarteiraDaoNativeImpl());
+        initComponents();
+        carregarCarteiras();
+    }
+
+    private void initComponents() {
+        setLayout(new BorderLayout());
+        setBackground(Color.WHITE);
+
+        JPanel top = new JPanel(new BorderLayout());
+        top.setBackground(Color.WHITE);
+
+        JPanel cards = new JPanel(new java.awt.GridLayout(1,3,18,0));
+        cards.setBackground(Color.WHITE);
+
+        iconCarteiras = IconFontSwing.buildIcon(GoogleMaterialDesignIcons.ACCOUNT_BALANCE_WALLET, 60, Color.WHITE,
+                new Color(255,255,255,15));
+        cardCarteiras = new Card();
+        cardCarteiras.setBackground(new Color(63,81,181));
+        cardCarteiras.setColorGradient(new Color(92,107,192));
+        cardCarteiras.setData(new ModelCard("Carteiras",0,0,iconCarteiras));
+        cards.add(cardCarteiras);
+
+        iconTipos = IconFontSwing.buildIcon(GoogleMaterialDesignIcons.LABEL, 60, Color.WHITE,
+                new Color(255,255,255,15));
+        cardTipos = new Card();
+        cardTipos.setBackground(new Color(0,150,136));
+        cardTipos.setColorGradient(new Color(38,166,154));
+        cardTipos.setData(new ModelCard("Tipos",0,0,iconTipos));
+        cards.add(cardTipos);
+
+        iconUsuarios = IconFontSwing.buildIcon(GoogleMaterialDesignIcons.GROUP, 60, Color.WHITE,
+                new Color(255,255,255,15));
+        cardUsuarios = new Card();
+        cardUsuarios.setBackground(new Color(255,87,34));
+        cardUsuarios.setColorGradient(new Color(255,112,67));
+        cardUsuarios.setData(new ModelCard("Usuários",0,0,iconUsuarios));
+        cards.add(cardUsuarios);
+
+        top.add(cards, BorderLayout.NORTH);
+
+        JPanel filtroWrapper = new JPanel(new BorderLayout());
+        filtroWrapper.setBackground(Color.WHITE);
+
+        JPanel filtro = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        filtro.setBackground(Color.WHITE);
+
+        btnTipo1 = criarBotaoFiltro(0);
+        filtro.add(btnTipo1);
+
+        btnTipo2 = criarBotaoFiltro(1);
+        filtro.add(btnTipo2);
+
+        btnTipo3 = criarBotaoFiltro(2);
+        filtro.add(btnTipo3);
+
+        txtBusca = new JTextField(15);
+        txtBusca.getDocument().addDocumentListener(new DocumentListener() {
+            @Override public void insertUpdate(DocumentEvent e) { aplicarFiltros(); }
+            @Override public void removeUpdate(DocumentEvent e) { aplicarFiltros(); }
+            @Override public void changedUpdate(DocumentEvent e) { aplicarFiltros(); }
+        });
+        filtro.add(new JLabel("Pesquisar:"));
+        filtro.add(txtBusca);
+
+        btnNovo = new Button();
+        btnNovo.setBackground(new Color(63,81,181));
+        btnNovo.setForeground(Color.WHITE);
+        btnNovo.setIcon(IconFontSwing.buildIcon(GoogleMaterialDesignIcons.ADD,20,Color.WHITE));
+        btnNovo.setPreferredSize(new Dimension(30,30));
+        btnNovo.addActionListener(e -> adicionarCarteira());
+        filtro.add(btnNovo);
+
+        filtroWrapper.add(filtro, BorderLayout.CENTER);
+        top.add(filtroWrapper, BorderLayout.CENTER);
+        add(top, BorderLayout.NORTH);
+
+        table = new Table();
+        table.setModel(new DefaultTableModel(new Object[][]{}, new String[]{
+            "Nome", "Tipo", "Data Início", "Usuário", "Ações"
+        }) {
+            @Override
+            public boolean isCellEditable(int row, int column) {
+                return column == 4;
+            }
+        });
+        table.setRowHeight(40);
+        JScrollPane scroll = new JScrollPane(table);
+        table.fixTable(scroll);
+        table.setRowSelectionAllowed(false);
+        add(scroll, BorderLayout.CENTER);
+
+        btnPrevPage = new JButton("Anterior");
+        btnNextPage = new JButton("Próximo");
+        btnPrevPage.addActionListener(e -> {
+            if (currentPage > 0) {
+                currentPage--;
+                updatePage();
+            }
+        });
+        btnNextPage.addActionListener(e -> {
+            if ((currentPage + 1) * PAGE_SIZE < (filtradas != null ? filtradas.size() : 0)) {
+                currentPage++;
+                updatePage();
+            }
+        });
+        JPanel pagination = new JPanel(new FlowLayout(FlowLayout.CENTER));
+        pagination.setBackground(Color.WHITE);
+        pagination.add(btnPrevPage);
+        pagination.add(btnNextPage);
+        add(pagination, BorderLayout.SOUTH);
+    }
+
+    private Button criarBotaoFiltro(int index) {
+        Button button = new Button();
+        button.setPreferredSize(new Dimension(120,30));
+        button.setBackground(new Color(0,150,136));
+        button.setForeground(Color.WHITE);
+        button.addActionListener(e -> aplicarFiltroTipo(index));
+        button.setEnabled(false);
+        button.setText("Tipo " + (index + 1));
+        return button;
+    }
+
+    private void aplicarFiltroTipo(int index) {
+        if (tiposBotoes[index] != null) {
+            filtroTipo = tiposBotoes[index];
+        } else {
+            filtroTipo = null;
+        }
+        aplicarFiltros();
+    }
+
+    private void carregarCarteiras() {
+        carteiras = controller.listar();
+        atualizarTiposBotoes();
+        filtroTipo = null;
+        aplicarFiltros();
+    }
+
+    private void atualizarTiposBotoes() {
+        for (int i = 0; i < tiposBotoes.length; i++) {
+            tiposBotoes[i] = null;
+        }
+        if (carteiras == null || carteiras.isEmpty()) {
+            atualizarTextoBotoes();
+            return;
+        }
+        Set<String> tipos = carteiras.stream()
+                .map(Carteira::getTipo)
+                .filter(s -> s != null && !s.isEmpty())
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        int idx = 0;
+        for (String t : tipos) {
+            if (idx >= tiposBotoes.length) break;
+            tiposBotoes[idx++] = t;
+        }
+        atualizarTextoBotoes();
+    }
+
+    private void atualizarTextoBotoes() {
+        Button[] botoes = {btnTipo1, btnTipo2, btnTipo3};
+        for (int i = 0; i < botoes.length; i++) {
+            String texto = tiposBotoes[i];
+            Button b = botoes[i];
+            if (texto != null) {
+                b.setText(texto);
+                b.setEnabled(true);
+            } else {
+                b.setText("Todos");
+                b.setEnabled(true);
+            }
+        }
+    }
+
+    private void aplicarFiltros() {
+        if (carteiras == null) return;
+        String busca = txtBusca.getText();
+        String filtro = (busca != null && !busca.isEmpty()) ? busca.toLowerCase() : null;
+        filtradas = carteiras.stream()
+                .filter(c -> filtroTipo == null || (c.getTipo() != null && c.getTipo().equalsIgnoreCase(filtroTipo))
+                        || (filtroTipo != null && "Todos".equalsIgnoreCase(filtroTipo)))
+                .filter(c -> filtro == null ||
+                        (c.getNome() != null && c.getNome().toLowerCase().contains(filtro)) ||
+                        (c.getTipo() != null && c.getTipo().toLowerCase().contains(filtro)))
+                .collect(Collectors.toList());
+        atualizarCards(filtradas);
+        currentPage = 0;
+        updatePage();
+    }
+
+    private void atualizarCards(List<Carteira> lista) {
+        int total = lista != null ? lista.size() : 0;
+        Set<String> tipos = new HashSet<>();
+        Set<Integer> usuarios = new HashSet<>();
+        for (Carteira c : lista) {
+            if (c.getTipo() != null && !c.getTipo().isEmpty()) tipos.add(c.getTipo());
+            if (c.getIdUsuario() != null) usuarios.add(c.getIdUsuario());
+        }
+        cardCarteiras.setData(new ModelCard("Carteiras", total, 0, iconCarteiras));
+        cardTipos.setData(new ModelCard("Tipos", tipos.size(), 0, iconTipos));
+        cardUsuarios.setData(new ModelCard("Usuários", usuarios.size(), 0, iconUsuarios));
+    }
+
+    private void atualizarTabela(List<Carteira> lista) {
+        DefaultTableModel model = (DefaultTableModel) table.getModel();
+        model.setRowCount(0);
+        EventAction<Carteira> eventAction = new EventAction<Carteira>() {
+            @Override
+            public void delete(Carteira c) { excluirCarteira(c); }
+            @Override
+            public void update(Carteira c) { editarCarteira(c); }
+        };
+        for (Carteira c : lista) {
+            model.addRow(new Object[]{
+                c.getNome(),
+                c.getTipo(),
+                c.getDataInicio() != null ? formatter.format(c.getDataInicio()) : "",
+                c.getIdUsuario(),
+                new ModelAction<>(c, eventAction)
+            });
+        }
+        int tipoCol = 1;
+        table.getColumnModel().getColumn(tipoCol).setCellRenderer(new TableCellRenderer() {
+            @Override
+            public Component getTableCellRendererComponent(JTable tbl, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+                Button lbl = new Button();
+                lbl.setText(value == null ? "" : value.toString());
+                lbl.setBorder(new EmptyBorder(5,5,5,5));
+                lbl.setBackground(new Color(0,150,136));
+                lbl.setForeground(Color.WHITE);
+                return lbl;
+            }
+        });
+    }
+
+    private void updatePage() {
+        List<Carteira> page = getCurrentPageCarteiras();
+        atualizarTabela(page);
+        updatePaginationButtons();
+    }
+
+    private List<Carteira> getCurrentPageCarteiras() {
+        if (filtradas == null) {
+            return Collections.emptyList();
+        }
+        int start = currentPage * PAGE_SIZE;
+        int end = Math.min(start + PAGE_SIZE, filtradas.size());
+        if (start > end) {
+            return new ArrayList<>();
+        }
+        return filtradas.subList(start, end);
+    }
+
+    private void updatePaginationButtons() {
+        int size = filtradas != null ? filtradas.size() : 0;
+        btnPrevPage.setEnabled(currentPage > 0);
+        btnNextPage.setEnabled((currentPage + 1) * PAGE_SIZE < size);
+    }
+
+    private void adicionarCarteira() {
+        Frame frame = (Frame) SwingUtilities.getWindowAncestor(this);
+        CarteiraDialog dialog = new CarteiraDialog(frame, null);
+        dialog.setVisible(true);
+        if (dialog.isConfirmed()) {
+            try {
+                controller.criar(dialog.getCarteira());
+                carregarCarteiras();
+            } catch (Exception ex) {
+                JOptionPane.showMessageDialog(this, ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+
+    private void editarCarteira(Carteira carteira) {
+        try {
+            Carteira completa = controller.buscarPorId(carteira.getIdCarteira());
+            Frame frame = (Frame) SwingUtilities.getWindowAncestor(this);
+            CarteiraDialog dialog = new CarteiraDialog(frame, completa);
+            dialog.setVisible(true);
+            if (dialog.isConfirmed()) {
+                controller.atualizar(dialog.getCarteira());
+                carregarCarteiras();
+            }
+        } catch (Exception ex) {
+            JOptionPane.showMessageDialog(this, ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+        }
+    }
+
+    private void excluirCarteira(Carteira carteira) {
+        int opt = JOptionPane.showConfirmDialog(this, "Excluir carteira?", "Confirmação", JOptionPane.YES_NO_OPTION);
+        if (opt == JOptionPane.YES_OPTION) {
+            try {
+                controller.remover(carteira.getIdCarteira());
+                carregarCarteiras();
+            } catch (Exception ex) {
+                JOptionPane.showMessageDialog(this, ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+}

--- a/src/main/java/form/MetaDialog.java
+++ b/src/main/java/form/MetaDialog.java
@@ -1,0 +1,164 @@
+package form;
+
+import java.awt.Color;
+import java.awt.Frame;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import javax.swing.JDialog;
+import javax.swing.JFileChooser;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import model.Meta;
+import swing.Button;
+
+public class MetaDialog extends JDialog {
+
+    private final Meta meta;
+    private boolean confirmed = false;
+
+    private JTextField txtId;
+    private JTextField txtPontoMinimo;
+    private JTextField txtPontoMedio;
+    private JTextField txtPontoMaximo;
+    private JTextField txtStatus;
+    private JTextField txtIdPeriodo;
+    private byte[] foto;
+
+    public MetaDialog(Frame parent, Meta meta) {
+        super(parent, true);
+        this.meta = meta != null ? meta : new Meta();
+        this.foto = this.meta.getFoto();
+        initComponents();
+        setLocationRelativeTo(parent);
+        preencherCampos();
+    }
+
+    private void preencherCampos() {
+        if (meta.getIdMeta() != null) {
+            txtId.setText(String.valueOf(meta.getIdMeta()));
+        }
+        if (meta.getPontoMinimo() != null) {
+            txtPontoMinimo.setText(String.valueOf(meta.getPontoMinimo()));
+        }
+        if (meta.getPontoMedio() != null) {
+            txtPontoMedio.setText(String.valueOf(meta.getPontoMedio()));
+        }
+        if (meta.getPontoMaximo() != null) {
+            txtPontoMaximo.setText(String.valueOf(meta.getPontoMaximo()));
+        }
+        if (meta.getStatus() != null) {
+            txtStatus.setText(String.valueOf(meta.getStatus()));
+        }
+        if (meta.getIdPeriodo() != null) {
+            txtIdPeriodo.setText(String.valueOf(meta.getIdPeriodo()));
+        }
+    }
+
+    private void initComponents() {
+        setTitle("Meta");
+        JPanel panel = new JPanel(new GridBagLayout());
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.insets = new Insets(5,5,5,5);
+        gbc.anchor = GridBagConstraints.WEST;
+        int y = 0;
+
+        txtId = new JTextField(10);
+        txtId.setEditable(false);
+        addRow(panel, gbc, y++, "ID", txtId);
+
+        txtPontoMinimo = new JTextField(20);
+        addRow(panel, gbc, y++, "Ponto Mínimo", txtPontoMinimo);
+
+        txtPontoMedio = new JTextField(20);
+        addRow(panel, gbc, y++, "Ponto Médio", txtPontoMedio);
+
+        txtPontoMaximo = new JTextField(20);
+        addRow(panel, gbc, y++, "Ponto Máximo", txtPontoMaximo);
+
+        txtStatus = new JTextField(20);
+        addRow(panel, gbc, y++, "Status", txtStatus);
+
+        txtIdPeriodo = new JTextField(20);
+        addRow(panel, gbc, y++, "ID Período", txtIdPeriodo);
+
+        Button btnFoto = new Button();
+        btnFoto.setText("Selecionar Foto");
+        btnFoto.setBackground(new Color(255,152,0));
+        btnFoto.setForeground(Color.BLACK);
+        btnFoto.addActionListener(e -> selecionarFoto());
+        addRow(panel, gbc, y++, "Foto", btnFoto);
+
+        Button btnSalvar = new Button();
+        btnSalvar.setText("Salvar");
+        btnSalvar.setBackground(new Color(75,134,253));
+        btnSalvar.setForeground(Color.WHITE);
+        btnSalvar.addActionListener(e -> salvar());
+
+        Button btnCancelar = new Button();
+        btnCancelar.setText("Cancelar");
+        btnCancelar.addActionListener(e -> dispose());
+
+        gbc.gridx = 0; gbc.gridy = y; panel.add(btnSalvar, gbc);
+        gbc.gridx = 1; panel.add(btnCancelar, gbc);
+
+        getContentPane().add(panel);
+        pack();
+        getRootPane().setDefaultButton(btnSalvar);
+    }
+
+    private void addRow(JPanel panel, GridBagConstraints gbc, int y, String label, java.awt.Component component) {
+        gbc.gridx = 0; gbc.gridy = y;
+        panel.add(new JLabel(label), gbc);
+        gbc.gridx = 1;
+        panel.add(component, gbc);
+    }
+
+    private void selecionarFoto() {
+        JFileChooser chooser = new JFileChooser();
+        int opt = chooser.showOpenDialog(this);
+        if (opt == JFileChooser.APPROVE_OPTION) {
+            File file = chooser.getSelectedFile();
+            try {
+                foto = Files.readAllBytes(file.toPath());
+            } catch (IOException ex) {
+                JOptionPane.showMessageDialog(this, "Erro ao ler arquivo: " + ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+
+    private void salvar() {
+        try {
+            meta.setPontoMinimo(parseInt(txtPontoMinimo.getText()));
+            meta.setPontoMedio(parseInt(txtPontoMedio.getText()));
+            meta.setPontoMaximo(parseInt(txtPontoMaximo.getText()));
+            meta.setStatus(parseInt(txtStatus.getText()));
+            meta.setIdPeriodo(parseInt(txtIdPeriodo.getText()));
+            meta.setFoto(foto);
+            confirmed = true;
+            dispose();
+        } catch (NumberFormatException ex) {
+            JOptionPane.showMessageDialog(this, "Preencha os campos numéricos corretamente.", "Erro", JOptionPane.ERROR_MESSAGE);
+        }
+    }
+
+    private Integer parseInt(String value) {
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
+        return Integer.parseInt(value);
+    }
+
+    public boolean isConfirmed() {
+        return confirmed;
+    }
+
+    public Meta getMeta() {
+        return meta;
+    }
+}

--- a/src/main/java/form/MetaForm.java
+++ b/src/main/java/form/MetaForm.java
@@ -1,0 +1,362 @@
+package form;
+
+import component.Card;
+import controller.MetaController;
+import dao.impl.MetaDaoNativeImpl;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+import javax.swing.JOptionPane;
+import javax.swing.border.EmptyBorder;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableCellRenderer;
+import model.Meta;
+import model.ModelCard;
+import swing.Button;
+import swing.ImageAvatar;
+import swing.icon.GoogleMaterialDesignIcons;
+import swing.icon.IconFontSwing;
+import swing.table.EventAction;
+import swing.table.ModelAction;
+import swing.table.Table;
+import util.ImageUtils;
+
+public class MetaForm extends JPanel {
+
+    private final MetaController controller;
+    private Card cardMetas;
+    private Card cardStatus;
+    private Card cardPeriodos;
+    private Table table;
+    private JTextField txtBusca;
+    private Button btnPlanejada;
+    private Button btnEmAndamento;
+    private Button btnConcluida;
+    private Button btnNovo;
+    private Integer filtroStatus;
+    private List<Meta> metas;
+    private List<Meta> filtradas;
+    private JButton btnPrevPage;
+    private JButton btnNextPage;
+    private int currentPage = 0;
+    private static final int PAGE_SIZE = 6;
+    private javax.swing.Icon iconMetas;
+    private javax.swing.Icon iconStatus;
+    private javax.swing.Icon iconPeriodos;
+
+    public MetaForm() {
+        controller = new MetaController(new MetaDaoNativeImpl());
+        initComponents();
+        carregarMetas();
+    }
+
+    private void initComponents() {
+        setLayout(new BorderLayout());
+        setBackground(Color.WHITE);
+
+        JPanel top = new JPanel(new BorderLayout());
+        top.setBackground(Color.WHITE);
+
+        JPanel cards = new JPanel(new java.awt.GridLayout(1,3,18,0));
+        cards.setBackground(Color.WHITE);
+
+        iconMetas = IconFontSwing.buildIcon(GoogleMaterialDesignIcons.FLAG, 60, Color.WHITE,
+                new Color(255,255,255,15));
+        cardMetas = new Card();
+        cardMetas.setBackground(new Color(63,81,181));
+        cardMetas.setColorGradient(new Color(92,107,192));
+        cardMetas.setData(new ModelCard("Metas",0,0,iconMetas));
+        cards.add(cardMetas);
+
+        iconStatus = IconFontSwing.buildIcon(GoogleMaterialDesignIcons.TRENDING_UP, 60, Color.WHITE,
+                new Color(255,255,255,15));
+        cardStatus = new Card();
+        cardStatus.setBackground(new Color(33,150,243));
+        cardStatus.setColorGradient(new Color(30,136,229));
+        cardStatus.setData(new ModelCard("Status",0,0,iconStatus));
+        cards.add(cardStatus);
+
+        iconPeriodos = IconFontSwing.buildIcon(GoogleMaterialDesignIcons.DATE_RANGE, 60, Color.WHITE,
+                new Color(255,255,255,15));
+        cardPeriodos = new Card();
+        cardPeriodos.setBackground(new Color(0,150,136));
+        cardPeriodos.setColorGradient(new Color(38,166,154));
+        cardPeriodos.setData(new ModelCard("Períodos",0,0,iconPeriodos));
+        cards.add(cardPeriodos);
+
+        top.add(cards, BorderLayout.NORTH);
+
+        JPanel filtroWrapper = new JPanel(new BorderLayout());
+        filtroWrapper.setBackground(Color.WHITE);
+
+        JPanel filtro = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        filtro.setBackground(Color.WHITE);
+
+        btnPlanejada = new Button();
+        btnPlanejada.setText("Planejada");
+        btnPlanejada.setBackground(new Color(63,81,181));
+        btnPlanejada.setForeground(Color.WHITE);
+        btnPlanejada.addActionListener(e -> { filtroStatus = 1; aplicarFiltros(); });
+        filtro.add(btnPlanejada);
+
+        btnEmAndamento = new Button();
+        btnEmAndamento.setText("Em andamento");
+        btnEmAndamento.setBackground(new Color(255,193,7));
+        btnEmAndamento.setForeground(Color.BLACK);
+        btnEmAndamento.addActionListener(e -> { filtroStatus = 2; aplicarFiltros(); });
+        filtro.add(btnEmAndamento);
+
+        btnConcluida = new Button();
+        btnConcluida.setText("Concluída");
+        btnConcluida.setBackground(new Color(76,175,80));
+        btnConcluida.setForeground(Color.WHITE);
+        btnConcluida.addActionListener(e -> { filtroStatus = 3; aplicarFiltros(); });
+        filtro.add(btnConcluida);
+
+        txtBusca = new JTextField(15);
+        txtBusca.getDocument().addDocumentListener(new DocumentListener() {
+            @Override public void insertUpdate(DocumentEvent e) { aplicarFiltros(); }
+            @Override public void removeUpdate(DocumentEvent e) { aplicarFiltros(); }
+            @Override public void changedUpdate(DocumentEvent e) { aplicarFiltros(); }
+        });
+        filtro.add(new JLabel("Pesquisar:"));
+        filtro.add(txtBusca);
+
+        btnNovo = new Button();
+        btnNovo.setBackground(new Color(63,81,181));
+        btnNovo.setForeground(Color.WHITE);
+        btnNovo.setIcon(IconFontSwing.buildIcon(GoogleMaterialDesignIcons.ADD,20,Color.WHITE));
+        btnNovo.setPreferredSize(new Dimension(30,30));
+        btnNovo.addActionListener(e -> adicionarMeta());
+        filtro.add(btnNovo);
+
+        filtroWrapper.add(filtro, BorderLayout.CENTER);
+        top.add(filtroWrapper, BorderLayout.CENTER);
+        add(top, BorderLayout.NORTH);
+
+        table = new Table();
+        table.setModel(new DefaultTableModel(new Object[][]{}, new String[]{
+            "Foto", "Ponto Mínimo", "Ponto Médio", "Ponto Máximo", "Status", "Período", "Ações"
+        }) {
+            @Override
+            public boolean isCellEditable(int row, int column) {
+                return column == 6;
+            }
+
+            @Override
+            public Class<?> getColumnClass(int columnIndex) {
+                return columnIndex == 0 ? ImageIcon.class : Object.class;
+            }
+        });
+        table.setRowHeight(50);
+        JScrollPane scroll = new JScrollPane(table);
+        table.fixTable(scroll);
+        table.setRowSelectionAllowed(false);
+        add(scroll, BorderLayout.CENTER);
+
+        btnPrevPage = new JButton("Anterior");
+        btnNextPage = new JButton("Próximo");
+        btnPrevPage.addActionListener(e -> {
+            if (currentPage > 0) {
+                currentPage--;
+                updatePage();
+            }
+        });
+        btnNextPage.addActionListener(e -> {
+            if ((currentPage + 1) * PAGE_SIZE < (filtradas != null ? filtradas.size() : 0)) {
+                currentPage++;
+                updatePage();
+            }
+        });
+        JPanel pagination = new JPanel(new FlowLayout(FlowLayout.CENTER));
+        pagination.setBackground(Color.WHITE);
+        pagination.add(btnPrevPage);
+        pagination.add(btnNextPage);
+        add(pagination, BorderLayout.SOUTH);
+    }
+
+    private void carregarMetas() {
+        metas = controller.listar();
+        aplicarFiltros();
+    }
+
+    private void aplicarFiltros() {
+        if (metas == null) return;
+        String busca = txtBusca.getText();
+        String filtro = (busca != null && !busca.isEmpty()) ? busca.toLowerCase() : null;
+        filtradas = metas.stream()
+                .filter(m -> filtroStatus == null || filtroStatus.equals(m.getStatus()))
+                .filter(m -> filtro == null ||
+                        (m.getPontoMinimo() != null && String.valueOf(m.getPontoMinimo()).contains(filtro)) ||
+                        (m.getPontoMedio() != null && String.valueOf(m.getPontoMedio()).contains(filtro)) ||
+                        (m.getPontoMaximo() != null && String.valueOf(m.getPontoMaximo()).contains(filtro)) ||
+                        (m.getIdPeriodo() != null && String.valueOf(m.getIdPeriodo()).contains(filtro)))
+                .collect(Collectors.toList());
+        atualizarCards(filtradas);
+        currentPage = 0;
+        updatePage();
+    }
+
+    private void atualizarCards(List<Meta> lista) {
+        int total = lista != null ? lista.size() : 0;
+        Set<Integer> status = new HashSet<>();
+        Set<Integer> periodos = new HashSet<>();
+        for (Meta m : lista) {
+            if (m.getStatus() != null) status.add(m.getStatus());
+            if (m.getIdPeriodo() != null) periodos.add(m.getIdPeriodo());
+        }
+        cardMetas.setData(new ModelCard("Metas", total, 0, iconMetas));
+        cardStatus.setData(new ModelCard("Status", status.size(), 0, iconStatus));
+        cardPeriodos.setData(new ModelCard("Períodos", periodos.size(), 0, iconPeriodos));
+    }
+
+    private void atualizarTabela(List<Meta> lista) {
+        DefaultTableModel model = (DefaultTableModel) table.getModel();
+        model.setRowCount(0);
+        EventAction<Meta> eventAction = new EventAction<Meta>() {
+            @Override
+            public void delete(Meta meta) { excluirMeta(meta); }
+            @Override
+            public void update(Meta meta) { editarMeta(meta); }
+        };
+        for (Meta m : lista) {
+            ImageIcon icon = ImageUtils.bytesToImageIcon(m.getFoto());
+            model.addRow(new Object[]{
+                icon,
+                m.getPontoMinimo(),
+                m.getPontoMedio(),
+                m.getPontoMaximo(),
+                statusTexto(m.getStatus()),
+                m.getIdPeriodo(),
+                new ModelAction<>(m, eventAction)
+            });
+        }
+        table.getColumnModel().getColumn(0).setCellRenderer(new TableCellRenderer() {
+            @Override
+            public Component getTableCellRendererComponent(JTable tbl, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+                ImageAvatar avatar = new ImageAvatar();
+                avatar.setPreferredSize(new Dimension(40, 40));
+                if (value instanceof ImageIcon) {
+                    avatar.setIcon((ImageIcon) value);
+                }
+                return avatar;
+            }
+        });
+        table.getColumnModel().getColumn(4).setCellRenderer(new TableCellRenderer() {
+            @Override
+            public Component getTableCellRendererComponent(JTable tbl, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+                Button lbl = new Button();
+                lbl.setText(value == null ? "" : value.toString());
+                lbl.setBorder(new EmptyBorder(5,5,5,5));
+                if ("Planejada".equals(value)) {
+                    lbl.setBackground(new Color(63,81,181));
+                    lbl.setForeground(Color.WHITE);
+                } else if ("Em andamento".equals(value)) {
+                    lbl.setBackground(new Color(255,193,7));
+                    lbl.setForeground(Color.BLACK);
+                } else if ("Concluída".equals(value)) {
+                    lbl.setBackground(new Color(76,175,80));
+                    lbl.setForeground(Color.WHITE);
+                } else {
+                    lbl.setBackground(new Color(158,158,158));
+                    lbl.setForeground(Color.WHITE);
+                }
+                return lbl;
+            }
+        });
+    }
+
+    private void updatePage() {
+        List<Meta> page = getCurrentPageMetas();
+        atualizarTabela(page);
+        updatePaginationButtons();
+    }
+
+    private List<Meta> getCurrentPageMetas() {
+        if (filtradas == null) {
+            return Collections.emptyList();
+        }
+        int start = currentPage * PAGE_SIZE;
+        int end = Math.min(start + PAGE_SIZE, filtradas.size());
+        if (start > end) {
+            return new ArrayList<>();
+        }
+        return filtradas.subList(start, end);
+    }
+
+    private void updatePaginationButtons() {
+        int size = filtradas != null ? filtradas.size() : 0;
+        btnPrevPage.setEnabled(currentPage > 0);
+        btnNextPage.setEnabled((currentPage + 1) * PAGE_SIZE < size);
+    }
+
+    private void adicionarMeta() {
+        Frame frame = (Frame) SwingUtilities.getWindowAncestor(this);
+        MetaDialog dialog = new MetaDialog(frame, null);
+        dialog.setVisible(true);
+        if (dialog.isConfirmed()) {
+            try {
+                controller.criar(dialog.getMeta());
+                carregarMetas();
+            } catch (Exception ex) {
+                JOptionPane.showMessageDialog(this, ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+
+    private void editarMeta(Meta meta) {
+        try {
+            Meta completa = controller.buscarComFotoPorId(meta.getIdMeta());
+            Frame frame = (Frame) SwingUtilities.getWindowAncestor(this);
+            MetaDialog dialog = new MetaDialog(frame, completa);
+            dialog.setVisible(true);
+            if (dialog.isConfirmed()) {
+                controller.atualizar(dialog.getMeta());
+                carregarMetas();
+            }
+        } catch (Exception ex) {
+            JOptionPane.showMessageDialog(this, ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+        }
+    }
+
+    private void excluirMeta(Meta meta) {
+        int opt = JOptionPane.showConfirmDialog(this, "Excluir meta?", "Confirmação", JOptionPane.YES_NO_OPTION);
+        if (opt == JOptionPane.YES_OPTION) {
+            try {
+                controller.remover(meta.getIdMeta());
+                carregarMetas();
+            } catch (Exception ex) {
+                JOptionPane.showMessageDialog(this, ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+
+    private String statusTexto(Integer status) {
+        if (status == null) return "";
+        switch (status) {
+            case 1: return "Planejada";
+            case 2: return "Em andamento";
+            case 3: return "Concluída";
+            default: return String.valueOf(status);
+        }
+    }
+}

--- a/src/main/java/form/ObjetoDialog.java
+++ b/src/main/java/form/ObjetoDialog.java
@@ -1,0 +1,162 @@
+package form;
+
+import java.awt.Color;
+import java.awt.Frame;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.io.File;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.file.Files;
+import javax.swing.JDialog;
+import javax.swing.JFileChooser;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import javax.swing.JTextField;
+import model.Objeto;
+import swing.Button;
+
+public class ObjetoDialog extends JDialog {
+
+    private final Objeto objeto;
+    private boolean confirmed = false;
+
+    private JTextField txtId;
+    private JTextField txtNome;
+    private JTextField txtTipo;
+    private JTextField txtValor;
+    private JTextArea txtDescricao;
+    private byte[] foto;
+
+    public ObjetoDialog(Frame parent, Objeto objeto) {
+        super(parent, true);
+        this.objeto = objeto != null ? objeto : new Objeto();
+        this.foto = this.objeto.getFoto();
+        initComponents();
+        setLocationRelativeTo(parent);
+        preencherCampos();
+    }
+
+    private void preencherCampos() {
+        if (objeto.getIdObjeto() != null) {
+            txtId.setText(String.valueOf(objeto.getIdObjeto()));
+        }
+        txtNome.setText(objeto.getNome());
+        if (objeto.getTipo() != null) {
+            txtTipo.setText(String.valueOf(objeto.getTipo()));
+        }
+        if (objeto.getValor() != null) {
+            txtValor.setText(objeto.getValor().toPlainString());
+        }
+        txtDescricao.setText(objeto.getDescricao());
+    }
+
+    private void initComponents() {
+        setTitle("Objeto");
+        JPanel panel = new JPanel(new GridBagLayout());
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.insets = new Insets(5,5,5,5);
+        gbc.anchor = GridBagConstraints.WEST;
+        int y = 0;
+
+        txtId = new JTextField(10);
+        txtId.setEditable(false);
+        addRow(panel, gbc, y++, "ID", txtId);
+
+        txtNome = new JTextField(20);
+        addRow(panel, gbc, y++, "Nome", txtNome);
+
+        txtTipo = new JTextField(20);
+        addRow(panel, gbc, y++, "Tipo", txtTipo);
+
+        txtValor = new JTextField(20);
+        addRow(panel, gbc, y++, "Valor", txtValor);
+
+        txtDescricao = new JTextArea(3, 20);
+        addRow(panel, gbc, y++, "Descrição", new JScrollPane(txtDescricao));
+
+        Button btnFoto = new Button();
+        btnFoto.setText("Selecionar Foto");
+        btnFoto.setBackground(new Color(255,152,0));
+        btnFoto.setForeground(Color.BLACK);
+        btnFoto.addActionListener(e -> selecionarFoto());
+        addRow(panel, gbc, y++, "Foto", btnFoto);
+
+        Button btnSalvar = new Button();
+        btnSalvar.setText("Salvar");
+        btnSalvar.setBackground(new Color(75,134,253));
+        btnSalvar.setForeground(Color.WHITE);
+        btnSalvar.addActionListener(e -> salvar());
+
+        Button btnCancelar = new Button();
+        btnCancelar.setText("Cancelar");
+        btnCancelar.addActionListener(e -> dispose());
+
+        gbc.gridx = 0; gbc.gridy = y; panel.add(btnSalvar, gbc);
+        gbc.gridx = 1; panel.add(btnCancelar, gbc);
+
+        getContentPane().add(panel);
+        pack();
+        getRootPane().setDefaultButton(btnSalvar);
+    }
+
+    private void addRow(JPanel panel, GridBagConstraints gbc, int y, String label, java.awt.Component component) {
+        gbc.gridx = 0; gbc.gridy = y;
+        panel.add(new JLabel(label), gbc);
+        gbc.gridx = 1;
+        panel.add(component, gbc);
+    }
+
+    private void selecionarFoto() {
+        JFileChooser chooser = new JFileChooser();
+        int opt = chooser.showOpenDialog(this);
+        if (opt == JFileChooser.APPROVE_OPTION) {
+            File file = chooser.getSelectedFile();
+            try {
+                foto = Files.readAllBytes(file.toPath());
+            } catch (IOException ex) {
+                JOptionPane.showMessageDialog(this, "Erro ao ler arquivo: " + ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+
+    private void salvar() {
+        try {
+            objeto.setNome(txtNome.getText());
+            objeto.setTipo(parseInteger(txtTipo.getText()));
+            objeto.setValor(parseDecimal(txtValor.getText()));
+            objeto.setDescricao(txtDescricao.getText());
+            objeto.setFoto(foto);
+            confirmed = true;
+            dispose();
+        } catch (NumberFormatException ex) {
+            JOptionPane.showMessageDialog(this, "Preencha os campos numéricos corretamente.", "Erro", JOptionPane.ERROR_MESSAGE);
+        }
+    }
+
+    private Integer parseInteger(String value) {
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
+        return Integer.parseInt(value);
+    }
+
+    private BigDecimal parseDecimal(String value) {
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
+        return new BigDecimal(value);
+    }
+
+    public boolean isConfirmed() {
+        return confirmed;
+    }
+
+    public Objeto getObjeto() {
+        return objeto;
+    }
+}

--- a/src/main/java/form/ObjetoForm.java
+++ b/src/main/java/form/ObjetoForm.java
@@ -1,0 +1,389 @@
+package form;
+
+import component.Card;
+import controller.ObjetoController;
+import dao.impl.ObjetoDaoNativeImpl;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.math.BigDecimal;
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.JTextArea;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+import javax.swing.JOptionPane;
+import javax.swing.border.EmptyBorder;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableCellRenderer;
+import model.ModelCard;
+import model.Objeto;
+import swing.Button;
+import swing.ImageAvatar;
+import swing.icon.GoogleMaterialDesignIcons;
+import swing.icon.IconFontSwing;
+import swing.table.EventAction;
+import swing.table.ModelAction;
+import swing.table.Table;
+import util.ImageUtils;
+
+public class ObjetoForm extends JPanel {
+
+    private final ObjetoController controller;
+    private Card cardObjetos;
+    private Card cardTipos;
+    private Card cardValor;
+    private Table table;
+    private JTextField txtBusca;
+    private Button btnTipo1;
+    private Button btnTipo2;
+    private Button btnTipo3;
+    private Button btnNovo;
+    private Integer filtroTipo;
+    private List<Objeto> objetos;
+    private List<Objeto> filtrados;
+    private JButton btnPrevPage;
+    private JButton btnNextPage;
+    private int currentPage = 0;
+    private static final int PAGE_SIZE = 6;
+    private final Integer[] tiposBotoes = new Integer[3];
+    private javax.swing.Icon iconObjetos;
+    private javax.swing.Icon iconTipos;
+    private javax.swing.Icon iconValor;
+    private final NumberFormat currency = NumberFormat.getCurrencyInstance(new Locale("pt", "BR"));
+
+    public ObjetoForm() {
+        controller = new ObjetoController(new ObjetoDaoNativeImpl());
+        initComponents();
+        carregarObjetos();
+    }
+
+    private void initComponents() {
+        setLayout(new BorderLayout());
+        setBackground(Color.WHITE);
+
+        JPanel top = new JPanel(new BorderLayout());
+        top.setBackground(Color.WHITE);
+
+        JPanel cards = new JPanel(new java.awt.GridLayout(1,3,18,0));
+        cards.setBackground(Color.WHITE);
+
+        iconObjetos = IconFontSwing.buildIcon(GoogleMaterialDesignIcons.CARD_GIFTCARD, 60, Color.WHITE,
+                new Color(255,255,255,15));
+        cardObjetos = new Card();
+        cardObjetos.setBackground(new Color(33,150,243));
+        cardObjetos.setColorGradient(new Color(30,136,229));
+        cardObjetos.setData(new ModelCard("Objetos",0,0,iconObjetos));
+        cards.add(cardObjetos);
+
+        iconTipos = IconFontSwing.buildIcon(GoogleMaterialDesignIcons.CATEGORY, 60, Color.WHITE,
+                new Color(255,255,255,15));
+        cardTipos = new Card();
+        cardTipos.setBackground(new Color(156,39,176));
+        cardTipos.setColorGradient(new Color(186,104,200));
+        cardTipos.setData(new ModelCard("Tipos",0,0,iconTipos));
+        cards.add(cardTipos);
+
+        iconValor = IconFontSwing.buildIcon(GoogleMaterialDesignIcons.ATTACH_MONEY, 60, Color.WHITE,
+                new Color(255,255,255,15));
+        cardValor = new Card();
+        cardValor.setBackground(new Color(76,175,80));
+        cardValor.setColorGradient(new Color(129,199,132));
+        cardValor.setData(new ModelCard("Valor Total",0,0,iconValor));
+        cards.add(cardValor);
+
+        top.add(cards, BorderLayout.NORTH);
+
+        JPanel filtroWrapper = new JPanel(new BorderLayout());
+        filtroWrapper.setBackground(Color.WHITE);
+
+        JPanel filtro = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        filtro.setBackground(Color.WHITE);
+
+        btnTipo1 = criarBotaoFiltro(0);
+        filtro.add(btnTipo1);
+
+        btnTipo2 = criarBotaoFiltro(1);
+        filtro.add(btnTipo2);
+
+        btnTipo3 = criarBotaoFiltro(2);
+        filtro.add(btnTipo3);
+
+        txtBusca = new JTextField(15);
+        txtBusca.getDocument().addDocumentListener(new DocumentListener() {
+            @Override public void insertUpdate(DocumentEvent e) { aplicarFiltros(); }
+            @Override public void removeUpdate(DocumentEvent e) { aplicarFiltros(); }
+            @Override public void changedUpdate(DocumentEvent e) { aplicarFiltros(); }
+        });
+        filtro.add(new JLabel("Pesquisar:"));
+        filtro.add(txtBusca);
+
+        btnNovo = new Button();
+        btnNovo.setBackground(new Color(33,150,243));
+        btnNovo.setForeground(Color.WHITE);
+        btnNovo.setIcon(IconFontSwing.buildIcon(GoogleMaterialDesignIcons.ADD,20,Color.WHITE));
+        btnNovo.setPreferredSize(new Dimension(30,30));
+        btnNovo.addActionListener(e -> adicionarObjeto());
+        filtro.add(btnNovo);
+
+        filtroWrapper.add(filtro, BorderLayout.CENTER);
+        top.add(filtroWrapper, BorderLayout.CENTER);
+        add(top, BorderLayout.NORTH);
+
+        table = new Table();
+        table.setModel(new DefaultTableModel(new Object[][]{}, new String[]{
+            "Foto", "Nome", "Tipo", "Valor", "Descrição", "Ações"
+        }) {
+            @Override
+            public boolean isCellEditable(int row, int column) {
+                return column == 5;
+            }
+
+            @Override
+            public Class<?> getColumnClass(int columnIndex) {
+                return columnIndex == 0 ? ImageIcon.class : Object.class;
+            }
+        });
+        table.setRowHeight(60);
+        JScrollPane scroll = new JScrollPane(table);
+        table.fixTable(scroll);
+        table.setRowSelectionAllowed(false);
+        add(scroll, BorderLayout.CENTER);
+
+        btnPrevPage = new JButton("Anterior");
+        btnNextPage = new JButton("Próximo");
+        btnPrevPage.addActionListener(e -> {
+            if (currentPage > 0) {
+                currentPage--;
+                updatePage();
+            }
+        });
+        btnNextPage.addActionListener(e -> {
+            if ((currentPage + 1) * PAGE_SIZE < (filtrados != null ? filtrados.size() : 0)) {
+                currentPage++;
+                updatePage();
+            }
+        });
+        JPanel pagination = new JPanel(new FlowLayout(FlowLayout.CENTER));
+        pagination.setBackground(Color.WHITE);
+        pagination.add(btnPrevPage);
+        pagination.add(btnNextPage);
+        add(pagination, BorderLayout.SOUTH);
+    }
+
+    private Button criarBotaoFiltro(int index) {
+        Button button = new Button();
+        button.setPreferredSize(new Dimension(110,30));
+        button.setBackground(new Color(156,39,176));
+        button.setForeground(Color.WHITE);
+        button.addActionListener(e -> aplicarFiltroTipo(index));
+        button.setEnabled(false);
+        button.setText("Tipo " + (index + 1));
+        return button;
+    }
+
+    private void aplicarFiltroTipo(int index) {
+        filtroTipo = tiposBotoes[index];
+        aplicarFiltros();
+    }
+
+    private void carregarObjetos() {
+        objetos = controller.listar();
+        atualizarTiposBotoes();
+        filtroTipo = null;
+        aplicarFiltros();
+    }
+
+    private void atualizarTiposBotoes() {
+        for (int i = 0; i < tiposBotoes.length; i++) {
+            tiposBotoes[i] = null;
+        }
+        if (objetos != null) {
+            Set<Integer> tipos = objetos.stream()
+                    .map(Objeto::getTipo)
+                    .filter(t -> t != null)
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+            int idx = 0;
+            for (Integer t : tipos) {
+                if (idx >= tiposBotoes.length) break;
+                tiposBotoes[idx++] = t;
+            }
+        }
+        atualizarTextoBotoes();
+    }
+
+    private void atualizarTextoBotoes() {
+        Button[] botoes = {btnTipo1, btnTipo2, btnTipo3};
+        for (int i = 0; i < botoes.length; i++) {
+            Button b = botoes[i];
+            Integer valor = tiposBotoes[i];
+            if (valor != null) {
+                b.setText("Tipo " + valor);
+                b.setEnabled(true);
+            } else {
+                b.setText("Todos");
+                b.setEnabled(true);
+            }
+        }
+    }
+
+    private void aplicarFiltros() {
+        if (objetos == null) return;
+        String busca = txtBusca.getText();
+        String filtro = (busca != null && !busca.isEmpty()) ? busca.toLowerCase() : null;
+        filtrados = objetos.stream()
+                .filter(o -> filtroTipo == null || filtroTipo.equals(o.getTipo()))
+                .filter(o -> filtro == null ||
+                        (o.getNome() != null && o.getNome().toLowerCase().contains(filtro)) ||
+                        (o.getDescricao() != null && o.getDescricao().toLowerCase().contains(filtro)))
+                .collect(Collectors.toList());
+        atualizarCards(filtrados);
+        currentPage = 0;
+        updatePage();
+    }
+
+    private void atualizarCards(List<Objeto> lista) {
+        int total = lista != null ? lista.size() : 0;
+        Set<Integer> tipos = new LinkedHashSet<>();
+        BigDecimal valorTotal = BigDecimal.ZERO;
+        for (Objeto o : lista) {
+            if (o.getTipo() != null) tipos.add(o.getTipo());
+            if (o.getValor() != null) valorTotal = valorTotal.add(o.getValor());
+        }
+        cardObjetos.setData(new ModelCard("Objetos", total, 0, iconObjetos));
+        cardTipos.setData(new ModelCard("Tipos", tipos.size(), 0, iconTipos));
+        cardValor.setData(new ModelCard("Valor Total", valorTotal.doubleValue(), 0, iconValor));
+    }
+
+    private void atualizarTabela(List<Objeto> lista) {
+        DefaultTableModel model = (DefaultTableModel) table.getModel();
+        model.setRowCount(0);
+        EventAction<Objeto> eventAction = new EventAction<Objeto>() {
+            @Override
+            public void delete(Objeto objeto) { excluirObjeto(objeto); }
+            @Override
+            public void update(Objeto objeto) { editarObjeto(objeto); }
+        };
+        for (Objeto o : lista) {
+            ImageIcon icon = ImageUtils.bytesToImageIcon(o.getFoto());
+            model.addRow(new Object[]{
+                icon,
+                o.getNome(),
+                o.getTipo(),
+                o.getValor() != null ? currency.format(o.getValor()) : "",
+                resumo(o.getDescricao()),
+                new ModelAction<>(o, eventAction)
+            });
+        }
+        table.getColumnModel().getColumn(0).setCellRenderer(new TableCellRenderer() {
+            @Override
+            public Component getTableCellRendererComponent(JTable tbl, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+                ImageAvatar avatar = new ImageAvatar();
+                avatar.setPreferredSize(new Dimension(50, 50));
+                if (value instanceof ImageIcon) {
+                    avatar.setIcon((ImageIcon) value);
+                }
+                return avatar;
+            }
+        });
+        table.getColumnModel().getColumn(4).setCellRenderer(new TableCellRenderer() {
+            @Override
+            public Component getTableCellRendererComponent(JTable tbl, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+                JTextArea area = new JTextArea(value == null ? "" : value.toString());
+                area.setWrapStyleWord(true);
+                area.setLineWrap(true);
+                area.setOpaque(false);
+                area.setBorder(new EmptyBorder(5,5,5,5));
+                return area;
+            }
+        });
+    }
+
+    private String resumo(String texto) {
+        if (texto == null) return "";
+        if (texto.length() <= 60) return texto;
+        return texto.substring(0, 57) + "...";
+    }
+
+    private void updatePage() {
+        List<Objeto> page = getCurrentPageObjetos();
+        atualizarTabela(page);
+        updatePaginationButtons();
+    }
+
+    private List<Objeto> getCurrentPageObjetos() {
+        if (filtrados == null) {
+            return Collections.emptyList();
+        }
+        int start = currentPage * PAGE_SIZE;
+        int end = Math.min(start + PAGE_SIZE, filtrados.size());
+        if (start > end) {
+            return new ArrayList<>();
+        }
+        return filtrados.subList(start, end);
+    }
+
+    private void updatePaginationButtons() {
+        int size = filtrados != null ? filtrados.size() : 0;
+        btnPrevPage.setEnabled(currentPage > 0);
+        btnNextPage.setEnabled((currentPage + 1) * PAGE_SIZE < size);
+    }
+
+    private void adicionarObjeto() {
+        Frame frame = (Frame) SwingUtilities.getWindowAncestor(this);
+        ObjetoDialog dialog = new ObjetoDialog(frame, null);
+        dialog.setVisible(true);
+        if (dialog.isConfirmed()) {
+            try {
+                controller.criar(dialog.getObjeto());
+                carregarObjetos();
+            } catch (Exception ex) {
+                JOptionPane.showMessageDialog(this, ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+
+    private void editarObjeto(Objeto objeto) {
+        try {
+            Objeto completo = controller.buscarPorId(objeto.getIdObjeto());
+            Frame frame = (Frame) SwingUtilities.getWindowAncestor(this);
+            ObjetoDialog dialog = new ObjetoDialog(frame, completo);
+            dialog.setVisible(true);
+            if (dialog.isConfirmed()) {
+                controller.atualizar(dialog.getObjeto());
+                carregarObjetos();
+            }
+        } catch (Exception ex) {
+            JOptionPane.showMessageDialog(this, ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+        }
+    }
+
+    private void excluirObjeto(Objeto objeto) {
+        int opt = JOptionPane.showConfirmDialog(this, "Excluir objeto?", "Confirmação", JOptionPane.YES_NO_OPTION);
+        if (opt == JOptionPane.YES_OPTION) {
+            try {
+                controller.remover(objeto.getIdObjeto());
+                carregarObjetos();
+            } catch (Exception ex) {
+                JOptionPane.showMessageDialog(this, ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+}

--- a/src/main/java/form/SiteDialog.java
+++ b/src/main/java/form/SiteDialog.java
@@ -1,0 +1,126 @@
+package form;
+
+import java.awt.Color;
+import java.awt.Frame;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import javax.swing.JCheckBox;
+import javax.swing.JDialog;
+import javax.swing.JFileChooser;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import model.Site;
+import swing.Button;
+
+public class SiteDialog extends JDialog {
+
+    private final Site site;
+    private boolean confirmed = false;
+
+    private JTextField txtId;
+    private JTextField txtUrl;
+    private JCheckBox chkAtivo;
+    private byte[] logo;
+
+    public SiteDialog(Frame parent, Site site) {
+        super(parent, true);
+        this.site = site != null ? site : new Site();
+        this.logo = this.site.getLogo();
+        initComponents();
+        setLocationRelativeTo(parent);
+        preencherCampos();
+    }
+
+    private void preencherCampos() {
+        if (site.getIdSite() != null) {
+            txtId.setText(String.valueOf(site.getIdSite()));
+        }
+        txtUrl.setText(site.getUrl());
+        chkAtivo.setSelected(Boolean.TRUE.equals(site.getAtivo()));
+    }
+
+    private void initComponents() {
+        setTitle("Site");
+        JPanel panel = new JPanel(new GridBagLayout());
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.insets = new Insets(5,5,5,5);
+        gbc.anchor = GridBagConstraints.WEST;
+        int y = 0;
+
+        txtId = new JTextField(10);
+        txtId.setEditable(false);
+        addRow(panel, gbc, y++, "ID", txtId);
+
+        txtUrl = new JTextField(20);
+        addRow(panel, gbc, y++, "URL", txtUrl);
+
+        chkAtivo = new JCheckBox("Ativo");
+        addRow(panel, gbc, y++, "Status", chkAtivo);
+
+        Button btnLogo = new Button();
+        btnLogo.setText("Selecionar Logo");
+        btnLogo.setBackground(new Color(0,150,136));
+        btnLogo.setForeground(Color.WHITE);
+        btnLogo.addActionListener(e -> selecionarLogo());
+        addRow(panel, gbc, y++, "Logo", btnLogo);
+
+        Button btnSalvar = new Button();
+        btnSalvar.setText("Salvar");
+        btnSalvar.setBackground(new Color(75,134,253));
+        btnSalvar.setForeground(Color.WHITE);
+        btnSalvar.addActionListener(e -> salvar());
+
+        Button btnCancelar = new Button();
+        btnCancelar.setText("Cancelar");
+        btnCancelar.addActionListener(e -> dispose());
+
+        gbc.gridx = 0; gbc.gridy = y; panel.add(btnSalvar, gbc);
+        gbc.gridx = 1; panel.add(btnCancelar, gbc);
+
+        getContentPane().add(panel);
+        pack();
+        getRootPane().setDefaultButton(btnSalvar);
+    }
+
+    private void addRow(JPanel panel, GridBagConstraints gbc, int y, String label, java.awt.Component component) {
+        gbc.gridx = 0; gbc.gridy = y;
+        panel.add(new JLabel(label), gbc);
+        gbc.gridx = 1;
+        panel.add(component, gbc);
+    }
+
+    private void selecionarLogo() {
+        JFileChooser chooser = new JFileChooser();
+        int opt = chooser.showOpenDialog(this);
+        if (opt == JFileChooser.APPROVE_OPTION) {
+            File file = chooser.getSelectedFile();
+            try {
+                logo = Files.readAllBytes(file.toPath());
+            } catch (IOException ex) {
+                JOptionPane.showMessageDialog(this, "Erro ao ler arquivo: " + ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+
+    private void salvar() {
+        site.setUrl(txtUrl.getText());
+        site.setAtivo(chkAtivo.isSelected());
+        site.setLogo(logo);
+        confirmed = true;
+        dispose();
+    }
+
+    public boolean isConfirmed() {
+        return confirmed;
+    }
+
+    public Site getSite() {
+        return site;
+    }
+}

--- a/src/main/java/form/SiteForm.java
+++ b/src/main/java/form/SiteForm.java
@@ -1,0 +1,334 @@
+package form;
+
+import component.Card;
+import controller.SiteController;
+import dao.impl.SiteDaoNativeImpl;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+import javax.swing.JOptionPane;
+import javax.swing.border.EmptyBorder;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableCellRenderer;
+import model.ModelCard;
+import model.Site;
+import swing.Button;
+import swing.ImageAvatar;
+import swing.icon.GoogleMaterialDesignIcons;
+import swing.icon.IconFontSwing;
+import swing.table.EventAction;
+import swing.table.ModelAction;
+import swing.table.Table;
+import util.ImageUtils;
+
+public class SiteForm extends JPanel {
+
+    private final SiteController controller;
+    private Card cardSites;
+    private Card cardAtivos;
+    private Card cardInativos;
+    private Table table;
+    private JTextField txtBusca;
+    private Button btnTodos;
+    private Button btnAtivos;
+    private Button btnInativos;
+    private Button btnNovo;
+    private Boolean filtroAtivo;
+    private List<Site> sites;
+    private List<Site> filtrados;
+    private JButton btnPrevPage;
+    private JButton btnNextPage;
+    private int currentPage = 0;
+    private static final int PAGE_SIZE = 6;
+    private javax.swing.Icon iconSites;
+    private javax.swing.Icon iconAtivos;
+    private javax.swing.Icon iconInativos;
+
+    public SiteForm() {
+        controller = new SiteController(new SiteDaoNativeImpl());
+        initComponents();
+        carregarSites();
+    }
+
+    private void initComponents() {
+        setLayout(new BorderLayout());
+        setBackground(Color.WHITE);
+
+        JPanel top = new JPanel(new BorderLayout());
+        top.setBackground(Color.WHITE);
+
+        JPanel cards = new JPanel(new java.awt.GridLayout(1,3,18,0));
+        cards.setBackground(Color.WHITE);
+
+        iconSites = IconFontSwing.buildIcon(GoogleMaterialDesignIcons.LANGUAGE, 60, Color.WHITE,
+                new Color(255,255,255,15));
+        cardSites = new Card();
+        cardSites.setBackground(new Color(63,81,181));
+        cardSites.setColorGradient(new Color(92,107,192));
+        cardSites.setData(new ModelCard("Sites",0,0,iconSites));
+        cards.add(cardSites);
+
+        iconAtivos = IconFontSwing.buildIcon(GoogleMaterialDesignIcons.CHECK_CIRCLE, 60, Color.WHITE,
+                new Color(255,255,255,15));
+        cardAtivos = new Card();
+        cardAtivos.setBackground(new Color(76,175,80));
+        cardAtivos.setColorGradient(new Color(129,199,132));
+        cardAtivos.setData(new ModelCard("Ativos",0,0,iconAtivos));
+        cards.add(cardAtivos);
+
+        iconInativos = IconFontSwing.buildIcon(GoogleMaterialDesignIcons.REPORT, 60, Color.WHITE,
+                new Color(255,255,255,15));
+        cardInativos = new Card();
+        cardInativos.setBackground(new Color(244,67,54));
+        cardInativos.setColorGradient(new Color(239,83,80));
+        cardInativos.setData(new ModelCard("Inativos",0,0,iconInativos));
+        cards.add(cardInativos);
+
+        top.add(cards, BorderLayout.NORTH);
+
+        JPanel filtroWrapper = new JPanel(new BorderLayout());
+        filtroWrapper.setBackground(Color.WHITE);
+
+        JPanel filtro = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        filtro.setBackground(Color.WHITE);
+
+        btnTodos = new Button();
+        btnTodos.setText("Todos");
+        btnTodos.setBackground(new Color(63,81,181));
+        btnTodos.setForeground(Color.WHITE);
+        btnTodos.addActionListener(e -> { filtroAtivo = null; aplicarFiltros(); });
+        filtro.add(btnTodos);
+
+        btnAtivos = new Button();
+        btnAtivos.setText("Ativos");
+        btnAtivos.setBackground(new Color(76,175,80));
+        btnAtivos.setForeground(Color.WHITE);
+        btnAtivos.addActionListener(e -> { filtroAtivo = Boolean.TRUE; aplicarFiltros(); });
+        filtro.add(btnAtivos);
+
+        btnInativos = new Button();
+        btnInativos.setText("Inativos");
+        btnInativos.setBackground(new Color(244,67,54));
+        btnInativos.setForeground(Color.WHITE);
+        btnInativos.addActionListener(e -> { filtroAtivo = Boolean.FALSE; aplicarFiltros(); });
+        filtro.add(btnInativos);
+
+        txtBusca = new JTextField(15);
+        txtBusca.getDocument().addDocumentListener(new DocumentListener() {
+            @Override public void insertUpdate(DocumentEvent e) { aplicarFiltros(); }
+            @Override public void removeUpdate(DocumentEvent e) { aplicarFiltros(); }
+            @Override public void changedUpdate(DocumentEvent e) { aplicarFiltros(); }
+        });
+        filtro.add(new JLabel("Pesquisar:"));
+        filtro.add(txtBusca);
+
+        btnNovo = new Button();
+        btnNovo.setBackground(new Color(63,81,181));
+        btnNovo.setForeground(Color.WHITE);
+        btnNovo.setIcon(IconFontSwing.buildIcon(GoogleMaterialDesignIcons.ADD,20,Color.WHITE));
+        btnNovo.setPreferredSize(new Dimension(30,30));
+        btnNovo.addActionListener(e -> adicionarSite());
+        filtro.add(btnNovo);
+
+        filtroWrapper.add(filtro, BorderLayout.CENTER);
+        top.add(filtroWrapper, BorderLayout.CENTER);
+        add(top, BorderLayout.NORTH);
+
+        table = new Table();
+        table.setModel(new DefaultTableModel(new Object[][]{}, new String[]{
+            "Logo", "URL", "Ativo", "Ações"
+        }) {
+            @Override
+            public boolean isCellEditable(int row, int column) {
+                return column == 3;
+            }
+
+            @Override
+            public Class<?> getColumnClass(int columnIndex) {
+                return columnIndex == 0 ? ImageIcon.class : Object.class;
+            }
+        });
+        table.setRowHeight(50);
+        JScrollPane scroll = new JScrollPane(table);
+        table.fixTable(scroll);
+        table.setRowSelectionAllowed(false);
+        add(scroll, BorderLayout.CENTER);
+
+        btnPrevPage = new JButton("Anterior");
+        btnNextPage = new JButton("Próximo");
+        btnPrevPage.addActionListener(e -> {
+            if (currentPage > 0) {
+                currentPage--;
+                updatePage();
+            }
+        });
+        btnNextPage.addActionListener(e -> {
+            if ((currentPage + 1) * PAGE_SIZE < (filtrados != null ? filtrados.size() : 0)) {
+                currentPage++;
+                updatePage();
+            }
+        });
+        JPanel pagination = new JPanel(new FlowLayout(FlowLayout.CENTER));
+        pagination.setBackground(Color.WHITE);
+        pagination.add(btnPrevPage);
+        pagination.add(btnNextPage);
+        add(pagination, BorderLayout.SOUTH);
+    }
+
+    private void carregarSites() {
+        sites = controller.listar();
+        filtroAtivo = null;
+        aplicarFiltros();
+    }
+
+    private void aplicarFiltros() {
+        if (sites == null) return;
+        String busca = txtBusca.getText();
+        String filtro = (busca != null && !busca.isEmpty()) ? busca.toLowerCase() : null;
+        filtrados = sites.stream()
+                .filter(s -> filtroAtivo == null || filtroAtivo.equals(s.getAtivo()))
+                .filter(s -> filtro == null || (s.getUrl() != null && s.getUrl().toLowerCase().contains(filtro)))
+                .collect(Collectors.toList());
+        atualizarCards(filtrados);
+        currentPage = 0;
+        updatePage();
+    }
+
+    private void atualizarCards(List<Site> lista) {
+        int total = lista != null ? lista.size() : 0;
+        long ativos = lista.stream().filter(s -> Boolean.TRUE.equals(s.getAtivo())).count();
+        long inativos = total - ativos;
+        cardSites.setData(new ModelCard("Sites", total, 0, iconSites));
+        cardAtivos.setData(new ModelCard("Ativos", (int) ativos, 0, iconAtivos));
+        cardInativos.setData(new ModelCard("Inativos", (int) inativos, 0, iconInativos));
+    }
+
+    private void atualizarTabela(List<Site> lista) {
+        DefaultTableModel model = (DefaultTableModel) table.getModel();
+        model.setRowCount(0);
+        EventAction<Site> eventAction = new EventAction<Site>() {
+            @Override
+            public void delete(Site site) { excluirSite(site); }
+            @Override
+            public void update(Site site) { editarSite(site); }
+        };
+        for (Site s : lista) {
+            ImageIcon icon = ImageUtils.bytesToImageIcon(s.getLogo());
+            model.addRow(new Object[]{
+                icon,
+                s.getUrl(),
+                Boolean.TRUE.equals(s.getAtivo()) ? "Sim" : "Não",
+                new ModelAction<>(s, eventAction)
+            });
+        }
+        table.getColumnModel().getColumn(0).setCellRenderer(new TableCellRenderer() {
+            @Override
+            public Component getTableCellRendererComponent(JTable tbl, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+                ImageAvatar avatar = new ImageAvatar();
+                avatar.setPreferredSize(new Dimension(40, 40));
+                if (value instanceof ImageIcon) {
+                    avatar.setIcon((ImageIcon) value);
+                }
+                return avatar;
+            }
+        });
+        table.getColumnModel().getColumn(2).setCellRenderer(new TableCellRenderer() {
+            @Override
+            public Component getTableCellRendererComponent(JTable tbl, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+                Button lbl = new Button();
+                lbl.setText(value == null ? "" : value.toString());
+                lbl.setBorder(new EmptyBorder(5,5,5,5));
+                if ("Sim".equals(value)) {
+                    lbl.setBackground(new Color(76,175,80));
+                    lbl.setForeground(Color.WHITE);
+                } else {
+                    lbl.setBackground(new Color(244,67,54));
+                    lbl.setForeground(Color.WHITE);
+                }
+                return lbl;
+            }
+        });
+    }
+
+    private void updatePage() {
+        List<Site> page = getCurrentPageSites();
+        atualizarTabela(page);
+        updatePaginationButtons();
+    }
+
+    private List<Site> getCurrentPageSites() {
+        if (filtrados == null) {
+            return Collections.emptyList();
+        }
+        int start = currentPage * PAGE_SIZE;
+        int end = Math.min(start + PAGE_SIZE, filtrados.size());
+        if (start > end) {
+            return new ArrayList<>();
+        }
+        return filtrados.subList(start, end);
+    }
+
+    private void updatePaginationButtons() {
+        int size = filtrados != null ? filtrados.size() : 0;
+        btnPrevPage.setEnabled(currentPage > 0);
+        btnNextPage.setEnabled((currentPage + 1) * PAGE_SIZE < size);
+    }
+
+    private void adicionarSite() {
+        Frame frame = (Frame) SwingUtilities.getWindowAncestor(this);
+        SiteDialog dialog = new SiteDialog(frame, null);
+        dialog.setVisible(true);
+        if (dialog.isConfirmed()) {
+            try {
+                controller.criar(dialog.getSite());
+                carregarSites();
+            } catch (Exception ex) {
+                JOptionPane.showMessageDialog(this, ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+
+    private void editarSite(Site site) {
+        try {
+            Site completo = controller.buscarPorId(site.getIdSite());
+            Frame frame = (Frame) SwingUtilities.getWindowAncestor(this);
+            SiteDialog dialog = new SiteDialog(frame, completo);
+            dialog.setVisible(true);
+            if (dialog.isConfirmed()) {
+                controller.atualizar(dialog.getSite());
+                carregarSites();
+            }
+        } catch (Exception ex) {
+            JOptionPane.showMessageDialog(this, ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+        }
+    }
+
+    private void excluirSite(Site site) {
+        int opt = JOptionPane.showConfirmDialog(this, "Excluir site?", "Confirmação", JOptionPane.YES_NO_OPTION);
+        if (opt == JOptionPane.YES_OPTION) {
+            try {
+                controller.remover(site.getIdSite());
+                carregarSites();
+            } catch (Exception ex) {
+                JOptionPane.showMessageDialog(this, ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+}

--- a/src/main/java/main/Main.java
+++ b/src/main/java/main/Main.java
@@ -12,6 +12,11 @@ import form.MainForm;
 import form.MovimentacaoForm;
 import form.CaixaForm;
 import form.CofreForm;
+import form.CarteiraForm;
+import form.CadernoForm;
+import form.MetaForm;
+import form.SiteForm;
+import form.ObjetoForm;
 import form.PapelForm;
 import form.BackupForm;
 import form.AgendamentosView;
@@ -87,6 +92,16 @@ public class Main extends javax.swing.JFrame {
                     } else if (subMenuIndex == 6) {
                         main.showForm(new CofreForm());
                     } else if (subMenuIndex == 7) {
+                        main.showForm(new CarteiraForm());
+                    } else if (subMenuIndex == 8) {
+                        main.showForm(new CadernoForm());
+                    } else if (subMenuIndex == 9) {
+                        main.showForm(new MetaForm());
+                    } else if (subMenuIndex == 10) {
+                        main.showForm(new SiteForm());
+                    } else if (subMenuIndex == 11) {
+                        main.showForm(new ObjetoForm());
+                    } else if (subMenuIndex == 12) {
                         main.showForm(new PapelForm());
                     }
                 } else if (menuIndex == 1) {

--- a/src/main/java/model/Caderno.java
+++ b/src/main/java/model/Caderno.java
@@ -1,0 +1,104 @@
+package model;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+import java.util.Objects;
+
+@Entity
+@Table(name = "Caderno", schema = "rotinamais")
+public class Caderno {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id_caderno")
+    private Integer idCaderno;
+
+    @Column(name = "nome_ia")
+    private String nomeIa;
+
+    @Column(name = "titulo")
+    private String titulo;
+
+    @Column(name = "objetivo")
+    private String objetivo;
+
+    @Column(name = "comando")
+    private String comando;
+
+    @Column(name = "resultado")
+    private String resultado;
+
+    @Column(name = "data")
+    private LocalDate data;
+
+    @Column(name = "resultado_imagem")
+    private byte[] resultadoImagem;
+
+    @Column(name = "resultado_video")
+    private byte[] resultadoVideo;
+
+    @Column(name = "id_usuario")
+    private Integer idUsuario;
+
+    @Column(name = "id_categoria")
+    private Integer idCategoria;
+
+    public Integer getIdCaderno() { return idCaderno; }
+    public void setIdCaderno(Integer idCaderno) { this.idCaderno = idCaderno; }
+
+    public String getNomeIa() { return nomeIa; }
+    public void setNomeIa(String nomeIa) { this.nomeIa = nomeIa; }
+
+    public String getTitulo() { return titulo; }
+    public void setTitulo(String titulo) { this.titulo = titulo; }
+
+    public String getObjetivo() { return objetivo; }
+    public void setObjetivo(String objetivo) { this.objetivo = objetivo; }
+
+    public String getComando() { return comando; }
+    public void setComando(String comando) { this.comando = comando; }
+
+    public String getResultado() { return resultado; }
+    public void setResultado(String resultado) { this.resultado = resultado; }
+
+    public LocalDate getData() { return data; }
+    public void setData(LocalDate data) { this.data = data; }
+
+    public byte[] getResultadoImagem() { return resultadoImagem; }
+    public void setResultadoImagem(byte[] resultadoImagem) { this.resultadoImagem = resultadoImagem; }
+
+    public byte[] getResultadoVideo() { return resultadoVideo; }
+    public void setResultadoVideo(byte[] resultadoVideo) { this.resultadoVideo = resultadoVideo; }
+
+    public Integer getIdUsuario() { return idUsuario; }
+    public void setIdUsuario(Integer idUsuario) { this.idUsuario = idUsuario; }
+
+    public Integer getIdCategoria() { return idCategoria; }
+    public void setIdCategoria(Integer idCategoria) { this.idCategoria = idCategoria; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Caderno caderno = (Caderno) o;
+        return Objects.equals(idCaderno, caderno.idCaderno);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idCaderno);
+    }
+
+    @Override
+    public String toString() {
+        return "Caderno{" +
+                "idCaderno=" + idCaderno +
+                ", nomeIa='" + nomeIa + '\'' +
+                ", titulo='" + titulo + '\'' +
+                ", objetivo='" + objetivo + '\'' +
+                ", comando='" + comando + '\'' +
+                ", data=" + data +
+                ", idUsuario=" + idUsuario +
+                ", idCategoria=" + idCategoria +
+                '}';
+    }
+}

--- a/src/main/java/test/CadernoControllerTest.java
+++ b/src/main/java/test/CadernoControllerTest.java
@@ -1,0 +1,50 @@
+package test;
+
+import controller.CadernoController;
+import controller.CategoriaController;
+import controller.UsuarioController;
+import dao.impl.CadernoDaoNativeImpl;
+import dao.impl.CategoriaDaoNativeImpl;
+import dao.impl.UsuarioDaoNativeImpl;
+import model.Caderno;
+import model.Categoria;
+import model.Usuario;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class CadernoControllerTest {
+    public static void main(String[] args) {
+        CadernoController controller = new CadernoController(new CadernoDaoNativeImpl());
+        UsuarioController usuarioController = new UsuarioController(new UsuarioDaoNativeImpl());
+        CategoriaController categoriaController = new CategoriaController(new CategoriaDaoNativeImpl());
+
+        List<Usuario> usuarios = usuarioController.listar();
+        List<Categoria> categorias = categoriaController.listar();
+        if (usuarios.isEmpty() || categorias.isEmpty()) {
+            System.out.println("Necessário ter usuário e categoria cadastrados para o teste de Caderno");
+            return;
+        }
+        Usuario usuario = usuarios.get(0);
+        Categoria categoria = categorias.get(0);
+
+        Caderno caderno = new Caderno();
+        caderno.setTitulo("Resumo Diario");
+        caderno.setComando("Gerar resumo");
+        caderno.setData(LocalDate.now());
+        caderno.setNomeIa("Assistente");
+        caderno.setObjetivo("Organizar tarefas");
+        caderno.setResultado("Resumo gerado");
+        caderno.setIdUsuario(usuario.getIdUsuario());
+        caderno.setIdCategoria(categoria.getIdCategoria());
+        controller.criar(caderno);
+
+        List<Caderno> list = controller.listar();
+        if (!list.isEmpty()) {
+            Caderno buscado = list.get(0);
+            buscado.setResultado("Atualizado");
+            controller.atualizar(buscado);
+            controller.remover(buscado.getIdCaderno());
+        }
+    }
+}

--- a/src/main/java/test/TestSuite.java
+++ b/src/main/java/test/TestSuite.java
@@ -4,6 +4,7 @@ public class TestSuite {
     public static void main(String[] args) {
         UsuarioControllerTest.main(args);
         CarteiraControllerTest.main(args);
+        CadernoControllerTest.main(args);
         CategoriaControllerTest.main(args);
         PapelControllerTest.main(args);
         CaixaControllerTest.main(args);


### PR DESCRIPTION
## Summary
- add full data stack for the Caderno entity including model, DAO, controller, dialog, form and tests
- create dialogs and dashboard forms for Carteira, Meta, Site and Objeto mirroring the Cofre layout with filtering, metrics and CRUD actions
- wire the new screens into the dashboard menu/navigation and extend the controller test suite

## Testing
- `mvn -q test` *(fails: Maven could not download dependencies because the network is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cea2bedefc8325aa477a77ded837db