### PR TITLE
Fix category card icon to use existing constant

### DIFF
--- a/src/main/java/form/CadernoForm.java
+++ b/src/main/java/form/CadernoForm.java
@@ -99,7 +99,7 @@ public class CadernoForm extends JPanel {
         cardIas.setData(new ModelCard("Assistentes",0,0,iconIas));
         cards.add(cardIas);
 
-        iconCategorias = IconFontSwing.buildIcon(GoogleMaterialDesignIcons.CATEGORY, 60, Color.WHITE,
+        iconCategorias = IconFontSwing.buildIcon(GoogleMaterialDesignIcons.VIEW_LIST, 60, Color.WHITE,
                 new Color(255,255,255,15));
         cardCategorias = new Card();
         cardCategorias.setBackground(new Color(0,150,136));

--- a/src/main/java/form/ObjetoForm.java
+++ b/src/main/java/form/ObjetoForm.java
@@ -93,7 +93,7 @@ public class ObjetoForm extends JPanel {
         cardObjetos.setData(new ModelCard("Objetos",0,0,iconObjetos));
         cards.add(cardObjetos);
 
-        iconTipos = IconFontSwing.buildIcon(GoogleMaterialDesignIcons.CATEGORY, 60, Color.WHITE,
+        iconTipos = IconFontSwing.buildIcon(GoogleMaterialDesignIcons.VIEW_LIST, 60, Color.WHITE,
                 new Color(255,255,255,15));
         cardTipos = new Card();
         cardTipos.setBackground(new Color(156,39,176));


### PR DESCRIPTION
## Summary
- replace the unavailable GoogleMaterialDesignIcons.CATEGORY constant with VIEW_LIST in CadernoForm and ObjetoForm so the forms compile

## Testing
- mvn -q -DskipTests compile *(fails: network is unreachable while resolving maven-enforcer-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68cebb4307308325ac33481e6ada3b98