### PR TITLE
Add dashboard screens for Exercicio and related entities

### DIFF
--- a/src/main/java/component/Menu.java
+++ b/src/main/java/component/Menu.java
@@ -54,7 +54,7 @@ public class Menu extends javax.swing.JPanel {
     }
 
     public void initMenuItem() {
-        addMenu(new ModelMenu(new ImageIcon(getClass().getResource("/icon/1.png")), "Dashboard", "Home", "Usuario", "Categoria", "Evento", "Caixa", "Movimentacao", "Cofre", "Carteira", "Caderno", "Meta", "Site", "Objeto", "Papel"));
+        addMenu(new ModelMenu(new ImageIcon(getClass().getResource("/icon/1.png")), "Dashboard", "Home", "Usuario", "Categoria", "Evento", "Caixa", "Movimentacao", "Cofre", "Exercicio", "Rotina", "Fornecedor", "Ingrediente", "Monitoramento", "Carteira", "Caderno", "Meta", "Site", "Objeto", "Papel"));
         addMenu(new ModelMenu(new ImageIcon(getClass().getResource("/icon/3.png")), "Configuração", "Backup"));
         addMenu(new ModelMenu(new ImageIcon(getClass().getResource("/icon/4.png")), "Agendamento", "Job"));
         addMenu(new ModelMenu(new ImageIcon(getClass().getResource("/icon/2.png")), "Sair"));

--- a/src/main/java/form/ExercicioDialog.java
+++ b/src/main/java/form/ExercicioDialog.java
@@ -1,0 +1,148 @@
+package form;
+
+import java.awt.Color;
+import java.awt.Frame;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JSpinner;
+import javax.swing.JTextField;
+import javax.swing.SpinnerNumberModel;
+import javax.swing.JOptionPane;
+import model.Exercicio;
+import swing.Button;
+
+/** Dialog for creating or editing an {@link Exercicio}. */
+public class ExercicioDialog extends JDialog {
+
+    private Exercicio exercicio;
+    private boolean confirmed = false;
+
+    private JTextField txtId;
+    private JTextField txtNome;
+    private JSpinner spCargaLeve;
+    private JSpinner spCargaMedia;
+    private JSpinner spCargaMaxima;
+
+    public ExercicioDialog(Frame parent, Exercicio exercicio) {
+        super(parent, true);
+        this.exercicio = exercicio != null ? exercicio : new Exercicio();
+        initComponents();
+        setLocationRelativeTo(parent);
+        if (this.exercicio.getIdExercicio() != null) {
+            txtId.setText(String.valueOf(this.exercicio.getIdExercicio()));
+        }
+        if (this.exercicio.getNome() != null) {
+            txtNome.setText(this.exercicio.getNome());
+        }
+        if (this.exercicio.getCargaLeve() != null) {
+            spCargaLeve.setValue(this.exercicio.getCargaLeve());
+        }
+        if (this.exercicio.getCargaMedia() != null) {
+            spCargaMedia.setValue(this.exercicio.getCargaMedia());
+        }
+        if (this.exercicio.getCargaMaxima() != null) {
+            spCargaMaxima.setValue(this.exercicio.getCargaMaxima());
+        }
+    }
+
+    private void initComponents() {
+        setTitle("Exercício");
+        JPanel panel = new JPanel(new GridBagLayout());
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.insets = new Insets(5, 5, 5, 5);
+        gbc.anchor = GridBagConstraints.WEST;
+        int y = 0;
+
+        JLabel lblId = new JLabel("ID");
+        txtId = new JTextField(10);
+        txtId.setEditable(false);
+        gbc.gridx = 0;
+        gbc.gridy = y;
+        panel.add(lblId, gbc);
+        gbc.gridx = 1;
+        panel.add(txtId, gbc);
+        y++;
+
+        JLabel lblNome = new JLabel("Nome");
+        txtNome = new JTextField(20);
+        gbc.gridx = 0;
+        gbc.gridy = y;
+        panel.add(lblNome, gbc);
+        gbc.gridx = 1;
+        panel.add(txtNome, gbc);
+        y++;
+
+        JLabel lblCargaLeve = new JLabel("Carga leve");
+        spCargaLeve = new JSpinner(new SpinnerNumberModel(0, 0, 9999, 1));
+        gbc.gridx = 0;
+        gbc.gridy = y;
+        panel.add(lblCargaLeve, gbc);
+        gbc.gridx = 1;
+        panel.add(spCargaLeve, gbc);
+        y++;
+
+        JLabel lblCargaMedia = new JLabel("Carga média");
+        spCargaMedia = new JSpinner(new SpinnerNumberModel(0, 0, 9999, 1));
+        gbc.gridx = 0;
+        gbc.gridy = y;
+        panel.add(lblCargaMedia, gbc);
+        gbc.gridx = 1;
+        panel.add(spCargaMedia, gbc);
+        y++;
+
+        JLabel lblCargaMaxima = new JLabel("Carga máxima");
+        spCargaMaxima = new JSpinner(new SpinnerNumberModel(0, 0, 9999, 1));
+        gbc.gridx = 0;
+        gbc.gridy = y;
+        panel.add(lblCargaMaxima, gbc);
+        gbc.gridx = 1;
+        panel.add(spCargaMaxima, gbc);
+        y++;
+
+        Button btnSalvar = new Button();
+        btnSalvar.setText("Salvar");
+        btnSalvar.setBackground(new Color(75, 134, 253));
+        btnSalvar.setForeground(Color.WHITE);
+        btnSalvar.addActionListener(e -> salvar());
+
+        Button btnCancelar = new Button();
+        btnCancelar.setText("Cancelar");
+        btnCancelar.addActionListener(e -> dispose());
+
+        gbc.gridx = 0;
+        gbc.gridy = y;
+        panel.add(btnSalvar, gbc);
+        gbc.gridx = 1;
+        panel.add(btnCancelar, gbc);
+
+        getContentPane().add(panel);
+        pack();
+        getRootPane().setDefaultButton(btnSalvar);
+    }
+
+    private void salvar() {
+        String nome = txtNome.getText();
+        if (nome == null || nome.isEmpty()) {
+            JOptionPane.showMessageDialog(this, "Nome é obrigatório", "Aviso", JOptionPane.WARNING_MESSAGE);
+            return;
+        }
+        exercicio.setNome(nome);
+        exercicio.setCargaLeve(((Number) spCargaLeve.getValue()).intValue());
+        exercicio.setCargaMedia(((Number) spCargaMedia.getValue()).intValue());
+        exercicio.setCargaMaxima(((Number) spCargaMaxima.getValue()).intValue());
+        confirmed = true;
+        dispose();
+    }
+
+    public boolean isConfirmed() {
+        return confirmed;
+    }
+
+    public Exercicio getExercicio() {
+        return exercicio;
+    }
+}

--- a/src/main/java/form/ExercicioForm.java
+++ b/src/main/java/form/ExercicioForm.java
@@ -1,0 +1,379 @@
+package form;
+
+import component.Card;
+import controller.ExercicioController;
+import dao.impl.ExercicioDaoNativeImpl;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableCellRenderer;
+import model.Exercicio;
+import model.ModelCard;
+import swing.Button;
+import swing.ImageAvatar;
+import swing.icon.GoogleMaterialDesignIcons;
+import swing.icon.IconFontSwing;
+import swing.table.EventAction;
+import swing.table.ModelAction;
+import swing.table.Table;
+
+/**
+ * Formulário para gerenciamento de Exercícios.
+ */
+public class ExercicioForm extends JPanel {
+
+    private final ExercicioController controller;
+    private Card cardTotal;
+    private Card cardCargaMedia;
+    private Card cardCargaMaxima;
+    private Table table;
+    private JTextField txtBusca;
+    private Button btnLeve;
+    private Button btnMedia;
+    private Button btnMaxima;
+    private Button btnNovo;
+    private Integer filtroCarga;
+    private List<Exercicio> exercicios;
+    private List<Exercicio> filtrados;
+    private javax.swing.Icon iconTotal;
+    private javax.swing.Icon iconMedia;
+    private javax.swing.Icon iconMax;
+    private JButton btnPrevPage;
+    private JButton btnNextPage;
+    private int currentPage = 0;
+    private static final int PAGE_SIZE = 6;
+
+    public ExercicioForm() {
+        controller = new ExercicioController(new ExercicioDaoNativeImpl());
+        initComponents();
+        carregarExercicios();
+    }
+
+    private void initComponents() {
+        setLayout(new BorderLayout());
+        setBackground(Color.WHITE);
+
+        JPanel top = new JPanel(new BorderLayout());
+        top.setBackground(Color.WHITE);
+
+        JPanel cards = new JPanel(new java.awt.GridLayout(1, 3, 18, 0));
+        cards.setBackground(Color.WHITE);
+
+        iconTotal = IconFontSwing.buildIcon(GoogleMaterialDesignIcons.FITNESS_CENTER, 60, Color.WHITE,
+                new Color(255, 255, 255, 15));
+        cardTotal = new Card();
+        cardTotal.setBackground(new Color(33, 150, 243));
+        cardTotal.setColorGradient(new Color(30, 136, 229));
+        cardTotal.setData(new ModelCard("Exercícios", 0, 0, iconTotal));
+        cards.add(cardTotal);
+
+        iconMedia = IconFontSwing.buildIcon(GoogleMaterialDesignIcons.SHOW_CHART, 60, Color.WHITE,
+                new Color(255, 255, 255, 15));
+        cardCargaMedia = new Card();
+        cardCargaMedia.setBackground(new Color(102, 187, 106));
+        cardCargaMedia.setColorGradient(new Color(129, 199, 132));
+        cardCargaMedia.setData(new ModelCard("Carga média", 0, 0, iconMedia));
+        cards.add(cardCargaMedia);
+
+        iconMax = IconFontSwing.buildIcon(GoogleMaterialDesignIcons.FLASH_ON, 60, Color.WHITE,
+                new Color(255, 255, 255, 15));
+        cardCargaMaxima = new Card();
+        cardCargaMaxima.setBackground(new Color(255, 152, 0));
+        cardCargaMaxima.setColorGradient(new Color(255, 203, 107));
+        cardCargaMaxima.setData(new ModelCard("Carga máxima", 0, 0, iconMax));
+        cards.add(cardCargaMaxima);
+
+        top.add(cards, BorderLayout.NORTH);
+
+        JPanel filtroWrapper = new JPanel(new BorderLayout());
+        filtroWrapper.setBackground(Color.WHITE);
+
+        JPanel filtro = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        filtro.setBackground(Color.WHITE);
+
+        btnLeve = new Button();
+        btnLeve.setText("Leve");
+        btnLeve.setBackground(new Color(33, 150, 243));
+        btnLeve.setForeground(Color.WHITE);
+        btnLeve.addActionListener(e -> {
+            filtroCarga = 1;
+            aplicarFiltros();
+        });
+        filtro.add(btnLeve);
+
+        btnMedia = new Button();
+        btnMedia.setText("Média");
+        btnMedia.setBackground(new Color(102, 187, 106));
+        btnMedia.setForeground(Color.WHITE);
+        btnMedia.addActionListener(e -> {
+            filtroCarga = 2;
+            aplicarFiltros();
+        });
+        filtro.add(btnMedia);
+
+        btnMaxima = new Button();
+        btnMaxima.setText("Máxima");
+        btnMaxima.setBackground(new Color(255, 152, 0));
+        btnMaxima.setForeground(Color.BLACK);
+        btnMaxima.addActionListener(e -> {
+            filtroCarga = 3;
+            aplicarFiltros();
+        });
+        filtro.add(btnMaxima);
+
+        Button btnLimpar = new Button();
+        btnLimpar.setText("Todos");
+        btnLimpar.addActionListener(e -> {
+            filtroCarga = null;
+            aplicarFiltros();
+        });
+        filtro.add(btnLimpar);
+
+        txtBusca = new JTextField(15);
+        txtBusca.getDocument().addDocumentListener(new DocumentListener() {
+            @Override
+            public void insertUpdate(DocumentEvent e) {
+                aplicarFiltros();
+            }
+
+            @Override
+            public void removeUpdate(DocumentEvent e) {
+                aplicarFiltros();
+            }
+
+            @Override
+            public void changedUpdate(DocumentEvent e) {
+                aplicarFiltros();
+            }
+        });
+        filtro.add(new JLabel("Pesquisar:"));
+        filtro.add(txtBusca);
+
+        btnNovo = new Button();
+        btnNovo.setBackground(new Color(33, 150, 243));
+        btnNovo.setForeground(Color.WHITE);
+        btnNovo.setIcon(IconFontSwing.buildIcon(GoogleMaterialDesignIcons.ADD, 20, Color.WHITE));
+        btnNovo.setPreferredSize(new Dimension(30, 30));
+        btnNovo.addActionListener(e -> adicionarExercicio());
+        filtro.add(btnNovo);
+
+        filtroWrapper.add(filtro, BorderLayout.CENTER);
+        top.add(filtroWrapper, BorderLayout.CENTER);
+        add(top, BorderLayout.NORTH);
+
+        table = new Table();
+        table.setModel(new DefaultTableModel(new Object[][]{}, new String[]{
+            "Ícone", "Nome", "Carga leve", "Carga média", "Carga máxima", "Ações"
+        }) {
+            @Override
+            public boolean isCellEditable(int row, int column) {
+                return column == 5;
+            }
+
+            @Override
+            public Class<?> getColumnClass(int columnIndex) {
+                if (columnIndex == 0) {
+                    return ImageIcon.class;
+                }
+                return Object.class;
+            }
+        });
+        table.setRowHeight(40);
+        JScrollPane scroll = new JScrollPane(table);
+        table.fixTable(scroll);
+        table.setRowSelectionAllowed(false);
+        add(scroll, BorderLayout.CENTER);
+
+        btnPrevPage = new JButton("Anterior");
+        btnNextPage = new JButton("Próximo");
+        btnPrevPage.addActionListener(e -> {
+            if (currentPage > 0) {
+                currentPage--;
+                updatePage();
+            }
+        });
+        btnNextPage.addActionListener(e -> {
+            if ((currentPage + 1) * PAGE_SIZE < (filtrados != null ? filtrados.size() : 0)) {
+                currentPage++;
+                updatePage();
+            }
+        });
+        JPanel pagination = new JPanel(new FlowLayout(FlowLayout.CENTER));
+        pagination.setBackground(Color.WHITE);
+        pagination.add(btnPrevPage);
+        pagination.add(btnNextPage);
+        add(pagination, BorderLayout.SOUTH);
+    }
+
+    private void carregarExercicios() {
+        exercicios = controller.listar();
+        aplicarFiltros();
+    }
+
+    private void aplicarFiltros() {
+        if (exercicios == null) {
+            return;
+        }
+        String busca = txtBusca.getText();
+        String filtro = (busca != null && !busca.isEmpty()) ? busca.toLowerCase() : null;
+        filtrados = exercicios.stream()
+                .filter(e -> filtroCarga == null || filtraPorCarga(e))
+                .filter(e -> filtro == null || (e.getNome() != null && e.getNome().toLowerCase().contains(filtro)))
+                .collect(Collectors.toList());
+        atualizarCards(filtrados);
+        currentPage = 0;
+        updatePage();
+    }
+
+    private boolean filtraPorCarga(Exercicio e) {
+        if (filtroCarga == null) {
+            return true;
+        }
+        switch (filtroCarga) {
+            case 1:
+                return e.getCargaLeve() != null && e.getCargaLeve() > 0;
+            case 2:
+                return e.getCargaMedia() != null && e.getCargaMedia() > 0;
+            case 3:
+                return e.getCargaMaxima() != null && e.getCargaMaxima() > 0;
+            default:
+                return true;
+        }
+    }
+
+    private void atualizarCards(List<Exercicio> lista) {
+        int total = lista.size();
+        int media = lista.stream().mapToInt(e -> e.getCargaMedia() != null ? e.getCargaMedia() : 0).sum();
+        int maxima = lista.stream().mapToInt(e -> e.getCargaMaxima() != null ? e.getCargaMaxima() : 0).sum();
+        cardTotal.setData(new ModelCard("Exercícios", total, 0, iconTotal));
+        cardCargaMedia.setData(new ModelCard("Carga média", media, 0, iconMedia));
+        cardCargaMaxima.setData(new ModelCard("Carga máxima", maxima, 0, iconMax));
+    }
+
+    private void atualizarTabela(List<Exercicio> lista) {
+        DefaultTableModel model = (DefaultTableModel) table.getModel();
+        model.setRowCount(0);
+        EventAction<Exercicio> eventAction = new EventAction<Exercicio>() {
+            @Override
+            public void delete(Exercicio e) {
+                excluirExercicio(e);
+            }
+
+            @Override
+            public void update(Exercicio e) {
+                editarExercicio(e);
+            }
+        };
+        ImageIcon avatarIcon = (ImageIcon) IconFontSwing.buildIcon(GoogleMaterialDesignIcons.FITNESS_CENTER, 35, Color.WHITE,
+                new Color(33, 150, 243, 80));
+        for (Exercicio e : lista) {
+            model.addRow(new Object[]{
+                avatarIcon,
+                e.getNome(),
+                valorOuVazio(e.getCargaLeve()),
+                valorOuVazio(e.getCargaMedia()),
+                valorOuVazio(e.getCargaMaxima()),
+                new ModelAction<>(e, eventAction)
+            });
+        }
+        table.getColumnModel().getColumn(0).setCellRenderer(new TableCellRenderer() {
+            @Override
+            public Component getTableCellRendererComponent(JTable tbl, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+                ImageAvatar avatar = new ImageAvatar();
+                avatar.setPreferredSize(new Dimension(40, 40));
+                if (value instanceof ImageIcon) {
+                    avatar.setIcon((ImageIcon) value);
+                }
+                return avatar;
+            }
+        });
+    }
+
+    private void updatePage() {
+        List<Exercicio> page = getCurrentPage();
+        atualizarTabela(page);
+        updatePaginationButtons();
+    }
+
+    private List<Exercicio> getCurrentPage() {
+        if (filtrados == null) {
+            return Collections.emptyList();
+        }
+        int start = currentPage * PAGE_SIZE;
+        int end = Math.min(start + PAGE_SIZE, filtrados.size());
+        return filtrados.subList(start, end);
+    }
+
+    private void updatePaginationButtons() {
+        int size = filtrados != null ? filtrados.size() : 0;
+        btnPrevPage.setEnabled(currentPage > 0);
+        btnNextPage.setEnabled((currentPage + 1) * PAGE_SIZE < size);
+    }
+
+    private void adicionarExercicio() {
+        Frame frame = (Frame) SwingUtilities.getWindowAncestor(this);
+        ExercicioDialog dialog = new ExercicioDialog(frame, null);
+        dialog.setVisible(true);
+        if (dialog.isConfirmed()) {
+            try {
+                controller.criar(dialog.getExercicio());
+                carregarExercicios();
+            } catch (Exception ex) {
+                JOptionPane.showMessageDialog(this, ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+
+    private void editarExercicio(Exercicio e) {
+        try {
+            Exercicio completo = controller.buscarPorId(e.getIdExercicio());
+            Frame frame = (Frame) SwingUtilities.getWindowAncestor(this);
+            ExercicioDialog dialog = new ExercicioDialog(frame, completo);
+            dialog.setVisible(true);
+            if (dialog.isConfirmed()) {
+                try {
+                    controller.atualizar(dialog.getExercicio());
+                    carregarExercicios();
+                } catch (Exception ex) {
+                    JOptionPane.showMessageDialog(this, ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+                }
+            }
+        } catch (Exception ex) {
+            JOptionPane.showMessageDialog(this, ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+        }
+    }
+
+    private void excluirExercicio(Exercicio e) {
+        int opt = JOptionPane.showConfirmDialog(this, "Excluir exercício?", "Confirmação", JOptionPane.YES_NO_OPTION);
+        if (opt == JOptionPane.YES_OPTION) {
+            try {
+                controller.remover(e.getIdExercicio());
+                carregarExercicios();
+            } catch (Exception ex) {
+                JOptionPane.showMessageDialog(this, ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+
+    private Object valorOuVazio(Integer valor) {
+        return valor == null ? "" : valor;
+    }
+}

--- a/src/main/java/form/FornecedorDialog.java
+++ b/src/main/java/form/FornecedorDialog.java
@@ -1,0 +1,186 @@
+package form;
+
+import java.awt.Color;
+import java.awt.Frame;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import javax.swing.JCheckBox;
+import javax.swing.JDialog;
+import javax.swing.JFileChooser;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import model.Fornecedor;
+import swing.Button;
+import swing.ImageAvatar;
+import util.ImageUtils;
+
+/** Dialog for creating or editing a {@link Fornecedor}. */
+public class FornecedorDialog extends JDialog {
+
+    private Fornecedor fornecedor;
+    private boolean confirmed;
+
+    private JTextField txtId;
+    private JTextField txtNome;
+    private JTextField txtEndereco;
+    private JCheckBox chkOnline;
+    private ImageAvatar avatar;
+    private byte[] fotoSelecionada;
+
+    public FornecedorDialog(Frame parent, Fornecedor fornecedor) {
+        super(parent, true);
+        this.fornecedor = fornecedor != null ? fornecedor : new Fornecedor();
+        this.fotoSelecionada = this.fornecedor.getFoto();
+        initComponents();
+        setLocationRelativeTo(parent);
+        preencherCampos();
+    }
+
+    private void preencherCampos() {
+        if (fornecedor.getIdFornecedor() != null) {
+            txtId.setText(String.valueOf(fornecedor.getIdFornecedor()));
+        }
+        if (fornecedor.getNome() != null) {
+            txtNome.setText(fornecedor.getNome());
+        }
+        if (fornecedor.getEndereco() != null) {
+            txtEndereco.setText(fornecedor.getEndereco());
+        }
+        if (fornecedor.getOnline() != null) {
+            chkOnline.setSelected(fornecedor.getOnline());
+        }
+        atualizarAvatar();
+    }
+
+    private void initComponents() {
+        setTitle("Fornecedor");
+        JPanel panel = new JPanel(new GridBagLayout());
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.insets = new Insets(5, 5, 5, 5);
+        gbc.anchor = GridBagConstraints.WEST;
+        int y = 0;
+
+        JLabel lblId = new JLabel("ID");
+        txtId = new JTextField(10);
+        txtId.setEditable(false);
+        gbc.gridx = 0;
+        gbc.gridy = y;
+        panel.add(lblId, gbc);
+        gbc.gridx = 1;
+        panel.add(txtId, gbc);
+        y++;
+
+        JLabel lblNome = new JLabel("Nome");
+        txtNome = new JTextField(20);
+        gbc.gridx = 0;
+        gbc.gridy = y;
+        panel.add(lblNome, gbc);
+        gbc.gridx = 1;
+        panel.add(txtNome, gbc);
+        y++;
+
+        JLabel lblEndereco = new JLabel("Endereço");
+        txtEndereco = new JTextField(20);
+        gbc.gridx = 0;
+        gbc.gridy = y;
+        panel.add(lblEndereco, gbc);
+        gbc.gridx = 1;
+        panel.add(txtEndereco, gbc);
+        y++;
+
+        JLabel lblOnline = new JLabel("Online");
+        chkOnline = new JCheckBox();
+        gbc.gridx = 0;
+        gbc.gridy = y;
+        panel.add(lblOnline, gbc);
+        gbc.gridx = 1;
+        panel.add(chkOnline, gbc);
+        y++;
+
+        JLabel lblFoto = new JLabel("Foto");
+        avatar = new ImageAvatar();
+        avatar.setPreferredSize(new java.awt.Dimension(80, 80));
+        Button btnSelecionar = new Button();
+        btnSelecionar.setText("Selecionar foto");
+        btnSelecionar.addActionListener(e -> selecionarFoto());
+        gbc.gridx = 0;
+        gbc.gridy = y;
+        panel.add(lblFoto, gbc);
+        gbc.gridx = 1;
+        panel.add(avatar, gbc);
+        y++;
+        gbc.gridx = 1;
+        panel.add(btnSelecionar, gbc);
+        y++;
+
+        Button btnSalvar = new Button();
+        btnSalvar.setText("Salvar");
+        btnSalvar.setBackground(new Color(75, 134, 253));
+        btnSalvar.setForeground(Color.WHITE);
+        btnSalvar.addActionListener(e -> salvar());
+
+        Button btnCancelar = new Button();
+        btnCancelar.setText("Cancelar");
+        btnCancelar.addActionListener(e -> dispose());
+
+        gbc.gridx = 0;
+        gbc.gridy = y;
+        panel.add(btnSalvar, gbc);
+        gbc.gridx = 1;
+        panel.add(btnCancelar, gbc);
+
+        getContentPane().add(panel);
+        pack();
+        getRootPane().setDefaultButton(btnSalvar);
+    }
+
+    private void selecionarFoto() {
+        JFileChooser chooser = new JFileChooser();
+        int result = chooser.showOpenDialog(this);
+        if (result == JFileChooser.APPROVE_OPTION) {
+            File file = chooser.getSelectedFile();
+            try {
+                fotoSelecionada = Files.readAllBytes(file.toPath());
+                atualizarAvatar();
+            } catch (IOException ex) {
+                JOptionPane.showMessageDialog(this, "Não foi possível carregar a imagem", "Erro", JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+
+    private void atualizarAvatar() {
+        if (fotoSelecionada != null) {
+            avatar.setIcon(ImageUtils.bytesToImageIcon(fotoSelecionada));
+        } else {
+            avatar.setIcon(new javax.swing.ImageIcon(getClass().getResource("/icon/profile.jpg")));
+        }
+    }
+
+    private void salvar() {
+        String nome = txtNome.getText();
+        if (nome == null || nome.isEmpty()) {
+            JOptionPane.showMessageDialog(this, "Nome é obrigatório", "Aviso", JOptionPane.WARNING_MESSAGE);
+            return;
+        }
+        fornecedor.setNome(nome);
+        fornecedor.setEndereco(txtEndereco.getText());
+        fornecedor.setOnline(chkOnline.isSelected());
+        fornecedor.setFoto(fotoSelecionada);
+        confirmed = true;
+        dispose();
+    }
+
+    public boolean isConfirmed() {
+        return confirmed;
+    }
+
+    public Fornecedor getFornecedor() {
+        return fornecedor;
+    }
+}

--- a/src/main/java/form/FornecedorForm.java
+++ b/src/main/java/form/FornecedorForm.java
@@ -1,0 +1,384 @@
+package form;
+
+import component.Card;
+import controller.FornecedorController;
+import dao.impl.FornecedorDaoNativeImpl;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableCellRenderer;
+import model.Fornecedor;
+import model.ModelCard;
+import swing.Button;
+import swing.ImageAvatar;
+import swing.icon.GoogleMaterialDesignIcons;
+import swing.icon.IconFontSwing;
+import swing.table.EventAction;
+import swing.table.ModelAction;
+import swing.table.Table;
+import util.ImageUtils;
+
+/**
+ * Formulário para gerenciamento de Fornecedores.
+ */
+public class FornecedorForm extends JPanel {
+
+    private final FornecedorController controller;
+    private Card cardTotal;
+    private Card cardOnline;
+    private Card cardOffline;
+    private Table table;
+    private JTextField txtBusca;
+    private Button btnTodos;
+    private Button btnOnline;
+    private Button btnOffline;
+    private Button btnNovo;
+    private Boolean filtroOnline;
+    private List<Fornecedor> fornecedores;
+    private List<Fornecedor> filtrados;
+    private javax.swing.Icon iconTotal;
+    private javax.swing.Icon iconOnline;
+    private javax.swing.Icon iconOffline;
+    private JButton btnPrevPage;
+    private JButton btnNextPage;
+    private int currentPage = 0;
+    private static final int PAGE_SIZE = 6;
+
+    public FornecedorForm() {
+        controller = new FornecedorController(new FornecedorDaoNativeImpl());
+        initComponents();
+        carregarFornecedores();
+    }
+
+    private void initComponents() {
+        setLayout(new BorderLayout());
+        setBackground(Color.WHITE);
+
+        JPanel top = new JPanel(new BorderLayout());
+        top.setBackground(Color.WHITE);
+
+        JPanel cards = new JPanel(new java.awt.GridLayout(1, 3, 18, 0));
+        cards.setBackground(Color.WHITE);
+
+        iconTotal = IconFontSwing.buildIcon(GoogleMaterialDesignIcons.SHOPPING_CART, 60, Color.WHITE,
+                new Color(255, 255, 255, 15));
+        cardTotal = new Card();
+        cardTotal.setBackground(new Color(63, 81, 181));
+        cardTotal.setColorGradient(new Color(92, 107, 192));
+        cardTotal.setData(new ModelCard("Fornecedores", 0, 0, iconTotal));
+        cards.add(cardTotal);
+
+        iconOnline = IconFontSwing.buildIcon(GoogleMaterialDesignIcons.WIFI, 60, Color.WHITE,
+                new Color(255, 255, 255, 15));
+        cardOnline = new Card();
+        cardOnline.setBackground(new Color(76, 175, 80));
+        cardOnline.setColorGradient(new Color(129, 199, 132));
+        cardOnline.setData(new ModelCard("Online", 0, 0, iconOnline));
+        cards.add(cardOnline);
+
+        iconOffline = IconFontSwing.buildIcon(GoogleMaterialDesignIcons.PORTABLE_WIFI_OFF, 60, Color.WHITE,
+                new Color(255, 255, 255, 15));
+        cardOffline = new Card();
+        cardOffline.setBackground(new Color(244, 67, 54));
+        cardOffline.setColorGradient(new Color(239, 83, 80));
+        cardOffline.setData(new ModelCard("Offline", 0, 0, iconOffline));
+        cards.add(cardOffline);
+
+        top.add(cards, BorderLayout.NORTH);
+
+        JPanel filtroWrapper = new JPanel(new BorderLayout());
+        filtroWrapper.setBackground(Color.WHITE);
+
+        JPanel filtro = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        filtro.setBackground(Color.WHITE);
+
+        btnTodos = new Button();
+        btnTodos.setText("Todos");
+        btnTodos.setBackground(new Color(63, 81, 181));
+        btnTodos.setForeground(Color.WHITE);
+        btnTodos.addActionListener(e -> {
+            filtroOnline = null;
+            aplicarFiltros();
+        });
+        filtro.add(btnTodos);
+
+        btnOnline = new Button();
+        btnOnline.setText("Online");
+        btnOnline.setBackground(new Color(76, 175, 80));
+        btnOnline.setForeground(Color.WHITE);
+        btnOnline.addActionListener(e -> {
+            filtroOnline = Boolean.TRUE;
+            aplicarFiltros();
+        });
+        filtro.add(btnOnline);
+
+        btnOffline = new Button();
+        btnOffline.setText("Offline");
+        btnOffline.setBackground(new Color(158, 158, 158));
+        btnOffline.setForeground(Color.BLACK);
+        btnOffline.addActionListener(e -> {
+            filtroOnline = Boolean.FALSE;
+            aplicarFiltros();
+        });
+        filtro.add(btnOffline);
+
+        txtBusca = new JTextField(15);
+        txtBusca.getDocument().addDocumentListener(new DocumentListener() {
+            @Override
+            public void insertUpdate(DocumentEvent e) {
+                aplicarFiltros();
+            }
+
+            @Override
+            public void removeUpdate(DocumentEvent e) {
+                aplicarFiltros();
+            }
+
+            @Override
+            public void changedUpdate(DocumentEvent e) {
+                aplicarFiltros();
+            }
+        });
+        filtro.add(new JLabel("Pesquisar:"));
+        filtro.add(txtBusca);
+
+        btnNovo = new Button();
+        btnNovo.setBackground(new Color(63, 81, 181));
+        btnNovo.setForeground(Color.WHITE);
+        btnNovo.setIcon(IconFontSwing.buildIcon(GoogleMaterialDesignIcons.ADD, 20, Color.WHITE));
+        btnNovo.setPreferredSize(new Dimension(30, 30));
+        btnNovo.addActionListener(e -> adicionarFornecedor());
+        filtro.add(btnNovo);
+
+        filtroWrapper.add(filtro, BorderLayout.CENTER);
+        top.add(filtroWrapper, BorderLayout.CENTER);
+        add(top, BorderLayout.NORTH);
+
+        table = new Table();
+        table.setModel(new DefaultTableModel(new Object[][]{}, new String[]{
+            "Foto", "Nome", "Endereço", "Status", "Ações"
+        }) {
+            @Override
+            public boolean isCellEditable(int row, int column) {
+                return column == 4;
+            }
+
+            @Override
+            public Class<?> getColumnClass(int columnIndex) {
+                return columnIndex == 0 ? ImageIcon.class : Object.class;
+            }
+        });
+        table.setRowHeight(40);
+        JScrollPane scroll = new JScrollPane(table);
+        table.fixTable(scroll);
+        table.setRowSelectionAllowed(false);
+        add(scroll, BorderLayout.CENTER);
+
+        btnPrevPage = new JButton("Anterior");
+        btnNextPage = new JButton("Próximo");
+        btnPrevPage.addActionListener(e -> {
+            if (currentPage > 0) {
+                currentPage--;
+                updatePage();
+            }
+        });
+        btnNextPage.addActionListener(e -> {
+            if ((currentPage + 1) * PAGE_SIZE < (filtrados != null ? filtrados.size() : 0)) {
+                currentPage++;
+                updatePage();
+            }
+        });
+        JPanel pagination = new JPanel(new FlowLayout(FlowLayout.CENTER));
+        pagination.setBackground(Color.WHITE);
+        pagination.add(btnPrevPage);
+        pagination.add(btnNextPage);
+        add(pagination, BorderLayout.SOUTH);
+    }
+
+    private void carregarFornecedores() {
+        fornecedores = controller.listar();
+        aplicarFiltros();
+    }
+
+    private void aplicarFiltros() {
+        if (fornecedores == null) {
+            return;
+        }
+        String busca = txtBusca.getText();
+        String filtro = (busca != null && !busca.isEmpty()) ? busca.toLowerCase() : null;
+        filtrados = fornecedores.stream()
+                .filter(f -> filtroOnline == null || (f.getOnline() != null && filtroOnline.equals(f.getOnline())))
+                .filter(f -> filtro == null || matchesBusca(f, filtro))
+                .collect(Collectors.toList());
+        atualizarCards(filtrados);
+        currentPage = 0;
+        updatePage();
+    }
+
+    private boolean matchesBusca(Fornecedor f, String filtro) {
+        return (f.getNome() != null && f.getNome().toLowerCase().contains(filtro))
+                || (f.getEndereco() != null && f.getEndereco().toLowerCase().contains(filtro));
+    }
+
+    private void atualizarCards(List<Fornecedor> lista) {
+        long online = lista.stream().filter(f -> Boolean.TRUE.equals(f.getOnline())).count();
+        long offline = lista.stream().filter(f -> Boolean.FALSE.equals(f.getOnline())).count();
+        cardTotal.setData(new ModelCard("Fornecedores", lista.size(), 0, iconTotal));
+        cardOnline.setData(new ModelCard("Online", (int) online, 0, iconOnline));
+        cardOffline.setData(new ModelCard("Offline", (int) offline, 0, iconOffline));
+    }
+
+    private void atualizarTabela(List<Fornecedor> lista) {
+        DefaultTableModel model = (DefaultTableModel) table.getModel();
+        model.setRowCount(0);
+        EventAction<Fornecedor> eventAction = new EventAction<Fornecedor>() {
+            @Override
+            public void delete(Fornecedor f) {
+                excluirFornecedor(f);
+            }
+
+            @Override
+            public void update(Fornecedor f) {
+                editarFornecedor(f);
+            }
+        };
+        for (Fornecedor f : lista) {
+            ImageIcon icon = ImageUtils.bytesToImageIcon(f.getFoto());
+            if (icon == null) {
+                icon = new ImageIcon(getClass().getResource("/icon/profile.jpg"));
+            }
+            model.addRow(new Object[]{
+                icon,
+                f.getNome(),
+                f.getEndereco(),
+                statusTexto(f.getOnline()),
+                new ModelAction<>(f, eventAction)
+            });
+        }
+        table.getColumnModel().getColumn(0).setCellRenderer(new TableCellRenderer() {
+            @Override
+            public Component getTableCellRendererComponent(JTable tbl, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+                ImageAvatar avatar = new ImageAvatar();
+                avatar.setPreferredSize(new Dimension(40, 40));
+                if (value instanceof ImageIcon) {
+                    avatar.setIcon((ImageIcon) value);
+                }
+                return avatar;
+            }
+        });
+        int statusCol = table.getColumnModel().getColumnCount() - 2;
+        table.getColumnModel().getColumn(statusCol).setCellRenderer(new TableCellRenderer() {
+            @Override
+            public Component getTableCellRendererComponent(JTable tbl, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+                Button lbl = new Button();
+                lbl.setText(value == null ? "" : value.toString());
+                lbl.setBorderPainted(false);
+                lbl.setFocusPainted(false);
+                lbl.setContentAreaFilled(true);
+                lbl.setPreferredSize(new Dimension(80, 28));
+                if ("Online".equals(value)) {
+                    lbl.setBackground(new Color(76, 175, 80));
+                    lbl.setForeground(Color.WHITE);
+                } else if ("Offline".equals(value)) {
+                    lbl.setBackground(new Color(158, 158, 158));
+                    lbl.setForeground(Color.BLACK);
+                } else {
+                    lbl.setBackground(new Color(189, 189, 189));
+                    lbl.setForeground(Color.BLACK);
+                }
+                return lbl;
+            }
+        });
+    }
+
+    private void updatePage() {
+        List<Fornecedor> page = getCurrentPage();
+        atualizarTabela(page);
+        updatePaginationButtons();
+    }
+
+    private List<Fornecedor> getCurrentPage() {
+        if (filtrados == null) {
+            return Collections.emptyList();
+        }
+        int start = currentPage * PAGE_SIZE;
+        int end = Math.min(start + PAGE_SIZE, filtrados.size());
+        return filtrados.subList(start, end);
+    }
+
+    private void updatePaginationButtons() {
+        int size = filtrados != null ? filtrados.size() : 0;
+        btnPrevPage.setEnabled(currentPage > 0);
+        btnNextPage.setEnabled((currentPage + 1) * PAGE_SIZE < size);
+    }
+
+    private void adicionarFornecedor() {
+        Frame frame = (Frame) SwingUtilities.getWindowAncestor(this);
+        FornecedorDialog dialog = new FornecedorDialog(frame, null);
+        dialog.setVisible(true);
+        if (dialog.isConfirmed()) {
+            try {
+                controller.criar(dialog.getFornecedor());
+                carregarFornecedores();
+            } catch (Exception ex) {
+                JOptionPane.showMessageDialog(this, ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+
+    private void editarFornecedor(Fornecedor f) {
+        try {
+            Fornecedor completo = controller.buscarComFotoPorId(f.getIdFornecedor());
+            Frame frame = (Frame) SwingUtilities.getWindowAncestor(this);
+            FornecedorDialog dialog = new FornecedorDialog(frame, completo);
+            dialog.setVisible(true);
+            if (dialog.isConfirmed()) {
+                try {
+                    controller.atualizar(dialog.getFornecedor());
+                    carregarFornecedores();
+                } catch (Exception ex) {
+                    JOptionPane.showMessageDialog(this, ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+                }
+            }
+        } catch (Exception ex) {
+            JOptionPane.showMessageDialog(this, ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+        }
+    }
+
+    private void excluirFornecedor(Fornecedor f) {
+        int opt = JOptionPane.showConfirmDialog(this, "Excluir fornecedor?", "Confirmação", JOptionPane.YES_NO_OPTION);
+        if (opt == JOptionPane.YES_OPTION) {
+            try {
+                controller.remover(f.getIdFornecedor());
+                carregarFornecedores();
+            } catch (Exception ex) {
+                JOptionPane.showMessageDialog(this, ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+
+    private String statusTexto(Boolean online) {
+        if (online == null) {
+            return "Indefinido";
+        }
+        return online ? "Online" : "Offline";
+    }
+}

--- a/src/main/java/form/IngredienteDialog.java
+++ b/src/main/java/form/IngredienteDialog.java
@@ -1,0 +1,174 @@
+package form;
+
+import java.awt.Color;
+import java.awt.Frame;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import javax.swing.JDialog;
+import javax.swing.JFileChooser;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import javax.swing.JTextField;
+import model.Ingrediente;
+import swing.Button;
+import swing.ImageAvatar;
+import util.ImageUtils;
+
+/** Dialog for creating or editing an {@link Ingrediente}. */
+public class IngredienteDialog extends JDialog {
+
+    private Ingrediente ingrediente;
+    private boolean confirmed;
+
+    private JTextField txtId;
+    private JTextField txtNome;
+    private JTextArea txtDescricao;
+    private ImageAvatar avatar;
+    private byte[] fotoSelecionada;
+
+    public IngredienteDialog(Frame parent, Ingrediente ingrediente) {
+        super(parent, true);
+        this.ingrediente = ingrediente != null ? ingrediente : new Ingrediente();
+        this.fotoSelecionada = this.ingrediente.getFoto();
+        initComponents();
+        setLocationRelativeTo(parent);
+        preencherCampos();
+    }
+
+    private void preencherCampos() {
+        if (ingrediente.getIdIngrediente() != null) {
+            txtId.setText(String.valueOf(ingrediente.getIdIngrediente()));
+        }
+        if (ingrediente.getNome() != null) {
+            txtNome.setText(ingrediente.getNome());
+        }
+        if (ingrediente.getDescricao() != null) {
+            txtDescricao.setText(ingrediente.getDescricao());
+        }
+        atualizarAvatar();
+    }
+
+    private void initComponents() {
+        setTitle("Ingrediente");
+        JPanel panel = new JPanel(new GridBagLayout());
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.insets = new Insets(5, 5, 5, 5);
+        gbc.anchor = GridBagConstraints.WEST;
+        int y = 0;
+
+        JLabel lblId = new JLabel("ID");
+        txtId = new JTextField(10);
+        txtId.setEditable(false);
+        gbc.gridx = 0;
+        gbc.gridy = y;
+        panel.add(lblId, gbc);
+        gbc.gridx = 1;
+        panel.add(txtId, gbc);
+        y++;
+
+        JLabel lblNome = new JLabel("Nome");
+        txtNome = new JTextField(20);
+        gbc.gridx = 0;
+        gbc.gridy = y;
+        panel.add(lblNome, gbc);
+        gbc.gridx = 1;
+        panel.add(txtNome, gbc);
+        y++;
+
+        JLabel lblDescricao = new JLabel("Descrição");
+        txtDescricao = new JTextArea(4, 20);
+        JScrollPane scroll = new JScrollPane(txtDescricao);
+        gbc.gridx = 0;
+        gbc.gridy = y;
+        panel.add(lblDescricao, gbc);
+        gbc.gridx = 1;
+        panel.add(scroll, gbc);
+        y++;
+
+        JLabel lblFoto = new JLabel("Foto");
+        avatar = new ImageAvatar();
+        avatar.setPreferredSize(new java.awt.Dimension(80, 80));
+        Button btnSelecionar = new Button();
+        btnSelecionar.setText("Selecionar foto");
+        btnSelecionar.addActionListener(e -> selecionarFoto());
+        gbc.gridx = 0;
+        gbc.gridy = y;
+        panel.add(lblFoto, gbc);
+        gbc.gridx = 1;
+        panel.add(avatar, gbc);
+        y++;
+        gbc.gridx = 1;
+        panel.add(btnSelecionar, gbc);
+        y++;
+
+        Button btnSalvar = new Button();
+        btnSalvar.setText("Salvar");
+        btnSalvar.setBackground(new Color(75, 134, 253));
+        btnSalvar.setForeground(Color.WHITE);
+        btnSalvar.addActionListener(e -> salvar());
+
+        Button btnCancelar = new Button();
+        btnCancelar.setText("Cancelar");
+        btnCancelar.addActionListener(e -> dispose());
+
+        gbc.gridx = 0;
+        gbc.gridy = y;
+        panel.add(btnSalvar, gbc);
+        gbc.gridx = 1;
+        panel.add(btnCancelar, gbc);
+
+        getContentPane().add(panel);
+        pack();
+        getRootPane().setDefaultButton(btnSalvar);
+    }
+
+    private void selecionarFoto() {
+        JFileChooser chooser = new JFileChooser();
+        int result = chooser.showOpenDialog(this);
+        if (result == JFileChooser.APPROVE_OPTION) {
+            File file = chooser.getSelectedFile();
+            try {
+                fotoSelecionada = Files.readAllBytes(file.toPath());
+                atualizarAvatar();
+            } catch (IOException ex) {
+                JOptionPane.showMessageDialog(this, "Não foi possível carregar a imagem", "Erro", JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+
+    private void atualizarAvatar() {
+        if (fotoSelecionada != null) {
+            avatar.setIcon(ImageUtils.bytesToImageIcon(fotoSelecionada));
+        } else {
+            avatar.setIcon(new javax.swing.ImageIcon(getClass().getResource("/icon/profile.jpg")));
+        }
+    }
+
+    private void salvar() {
+        String nome = txtNome.getText();
+        if (nome == null || nome.isEmpty()) {
+            JOptionPane.showMessageDialog(this, "Nome é obrigatório", "Aviso", JOptionPane.WARNING_MESSAGE);
+            return;
+        }
+        ingrediente.setNome(nome);
+        ingrediente.setDescricao(txtDescricao.getText());
+        ingrediente.setFoto(fotoSelecionada);
+        confirmed = true;
+        dispose();
+    }
+
+    public boolean isConfirmed() {
+        return confirmed;
+    }
+
+    public Ingrediente getIngrediente() {
+        return ingrediente;
+    }
+}

--- a/src/main/java/form/IngredienteForm.java
+++ b/src/main/java/form/IngredienteForm.java
@@ -1,0 +1,367 @@
+package form;
+
+import component.Card;
+import controller.IngredienteController;
+import dao.impl.IngredienteDaoNativeImpl;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableCellRenderer;
+import model.Ingrediente;
+import model.ModelCard;
+import swing.Button;
+import swing.ImageAvatar;
+import swing.icon.GoogleMaterialDesignIcons;
+import swing.icon.IconFontSwing;
+import swing.table.EventAction;
+import swing.table.ModelAction;
+import swing.table.Table;
+import util.ImageUtils;
+
+/**
+ * Formulário para gerenciamento de Ingredientes.
+ */
+public class IngredienteForm extends JPanel {
+
+    private final IngredienteController controller;
+    private Card cardTotal;
+    private Card cardComFoto;
+    private Card cardSemFoto;
+    private Table table;
+    private JTextField txtBusca;
+    private Button btnTodos;
+    private Button btnComFoto;
+    private Button btnSemFoto;
+    private Button btnNovo;
+    private Integer filtroFoto; // 1 = com foto, 2 = sem foto
+    private List<Ingrediente> ingredientes;
+    private List<Ingrediente> filtrados;
+    private javax.swing.Icon iconTotal;
+    private javax.swing.Icon iconComFoto;
+    private javax.swing.Icon iconSemFoto;
+    private JButton btnPrevPage;
+    private JButton btnNextPage;
+    private int currentPage = 0;
+    private static final int PAGE_SIZE = 6;
+
+    public IngredienteForm() {
+        controller = new IngredienteController(new IngredienteDaoNativeImpl());
+        initComponents();
+        carregarIngredientes();
+    }
+
+    private void initComponents() {
+        setLayout(new BorderLayout());
+        setBackground(Color.WHITE);
+
+        JPanel top = new JPanel(new BorderLayout());
+        top.setBackground(Color.WHITE);
+
+        JPanel cards = new JPanel(new java.awt.GridLayout(1, 3, 18, 0));
+        cards.setBackground(Color.WHITE);
+
+        iconTotal = IconFontSwing.buildIcon(GoogleMaterialDesignIcons.LOCAL_DINING, 60, Color.WHITE,
+                new Color(255, 255, 255, 15));
+        cardTotal = new Card();
+        cardTotal.setBackground(new Color(63, 81, 181));
+        cardTotal.setColorGradient(new Color(92, 107, 192));
+        cardTotal.setData(new ModelCard("Ingredientes", 0, 0, iconTotal));
+        cards.add(cardTotal);
+
+        iconComFoto = IconFontSwing.buildIcon(GoogleMaterialDesignIcons.PHOTO_CAMERA, 60, Color.WHITE,
+                new Color(255, 255, 255, 15));
+        cardComFoto = new Card();
+        cardComFoto.setBackground(new Color(76, 175, 80));
+        cardComFoto.setColorGradient(new Color(129, 199, 132));
+        cardComFoto.setData(new ModelCard("Com foto", 0, 0, iconComFoto));
+        cards.add(cardComFoto);
+
+        iconSemFoto = IconFontSwing.buildIcon(GoogleMaterialDesignIcons.IMAGE_NOT_SUPPORTED, 60, Color.WHITE,
+                new Color(255, 255, 255, 15));
+        cardSemFoto = new Card();
+        cardSemFoto.setBackground(new Color(255, 152, 0));
+        cardSemFoto.setColorGradient(new Color(255, 203, 107));
+        cardSemFoto.setData(new ModelCard("Sem foto", 0, 0, iconSemFoto));
+        cards.add(cardSemFoto);
+
+        top.add(cards, BorderLayout.NORTH);
+
+        JPanel filtroWrapper = new JPanel(new BorderLayout());
+        filtroWrapper.setBackground(Color.WHITE);
+
+        JPanel filtro = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        filtro.setBackground(Color.WHITE);
+
+        btnTodos = new Button();
+        btnTodos.setText("Todos");
+        btnTodos.setBackground(new Color(63, 81, 181));
+        btnTodos.setForeground(Color.WHITE);
+        btnTodos.addActionListener(e -> {
+            filtroFoto = null;
+            aplicarFiltros();
+        });
+        filtro.add(btnTodos);
+
+        btnComFoto = new Button();
+        btnComFoto.setText("Com foto");
+        btnComFoto.setBackground(new Color(76, 175, 80));
+        btnComFoto.setForeground(Color.WHITE);
+        btnComFoto.addActionListener(e -> {
+            filtroFoto = 1;
+            aplicarFiltros();
+        });
+        filtro.add(btnComFoto);
+
+        btnSemFoto = new Button();
+        btnSemFoto.setText("Sem foto");
+        btnSemFoto.setBackground(new Color(255, 152, 0));
+        btnSemFoto.setForeground(Color.BLACK);
+        btnSemFoto.addActionListener(e -> {
+            filtroFoto = 2;
+            aplicarFiltros();
+        });
+        filtro.add(btnSemFoto);
+
+        txtBusca = new JTextField(15);
+        txtBusca.getDocument().addDocumentListener(new DocumentListener() {
+            @Override
+            public void insertUpdate(DocumentEvent e) {
+                aplicarFiltros();
+            }
+
+            @Override
+            public void removeUpdate(DocumentEvent e) {
+                aplicarFiltros();
+            }
+
+            @Override
+            public void changedUpdate(DocumentEvent e) {
+                aplicarFiltros();
+            }
+        });
+        filtro.add(new JLabel("Pesquisar:"));
+        filtro.add(txtBusca);
+
+        btnNovo = new Button();
+        btnNovo.setBackground(new Color(63, 81, 181));
+        btnNovo.setForeground(Color.WHITE);
+        btnNovo.setIcon(IconFontSwing.buildIcon(GoogleMaterialDesignIcons.ADD, 20, Color.WHITE));
+        btnNovo.setPreferredSize(new Dimension(30, 30));
+        btnNovo.addActionListener(e -> adicionarIngrediente());
+        filtro.add(btnNovo);
+
+        filtroWrapper.add(filtro, BorderLayout.CENTER);
+        top.add(filtroWrapper, BorderLayout.CENTER);
+        add(top, BorderLayout.NORTH);
+
+        table = new Table();
+        table.setModel(new DefaultTableModel(new Object[][]{}, new String[]{
+            "Foto", "Nome", "Descrição", "Ações"
+        }) {
+            @Override
+            public boolean isCellEditable(int row, int column) {
+                return column == 3;
+            }
+
+            @Override
+            public Class<?> getColumnClass(int columnIndex) {
+                return columnIndex == 0 ? ImageIcon.class : Object.class;
+            }
+        });
+        table.setRowHeight(40);
+        JScrollPane scroll = new JScrollPane(table);
+        table.fixTable(scroll);
+        table.setRowSelectionAllowed(false);
+        add(scroll, BorderLayout.CENTER);
+
+        btnPrevPage = new JButton("Anterior");
+        btnNextPage = new JButton("Próximo");
+        btnPrevPage.addActionListener(e -> {
+            if (currentPage > 0) {
+                currentPage--;
+                updatePage();
+            }
+        });
+        btnNextPage.addActionListener(e -> {
+            if ((currentPage + 1) * PAGE_SIZE < (filtrados != null ? filtrados.size() : 0)) {
+                currentPage++;
+                updatePage();
+            }
+        });
+        JPanel pagination = new JPanel(new FlowLayout(FlowLayout.CENTER));
+        pagination.setBackground(Color.WHITE);
+        pagination.add(btnPrevPage);
+        pagination.add(btnNextPage);
+        add(pagination, BorderLayout.SOUTH);
+    }
+
+    private void carregarIngredientes() {
+        ingredientes = controller.listar();
+        aplicarFiltros();
+    }
+
+    private void aplicarFiltros() {
+        if (ingredientes == null) {
+            return;
+        }
+        String busca = txtBusca.getText();
+        String filtro = (busca != null && !busca.isEmpty()) ? busca.toLowerCase() : null;
+        filtrados = ingredientes.stream()
+                .filter(i -> filtroFoto == null || filtraPorFoto(i))
+                .filter(i -> filtro == null || matchesBusca(i, filtro))
+                .collect(Collectors.toList());
+        atualizarCards(filtrados);
+        currentPage = 0;
+        updatePage();
+    }
+
+    private boolean filtraPorFoto(Ingrediente i) {
+        if (filtroFoto == null) {
+            return true;
+        }
+        boolean hasFoto = i.getFoto() != null && i.getFoto().length > 0;
+        if (filtroFoto == 1) {
+            return hasFoto;
+        }
+        if (filtroFoto == 2) {
+            return !hasFoto;
+        }
+        return true;
+    }
+
+    private boolean matchesBusca(Ingrediente i, String filtro) {
+        return (i.getNome() != null && i.getNome().toLowerCase().contains(filtro))
+                || (i.getDescricao() != null && i.getDescricao().toLowerCase().contains(filtro));
+    }
+
+    private void atualizarCards(List<Ingrediente> lista) {
+        long comFoto = lista.stream().filter(i -> i.getFoto() != null && i.getFoto().length > 0).count();
+        long semFoto = lista.stream().filter(i -> i.getFoto() == null || i.getFoto().length == 0).count();
+        cardTotal.setData(new ModelCard("Ingredientes", lista.size(), 0, iconTotal));
+        cardComFoto.setData(new ModelCard("Com foto", (int) comFoto, 0, iconComFoto));
+        cardSemFoto.setData(new ModelCard("Sem foto", (int) semFoto, 0, iconSemFoto));
+    }
+
+    private void atualizarTabela(List<Ingrediente> lista) {
+        DefaultTableModel model = (DefaultTableModel) table.getModel();
+        model.setRowCount(0);
+        EventAction<Ingrediente> eventAction = new EventAction<Ingrediente>() {
+            @Override
+            public void delete(Ingrediente i) {
+                excluirIngrediente(i);
+            }
+
+            @Override
+            public void update(Ingrediente i) {
+                editarIngrediente(i);
+            }
+        };
+        for (Ingrediente i : lista) {
+            ImageIcon icon = ImageUtils.bytesToImageIcon(i.getFoto());
+            if (icon == null) {
+                icon = new ImageIcon(getClass().getResource("/icon/profile.jpg"));
+            }
+            model.addRow(new Object[]{
+                icon,
+                i.getNome(),
+                i.getDescricao(),
+                new ModelAction<>(i, eventAction)
+            });
+        }
+        table.getColumnModel().getColumn(0).setCellRenderer(new TableCellRenderer() {
+            @Override
+            public Component getTableCellRendererComponent(JTable tbl, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+                ImageAvatar avatar = new ImageAvatar();
+                avatar.setPreferredSize(new Dimension(40, 40));
+                if (value instanceof ImageIcon) {
+                    avatar.setIcon((ImageIcon) value);
+                }
+                return avatar;
+            }
+        });
+    }
+
+    private void updatePage() {
+        List<Ingrediente> page = getCurrentPage();
+        atualizarTabela(page);
+        updatePaginationButtons();
+    }
+
+    private List<Ingrediente> getCurrentPage() {
+        if (filtrados == null) {
+            return Collections.emptyList();
+        }
+        int start = currentPage * PAGE_SIZE;
+        int end = Math.min(start + PAGE_SIZE, filtrados.size());
+        return filtrados.subList(start, end);
+    }
+
+    private void updatePaginationButtons() {
+        int size = filtrados != null ? filtrados.size() : 0;
+        btnPrevPage.setEnabled(currentPage > 0);
+        btnNextPage.setEnabled((currentPage + 1) * PAGE_SIZE < size);
+    }
+
+    private void adicionarIngrediente() {
+        Frame frame = (Frame) SwingUtilities.getWindowAncestor(this);
+        IngredienteDialog dialog = new IngredienteDialog(frame, null);
+        dialog.setVisible(true);
+        if (dialog.isConfirmed()) {
+            try {
+                controller.criar(dialog.getIngrediente());
+                carregarIngredientes();
+            } catch (Exception ex) {
+                JOptionPane.showMessageDialog(this, ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+
+    private void editarIngrediente(Ingrediente i) {
+        try {
+            Ingrediente completo = controller.buscarComFotoPorId(i.getIdIngrediente());
+            Frame frame = (Frame) SwingUtilities.getWindowAncestor(this);
+            IngredienteDialog dialog = new IngredienteDialog(frame, completo);
+            dialog.setVisible(true);
+            if (dialog.isConfirmed()) {
+                try {
+                    controller.atualizar(dialog.getIngrediente());
+                    carregarIngredientes();
+                } catch (Exception ex) {
+                    JOptionPane.showMessageDialog(this, ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+                }
+            }
+        } catch (Exception ex) {
+            JOptionPane.showMessageDialog(this, ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+        }
+    }
+
+    private void excluirIngrediente(Ingrediente i) {
+        int opt = JOptionPane.showConfirmDialog(this, "Excluir ingrediente?", "Confirmação", JOptionPane.YES_NO_OPTION);
+        if (opt == JOptionPane.YES_OPTION) {
+            try {
+                controller.remover(i.getIdIngrediente());
+                carregarIngredientes();
+            } catch (Exception ex) {
+                JOptionPane.showMessageDialog(this, ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+}

--- a/src/main/java/form/MonitoramentoDialog.java
+++ b/src/main/java/form/MonitoramentoDialog.java
@@ -1,0 +1,243 @@
+package form;
+
+import java.awt.Color;
+import java.awt.Frame;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import javax.swing.JComboBox;
+import javax.swing.JDialog;
+import javax.swing.JFileChooser;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import javax.swing.JTextField;
+import model.Monitoramento;
+import swing.Button;
+import swing.ImageAvatar;
+import util.ImageUtils;
+
+/** Dialog for creating or editing a {@link Monitoramento}. */
+public class MonitoramentoDialog extends JDialog {
+
+    private Monitoramento monitoramento;
+    private boolean confirmed;
+
+    private JTextField txtId;
+    private JTextField txtNome;
+    private JTextArea txtDescricao;
+    private JComboBox<StatusOption> cbStatus;
+    private JTextField txtIdPeriodo;
+    private ImageAvatar avatar;
+    private byte[] fotoSelecionada;
+
+    public MonitoramentoDialog(Frame parent, Monitoramento monitoramento) {
+        super(parent, true);
+        this.monitoramento = monitoramento != null ? monitoramento : new Monitoramento();
+        this.fotoSelecionada = this.monitoramento.getFoto();
+        initComponents();
+        setLocationRelativeTo(parent);
+        preencherCampos();
+    }
+
+    private void preencherCampos() {
+        if (monitoramento.getIdMonitoramento() != null) {
+            txtId.setText(String.valueOf(monitoramento.getIdMonitoramento()));
+        }
+        if (monitoramento.getNome() != null) {
+            txtNome.setText(monitoramento.getNome());
+        }
+        if (monitoramento.getDescricao() != null) {
+            txtDescricao.setText(monitoramento.getDescricao());
+        }
+        if (monitoramento.getStatus() != null) {
+            for (int i = 0; i < cbStatus.getItemCount(); i++) {
+                if (cbStatus.getItemAt(i).codigo.equals(monitoramento.getStatus())) {
+                    cbStatus.setSelectedIndex(i);
+                    break;
+                }
+            }
+        }
+        if (monitoramento.getIdPeriodo() != null) {
+            txtIdPeriodo.setText(String.valueOf(monitoramento.getIdPeriodo()));
+        }
+        atualizarAvatar();
+    }
+
+    private void initComponents() {
+        setTitle("Monitoramento");
+        JPanel panel = new JPanel(new GridBagLayout());
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.insets = new Insets(5, 5, 5, 5);
+        gbc.anchor = GridBagConstraints.WEST;
+        int y = 0;
+
+        JLabel lblId = new JLabel("ID");
+        txtId = new JTextField(10);
+        txtId.setEditable(false);
+        gbc.gridx = 0;
+        gbc.gridy = y;
+        panel.add(lblId, gbc);
+        gbc.gridx = 1;
+        panel.add(txtId, gbc);
+        y++;
+
+        JLabel lblNome = new JLabel("Nome");
+        txtNome = new JTextField(20);
+        gbc.gridx = 0;
+        gbc.gridy = y;
+        panel.add(lblNome, gbc);
+        gbc.gridx = 1;
+        panel.add(txtNome, gbc);
+        y++;
+
+        JLabel lblDescricao = new JLabel("Descrição");
+        txtDescricao = new JTextArea(4, 20);
+        JScrollPane scroll = new JScrollPane(txtDescricao);
+        gbc.gridx = 0;
+        gbc.gridy = y;
+        panel.add(lblDescricao, gbc);
+        gbc.gridx = 1;
+        panel.add(scroll, gbc);
+        y++;
+
+        JLabel lblStatus = new JLabel("Status");
+        cbStatus = new JComboBox<>(new StatusOption[]{
+            new StatusOption("Ativo", 1),
+            new StatusOption("Pausado", 2),
+            new StatusOption("Alerta", 3)
+        });
+        gbc.gridx = 0;
+        gbc.gridy = y;
+        panel.add(lblStatus, gbc);
+        gbc.gridx = 1;
+        panel.add(cbStatus, gbc);
+        y++;
+
+        JLabel lblPeriodo = new JLabel("Id Período");
+        txtIdPeriodo = new JTextField(20);
+        gbc.gridx = 0;
+        gbc.gridy = y;
+        panel.add(lblPeriodo, gbc);
+        gbc.gridx = 1;
+        panel.add(txtIdPeriodo, gbc);
+        y++;
+
+        JLabel lblFoto = new JLabel("Foto");
+        avatar = new ImageAvatar();
+        avatar.setPreferredSize(new java.awt.Dimension(80, 80));
+        Button btnSelecionar = new Button();
+        btnSelecionar.setText("Selecionar foto");
+        btnSelecionar.addActionListener(e -> selecionarFoto());
+        gbc.gridx = 0;
+        gbc.gridy = y;
+        panel.add(lblFoto, gbc);
+        gbc.gridx = 1;
+        panel.add(avatar, gbc);
+        y++;
+        gbc.gridx = 1;
+        panel.add(btnSelecionar, gbc);
+        y++;
+
+        Button btnSalvar = new Button();
+        btnSalvar.setText("Salvar");
+        btnSalvar.setBackground(new Color(75, 134, 253));
+        btnSalvar.setForeground(Color.WHITE);
+        btnSalvar.addActionListener(e -> salvar());
+
+        Button btnCancelar = new Button();
+        btnCancelar.setText("Cancelar");
+        btnCancelar.addActionListener(e -> dispose());
+
+        gbc.gridx = 0;
+        gbc.gridy = y;
+        panel.add(btnSalvar, gbc);
+        gbc.gridx = 1;
+        panel.add(btnCancelar, gbc);
+
+        getContentPane().add(panel);
+        pack();
+        getRootPane().setDefaultButton(btnSalvar);
+    }
+
+    private void selecionarFoto() {
+        JFileChooser chooser = new JFileChooser();
+        int result = chooser.showOpenDialog(this);
+        if (result == JFileChooser.APPROVE_OPTION) {
+            File file = chooser.getSelectedFile();
+            try {
+                fotoSelecionada = Files.readAllBytes(file.toPath());
+                atualizarAvatar();
+            } catch (IOException ex) {
+                JOptionPane.showMessageDialog(this, "Não foi possível carregar a imagem", "Erro", JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+
+    private void atualizarAvatar() {
+        if (fotoSelecionada != null) {
+            avatar.setIcon(ImageUtils.bytesToImageIcon(fotoSelecionada));
+        } else {
+            avatar.setIcon(new javax.swing.ImageIcon(getClass().getResource("/icon/profile.jpg")));
+        }
+    }
+
+    private void salvar() {
+        String nome = txtNome.getText();
+        if (nome == null || nome.isEmpty()) {
+            JOptionPane.showMessageDialog(this, "Nome é obrigatório", "Aviso", JOptionPane.WARNING_MESSAGE);
+            return;
+        }
+        monitoramento.setNome(nome);
+        monitoramento.setDescricao(txtDescricao.getText());
+        monitoramento.setStatus(((StatusOption) cbStatus.getSelectedItem()).codigo);
+        monitoramento.setFoto(fotoSelecionada);
+        try {
+            monitoramento.setIdPeriodo(parseInteger(txtIdPeriodo.getText()));
+        } catch (IllegalArgumentException ex) {
+            return;
+        }
+        confirmed = true;
+        dispose();
+    }
+
+    private Integer parseInteger(String text) {
+        if (text == null || text.isEmpty()) {
+            return null;
+        }
+        try {
+            return Integer.valueOf(text);
+        } catch (NumberFormatException ex) {
+            JOptionPane.showMessageDialog(this, "Id do período inválido", "Erro", JOptionPane.ERROR_MESSAGE);
+            throw new IllegalArgumentException("Id período inválido", ex);
+        }
+    }
+
+    public boolean isConfirmed() {
+        return confirmed;
+    }
+
+    public Monitoramento getMonitoramento() {
+        return monitoramento;
+    }
+
+    private static class StatusOption {
+        private final String descricao;
+        private final Integer codigo;
+
+        private StatusOption(String descricao, Integer codigo) {
+            this.descricao = descricao;
+            this.codigo = codigo;
+        }
+
+        @Override
+        public String toString() {
+            return descricao;
+        }
+    }
+}

--- a/src/main/java/form/MonitoramentoForm.java
+++ b/src/main/java/form/MonitoramentoForm.java
@@ -1,0 +1,411 @@
+package form;
+
+import component.Card;
+import controller.MonitoramentoController;
+import dao.impl.MonitoramentoDaoNativeImpl;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableCellRenderer;
+import model.ModelCard;
+import model.Monitoramento;
+import swing.Button;
+import swing.ImageAvatar;
+import swing.icon.GoogleMaterialDesignIcons;
+import swing.icon.IconFontSwing;
+import swing.table.EventAction;
+import swing.table.ModelAction;
+import swing.table.Table;
+import util.ImageUtils;
+
+/**
+ * Formulário para gerenciamento de Monitoramentos.
+ */
+public class MonitoramentoForm extends JPanel {
+
+    private final MonitoramentoController controller;
+    private Card cardTotal;
+    private Card cardAtivos;
+    private Card cardAlertas;
+    private Table table;
+    private JTextField txtBusca;
+    private Button btnAtivo;
+    private Button btnPausado;
+    private Button btnAlerta;
+    private Button btnNovo;
+    private Integer filtroStatus;
+    private List<Monitoramento> monitoramentos;
+    private List<Monitoramento> filtrados;
+    private javax.swing.Icon iconTotal;
+    private javax.swing.Icon iconAtivo;
+    private javax.swing.Icon iconAlerta;
+    private JButton btnPrevPage;
+    private JButton btnNextPage;
+    private int currentPage = 0;
+    private static final int PAGE_SIZE = 6;
+
+    public MonitoramentoForm() {
+        controller = new MonitoramentoController(new MonitoramentoDaoNativeImpl());
+        initComponents();
+        carregarMonitoramentos();
+    }
+
+    private void initComponents() {
+        setLayout(new BorderLayout());
+        setBackground(Color.WHITE);
+
+        JPanel top = new JPanel(new BorderLayout());
+        top.setBackground(Color.WHITE);
+
+        JPanel cards = new JPanel(new java.awt.GridLayout(1, 3, 18, 0));
+        cards.setBackground(Color.WHITE);
+
+        iconTotal = IconFontSwing.buildIcon(GoogleMaterialDesignIcons.ASSESSMENT, 60, Color.WHITE,
+                new Color(255, 255, 255, 15));
+        cardTotal = new Card();
+        cardTotal.setBackground(new Color(63, 81, 181));
+        cardTotal.setColorGradient(new Color(92, 107, 192));
+        cardTotal.setData(new ModelCard("Monitoramentos", 0, 0, iconTotal));
+        cards.add(cardTotal);
+
+        iconAtivo = IconFontSwing.buildIcon(GoogleMaterialDesignIcons.VISIBILITY, 60, Color.WHITE,
+                new Color(255, 255, 255, 15));
+        cardAtivos = new Card();
+        cardAtivos.setBackground(new Color(76, 175, 80));
+        cardAtivos.setColorGradient(new Color(129, 199, 132));
+        cardAtivos.setData(new ModelCard("Ativos", 0, 0, iconAtivo));
+        cards.add(cardAtivos);
+
+        iconAlerta = IconFontSwing.buildIcon(GoogleMaterialDesignIcons.WARNING, 60, Color.WHITE,
+                new Color(255, 255, 255, 15));
+        cardAlertas = new Card();
+        cardAlertas.setBackground(new Color(255, 152, 0));
+        cardAlertas.setColorGradient(new Color(255, 203, 107));
+        cardAlertas.setData(new ModelCard("Alertas", 0, 0, iconAlerta));
+        cards.add(cardAlertas);
+
+        top.add(cards, BorderLayout.NORTH);
+
+        JPanel filtroWrapper = new JPanel(new BorderLayout());
+        filtroWrapper.setBackground(Color.WHITE);
+
+        JPanel filtro = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        filtro.setBackground(Color.WHITE);
+
+        btnAtivo = new Button();
+        btnAtivo.setText("Ativos");
+        btnAtivo.setBackground(new Color(76, 175, 80));
+        btnAtivo.setForeground(Color.WHITE);
+        btnAtivo.addActionListener(e -> {
+            filtroStatus = 1;
+            aplicarFiltros();
+        });
+        filtro.add(btnAtivo);
+
+        btnPausado = new Button();
+        btnPausado.setText("Pausados");
+        btnPausado.setBackground(new Color(33, 150, 243));
+        btnPausado.setForeground(Color.WHITE);
+        btnPausado.addActionListener(e -> {
+            filtroStatus = 2;
+            aplicarFiltros();
+        });
+        filtro.add(btnPausado);
+
+        btnAlerta = new Button();
+        btnAlerta.setText("Alertas");
+        btnAlerta.setBackground(new Color(255, 152, 0));
+        btnAlerta.setForeground(Color.BLACK);
+        btnAlerta.addActionListener(e -> {
+            filtroStatus = 3;
+            aplicarFiltros();
+        });
+        filtro.add(btnAlerta);
+
+        Button btnTodos = new Button();
+        btnTodos.setText("Todos");
+        btnTodos.addActionListener(e -> {
+            filtroStatus = null;
+            aplicarFiltros();
+        });
+        filtro.add(btnTodos);
+
+        txtBusca = new JTextField(15);
+        txtBusca.getDocument().addDocumentListener(new DocumentListener() {
+            @Override
+            public void insertUpdate(DocumentEvent e) {
+                aplicarFiltros();
+            }
+
+            @Override
+            public void removeUpdate(DocumentEvent e) {
+                aplicarFiltros();
+            }
+
+            @Override
+            public void changedUpdate(DocumentEvent e) {
+                aplicarFiltros();
+            }
+        });
+        filtro.add(new JLabel("Pesquisar:"));
+        filtro.add(txtBusca);
+
+        btnNovo = new Button();
+        btnNovo.setBackground(new Color(63, 81, 181));
+        btnNovo.setForeground(Color.WHITE);
+        btnNovo.setIcon(IconFontSwing.buildIcon(GoogleMaterialDesignIcons.ADD, 20, Color.WHITE));
+        btnNovo.setPreferredSize(new Dimension(30, 30));
+        btnNovo.addActionListener(e -> adicionarMonitoramento());
+        filtro.add(btnNovo);
+
+        filtroWrapper.add(filtro, BorderLayout.CENTER);
+        top.add(filtroWrapper, BorderLayout.CENTER);
+        add(top, BorderLayout.NORTH);
+
+        table = new Table();
+        table.setModel(new DefaultTableModel(new Object[][]{}, new String[]{
+            "Foto", "Nome", "Status", "Período", "Ações"
+        }) {
+            @Override
+            public boolean isCellEditable(int row, int column) {
+                return column == 4;
+            }
+
+            @Override
+            public Class<?> getColumnClass(int columnIndex) {
+                return columnIndex == 0 ? ImageIcon.class : Object.class;
+            }
+        });
+        table.setRowHeight(40);
+        JScrollPane scroll = new JScrollPane(table);
+        table.fixTable(scroll);
+        table.setRowSelectionAllowed(false);
+        add(scroll, BorderLayout.CENTER);
+
+        btnPrevPage = new JButton("Anterior");
+        btnNextPage = new JButton("Próximo");
+        btnPrevPage.addActionListener(e -> {
+            if (currentPage > 0) {
+                currentPage--;
+                updatePage();
+            }
+        });
+        btnNextPage.addActionListener(e -> {
+            if ((currentPage + 1) * PAGE_SIZE < (filtrados != null ? filtrados.size() : 0)) {
+                currentPage++;
+                updatePage();
+            }
+        });
+        JPanel pagination = new JPanel(new FlowLayout(FlowLayout.CENTER));
+        pagination.setBackground(Color.WHITE);
+        pagination.add(btnPrevPage);
+        pagination.add(btnNextPage);
+        add(pagination, BorderLayout.SOUTH);
+    }
+
+    private void carregarMonitoramentos() {
+        monitoramentos = controller.listar();
+        aplicarFiltros();
+    }
+
+    private void aplicarFiltros() {
+        if (monitoramentos == null) {
+            return;
+        }
+        String busca = txtBusca.getText();
+        String filtro = (busca != null && !busca.isEmpty()) ? busca.toLowerCase() : null;
+        filtrados = monitoramentos.stream()
+                .filter(m -> filtroStatus == null || (m.getStatus() != null && filtroStatus.equals(m.getStatus())))
+                .filter(m -> filtro == null || matchesBusca(m, filtro))
+                .collect(Collectors.toList());
+        atualizarCards(filtrados);
+        currentPage = 0;
+        updatePage();
+    }
+
+    private boolean matchesBusca(Monitoramento m, String filtro) {
+        return (m.getNome() != null && m.getNome().toLowerCase().contains(filtro))
+                || (m.getDescricao() != null && m.getDescricao().toLowerCase().contains(filtro));
+    }
+
+    private void atualizarCards(List<Monitoramento> lista) {
+        long ativos = lista.stream().filter(m -> m.getStatus() != null && m.getStatus() == 1).count();
+        long alertas = lista.stream().filter(m -> m.getStatus() != null && m.getStatus() == 3).count();
+        cardTotal.setData(new ModelCard("Monitoramentos", lista.size(), 0, iconTotal));
+        cardAtivos.setData(new ModelCard("Ativos", (int) ativos, 0, iconAtivo));
+        cardAlertas.setData(new ModelCard("Alertas", (int) alertas, 0, iconAlerta));
+    }
+
+    private void atualizarTabela(List<Monitoramento> lista) {
+        DefaultTableModel model = (DefaultTableModel) table.getModel();
+        model.setRowCount(0);
+        EventAction<Monitoramento> eventAction = new EventAction<Monitoramento>() {
+            @Override
+            public void delete(Monitoramento m) {
+                excluirMonitoramento(m);
+            }
+
+            @Override
+            public void update(Monitoramento m) {
+                editarMonitoramento(m);
+            }
+        };
+        for (Monitoramento m : lista) {
+            ImageIcon icon = ImageUtils.bytesToImageIcon(m.getFoto());
+            if (icon == null) {
+                icon = new ImageIcon(getClass().getResource("/icon/profile.jpg"));
+            }
+            model.addRow(new Object[]{
+                icon,
+                m.getNome(),
+                statusTexto(m.getStatus()),
+                periodoTexto(m.getIdPeriodo()),
+                new ModelAction<>(m, eventAction)
+            });
+        }
+        table.getColumnModel().getColumn(0).setCellRenderer(new TableCellRenderer() {
+            @Override
+            public Component getTableCellRendererComponent(JTable tbl, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+                ImageAvatar avatar = new ImageAvatar();
+                avatar.setPreferredSize(new Dimension(40, 40));
+                if (value instanceof ImageIcon) {
+                    avatar.setIcon((ImageIcon) value);
+                }
+                return avatar;
+            }
+        });
+        int statusCol = table.getColumnModel().getColumnCount() - 2;
+        table.getColumnModel().getColumn(statusCol).setCellRenderer(new TableCellRenderer() {
+            @Override
+            public Component getTableCellRendererComponent(JTable tbl, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+                Button lbl = new Button();
+                lbl.setText(value == null ? "" : value.toString());
+                lbl.setBorderPainted(false);
+                lbl.setFocusPainted(false);
+                lbl.setContentAreaFilled(true);
+                lbl.setPreferredSize(new Dimension(90, 28));
+                if ("Ativo".equals(value)) {
+                    lbl.setBackground(new Color(76, 175, 80));
+                    lbl.setForeground(Color.WHITE);
+                } else if ("Pausado".equals(value)) {
+                    lbl.setBackground(new Color(33, 150, 243));
+                    lbl.setForeground(Color.WHITE);
+                } else if ("Alerta".equals(value)) {
+                    lbl.setBackground(new Color(255, 152, 0));
+                    lbl.setForeground(Color.BLACK);
+                } else {
+                    lbl.setBackground(new Color(189, 189, 189));
+                    lbl.setForeground(Color.BLACK);
+                }
+                return lbl;
+            }
+        });
+    }
+
+    private String periodoTexto(Integer idPeriodo) {
+        if (idPeriodo == null) {
+            return "";
+        }
+        return "Período #" + idPeriodo;
+    }
+
+    private void updatePage() {
+        List<Monitoramento> page = getCurrentPage();
+        atualizarTabela(page);
+        updatePaginationButtons();
+    }
+
+    private List<Monitoramento> getCurrentPage() {
+        if (filtrados == null) {
+            return Collections.emptyList();
+        }
+        int start = currentPage * PAGE_SIZE;
+        int end = Math.min(start + PAGE_SIZE, filtrados.size());
+        return filtrados.subList(start, end);
+    }
+
+    private void updatePaginationButtons() {
+        int size = filtrados != null ? filtrados.size() : 0;
+        btnPrevPage.setEnabled(currentPage > 0);
+        btnNextPage.setEnabled((currentPage + 1) * PAGE_SIZE < size);
+    }
+
+    private void adicionarMonitoramento() {
+        Frame frame = (Frame) SwingUtilities.getWindowAncestor(this);
+        MonitoramentoDialog dialog = new MonitoramentoDialog(frame, null);
+        dialog.setVisible(true);
+        if (dialog.isConfirmed()) {
+            try {
+                controller.criar(dialog.getMonitoramento());
+                carregarMonitoramentos();
+            } catch (Exception ex) {
+                JOptionPane.showMessageDialog(this, ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+
+    private void editarMonitoramento(Monitoramento m) {
+        try {
+            Monitoramento completo = controller.buscarComFotoPorId(m.getIdMonitoramento());
+            Frame frame = (Frame) SwingUtilities.getWindowAncestor(this);
+            MonitoramentoDialog dialog = new MonitoramentoDialog(frame, completo);
+            dialog.setVisible(true);
+            if (dialog.isConfirmed()) {
+                try {
+                    controller.atualizar(dialog.getMonitoramento());
+                    carregarMonitoramentos();
+                } catch (Exception ex) {
+                    JOptionPane.showMessageDialog(this, ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+                }
+            }
+        } catch (Exception ex) {
+            JOptionPane.showMessageDialog(this, ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+        }
+    }
+
+    private void excluirMonitoramento(Monitoramento m) {
+        int opt = JOptionPane.showConfirmDialog(this, "Excluir monitoramento?", "Confirmação", JOptionPane.YES_NO_OPTION);
+        if (opt == JOptionPane.YES_OPTION) {
+            try {
+                controller.remover(m.getIdMonitoramento());
+                carregarMonitoramentos();
+            } catch (Exception ex) {
+                JOptionPane.showMessageDialog(this, ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+
+    private String statusTexto(Integer status) {
+        if (status == null) {
+            return "";
+        }
+        switch (status) {
+            case 1:
+                return "Ativo";
+            case 2:
+                return "Pausado";
+            case 3:
+                return "Alerta";
+            default:
+                return status.toString();
+        }
+    }
+}

--- a/src/main/java/form/RotinaDialog.java
+++ b/src/main/java/form/RotinaDialog.java
@@ -1,0 +1,255 @@
+package form;
+
+import java.awt.Color;
+import java.awt.Frame;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import javax.swing.JComboBox;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JSpinner;
+import javax.swing.JTextArea;
+import javax.swing.JTextField;
+import javax.swing.SpinnerNumberModel;
+import javax.swing.JScrollPane;
+import model.Rotina;
+import swing.Button;
+
+/** Dialog for creating or editing a {@link Rotina}. */
+public class RotinaDialog extends JDialog {
+
+    private Rotina rotina;
+    private boolean confirmed;
+
+    private JTextField txtId;
+    private JTextField txtNome;
+    private JTextField txtInicio;
+    private JTextField txtFim;
+    private JTextArea txtDescricao;
+    private JComboBox<StatusOption> cbStatus;
+    private JSpinner spPonto;
+    private JTextField txtIdUsuario;
+
+    private final DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE;
+
+    public RotinaDialog(Frame parent, Rotina rotina) {
+        super(parent, true);
+        this.rotina = rotina != null ? rotina : new Rotina();
+        initComponents();
+        setLocationRelativeTo(parent);
+        preencherCampos();
+    }
+
+    private void preencherCampos() {
+        if (rotina.getIdRotina() != null) {
+            txtId.setText(String.valueOf(rotina.getIdRotina()));
+        }
+        if (rotina.getNome() != null) {
+            txtNome.setText(rotina.getNome());
+        }
+        if (rotina.getInicio() != null) {
+            txtInicio.setText(rotina.getInicio().format(formatter));
+        }
+        if (rotina.getFim() != null) {
+            txtFim.setText(rotina.getFim().format(formatter));
+        }
+        if (rotina.getDescricao() != null) {
+            txtDescricao.setText(rotina.getDescricao());
+        }
+        if (rotina.getStatus() != null) {
+            for (int i = 0; i < cbStatus.getItemCount(); i++) {
+                if (cbStatus.getItemAt(i).codigo.equals(rotina.getStatus())) {
+                    cbStatus.setSelectedIndex(i);
+                    break;
+                }
+            }
+        }
+        if (rotina.getPonto() != null) {
+            spPonto.setValue(rotina.getPonto());
+        }
+        if (rotina.getIdUsuario() != null) {
+            txtIdUsuario.setText(String.valueOf(rotina.getIdUsuario()));
+        }
+    }
+
+    private void initComponents() {
+        setTitle("Rotina");
+        JPanel panel = new JPanel(new GridBagLayout());
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.insets = new Insets(5, 5, 5, 5);
+        gbc.anchor = GridBagConstraints.WEST;
+        int y = 0;
+
+        JLabel lblId = new JLabel("ID");
+        txtId = new JTextField(10);
+        txtId.setEditable(false);
+        gbc.gridx = 0;
+        gbc.gridy = y;
+        panel.add(lblId, gbc);
+        gbc.gridx = 1;
+        panel.add(txtId, gbc);
+        y++;
+
+        JLabel lblNome = new JLabel("Nome");
+        txtNome = new JTextField(20);
+        gbc.gridx = 0;
+        gbc.gridy = y;
+        panel.add(lblNome, gbc);
+        gbc.gridx = 1;
+        panel.add(txtNome, gbc);
+        y++;
+
+        JLabel lblInicio = new JLabel("Início (AAAA-MM-DD)");
+        txtInicio = new JTextField(20);
+        gbc.gridx = 0;
+        gbc.gridy = y;
+        panel.add(lblInicio, gbc);
+        gbc.gridx = 1;
+        panel.add(txtInicio, gbc);
+        y++;
+
+        JLabel lblFim = new JLabel("Fim (AAAA-MM-DD)");
+        txtFim = new JTextField(20);
+        gbc.gridx = 0;
+        gbc.gridy = y;
+        panel.add(lblFim, gbc);
+        gbc.gridx = 1;
+        panel.add(txtFim, gbc);
+        y++;
+
+        JLabel lblDescricao = new JLabel("Descrição");
+        txtDescricao = new JTextArea(4, 20);
+        JScrollPane scroll = new JScrollPane(txtDescricao);
+        gbc.gridx = 0;
+        gbc.gridy = y;
+        panel.add(lblDescricao, gbc);
+        gbc.gridx = 1;
+        panel.add(scroll, gbc);
+        y++;
+
+        JLabel lblStatus = new JLabel("Status");
+        cbStatus = new JComboBox<>(new StatusOption[]{
+            new StatusOption("Ativa", 1),
+            new StatusOption("Pausada", 2),
+            new StatusOption("Concluída", 3)
+        });
+        gbc.gridx = 0;
+        gbc.gridy = y;
+        panel.add(lblStatus, gbc);
+        gbc.gridx = 1;
+        panel.add(cbStatus, gbc);
+        y++;
+
+        JLabel lblPonto = new JLabel("Pontos");
+        spPonto = new JSpinner(new SpinnerNumberModel(0, 0, 9999, 1));
+        gbc.gridx = 0;
+        gbc.gridy = y;
+        panel.add(lblPonto, gbc);
+        gbc.gridx = 1;
+        panel.add(spPonto, gbc);
+        y++;
+
+        JLabel lblUsuario = new JLabel("Id Usuário");
+        txtIdUsuario = new JTextField(20);
+        gbc.gridx = 0;
+        gbc.gridy = y;
+        panel.add(lblUsuario, gbc);
+        gbc.gridx = 1;
+        panel.add(txtIdUsuario, gbc);
+        y++;
+
+        Button btnSalvar = new Button();
+        btnSalvar.setText("Salvar");
+        btnSalvar.setBackground(new Color(75, 134, 253));
+        btnSalvar.setForeground(Color.WHITE);
+        btnSalvar.addActionListener(e -> salvar());
+
+        Button btnCancelar = new Button();
+        btnCancelar.setText("Cancelar");
+        btnCancelar.addActionListener(e -> dispose());
+
+        gbc.gridx = 0;
+        gbc.gridy = y;
+        panel.add(btnSalvar, gbc);
+        gbc.gridx = 1;
+        panel.add(btnCancelar, gbc);
+
+        getContentPane().add(panel);
+        pack();
+        getRootPane().setDefaultButton(btnSalvar);
+    }
+
+    private void salvar() {
+        String nome = txtNome.getText();
+        if (nome == null || nome.isEmpty()) {
+            JOptionPane.showMessageDialog(this, "Nome é obrigatório", "Aviso", JOptionPane.WARNING_MESSAGE);
+            return;
+        }
+        rotina.setNome(nome);
+        rotina.setDescricao(txtDescricao.getText());
+        rotina.setStatus(((StatusOption) cbStatus.getSelectedItem()).codigo);
+        rotina.setPonto(((Number) spPonto.getValue()).intValue());
+        try {
+            rotina.setIdUsuario(parseInteger(txtIdUsuario.getText()));
+            rotina.setInicio(parseDate(txtInicio.getText()));
+            rotina.setFim(parseDate(txtFim.getText()));
+        } catch (IllegalArgumentException ex) {
+            return;
+        }
+        confirmed = true;
+        dispose();
+    }
+
+    private Integer parseInteger(String text) {
+        if (text == null || text.isEmpty()) {
+            return null;
+        }
+        try {
+            return Integer.valueOf(text);
+        } catch (NumberFormatException ex) {
+            JOptionPane.showMessageDialog(this, "Id do usuário inválido", "Erro", JOptionPane.ERROR_MESSAGE);
+            throw new IllegalArgumentException("Id inválido", ex);
+        }
+    }
+
+    private LocalDate parseDate(String text) {
+        if (text == null || text.isEmpty()) {
+            return null;
+        }
+        try {
+            return LocalDate.parse(text, formatter);
+        } catch (DateTimeParseException ex) {
+            JOptionPane.showMessageDialog(this, "Data inválida. Utilize o formato AAAA-MM-DD", "Erro", JOptionPane.ERROR_MESSAGE);
+            throw new IllegalArgumentException("Data inválida", ex);
+        }
+    }
+
+    public boolean isConfirmed() {
+        return confirmed;
+    }
+
+    public Rotina getRotina() {
+        return rotina;
+    }
+
+    private static class StatusOption {
+        private final String descricao;
+        private final Integer codigo;
+
+        private StatusOption(String descricao, Integer codigo) {
+            this.descricao = descricao;
+            this.codigo = codigo;
+        }
+
+        @Override
+        public String toString() {
+            return descricao;
+        }
+    }
+}

--- a/src/main/java/form/RotinaForm.java
+++ b/src/main/java/form/RotinaForm.java
@@ -1,0 +1,388 @@
+package form;
+
+import component.Card;
+import controller.RotinaController;
+import dao.impl.RotinaDaoNativeImpl;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableCellRenderer;
+import model.ModelCard;
+import model.Rotina;
+import swing.Button;
+import swing.ImageAvatar;
+import swing.icon.GoogleMaterialDesignIcons;
+import swing.icon.IconFontSwing;
+import swing.table.EventAction;
+import swing.table.ModelAction;
+import swing.table.Table;
+
+/**
+ * Formulário para gerenciamento de Rotinas.
+ */
+public class RotinaForm extends JPanel {
+
+    private final RotinaController controller;
+    private Card cardTotal;
+    private Card cardAtivas;
+    private Card cardConcluidas;
+    private Table table;
+    private JTextField txtBusca;
+    private Button btnAtiva;
+    private Button btnPausada;
+    private Button btnConcluida;
+    private Button btnNovo;
+    private Integer filtroStatus;
+    private List<Rotina> rotinas;
+    private List<Rotina> filtradas;
+    private javax.swing.Icon iconTotal;
+    private javax.swing.Icon iconAtiva;
+    private javax.swing.Icon iconConcluida;
+    private JButton btnPrevPage;
+    private JButton btnNextPage;
+    private int currentPage = 0;
+    private static final int PAGE_SIZE = 6;
+    private final DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE;
+
+    public RotinaForm() {
+        controller = new RotinaController(new RotinaDaoNativeImpl());
+        initComponents();
+        carregarRotinas();
+    }
+
+    private void initComponents() {
+        setLayout(new BorderLayout());
+        setBackground(Color.WHITE);
+
+        JPanel top = new JPanel(new BorderLayout());
+        top.setBackground(Color.WHITE);
+
+        JPanel cards = new JPanel(new java.awt.GridLayout(1, 3, 18, 0));
+        cards.setBackground(Color.WHITE);
+
+        iconTotal = IconFontSwing.buildIcon(GoogleMaterialDesignIcons.VIEW_LIST, 60, Color.WHITE,
+                new Color(255, 255, 255, 15));
+        cardTotal = new Card();
+        cardTotal.setBackground(new Color(63, 81, 181));
+        cardTotal.setColorGradient(new Color(92, 107, 192));
+        cardTotal.setData(new ModelCard("Rotinas", 0, 0, iconTotal));
+        cards.add(cardTotal);
+
+        iconAtiva = IconFontSwing.buildIcon(GoogleMaterialDesignIcons.PLAY_ARROW, 60, Color.WHITE,
+                new Color(255, 255, 255, 15));
+        cardAtivas = new Card();
+        cardAtivas.setBackground(new Color(76, 175, 80));
+        cardAtivas.setColorGradient(new Color(129, 199, 132));
+        cardAtivas.setData(new ModelCard("Ativas", 0, 0, iconAtiva));
+        cards.add(cardAtivas);
+
+        iconConcluida = IconFontSwing.buildIcon(GoogleMaterialDesignIcons.CHECK_CIRCLE, 60, Color.WHITE,
+                new Color(255, 255, 255, 15));
+        cardConcluidas = new Card();
+        cardConcluidas.setBackground(new Color(255, 152, 0));
+        cardConcluidas.setColorGradient(new Color(255, 203, 107));
+        cardConcluidas.setData(new ModelCard("Concluídas", 0, 0, iconConcluida));
+        cards.add(cardConcluidas);
+
+        top.add(cards, BorderLayout.NORTH);
+
+        JPanel filtroWrapper = new JPanel(new BorderLayout());
+        filtroWrapper.setBackground(Color.WHITE);
+
+        JPanel filtro = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        filtro.setBackground(Color.WHITE);
+
+        btnAtiva = new Button();
+        btnAtiva.setText("Ativas");
+        btnAtiva.setBackground(new Color(76, 175, 80));
+        btnAtiva.setForeground(Color.WHITE);
+        btnAtiva.addActionListener(e -> {
+            filtroStatus = 1;
+            aplicarFiltros();
+        });
+        filtro.add(btnAtiva);
+
+        btnPausada = new Button();
+        btnPausada.setText("Pausadas");
+        btnPausada.setBackground(new Color(33, 150, 243));
+        btnPausada.setForeground(Color.WHITE);
+        btnPausada.addActionListener(e -> {
+            filtroStatus = 2;
+            aplicarFiltros();
+        });
+        filtro.add(btnPausada);
+
+        btnConcluida = new Button();
+        btnConcluida.setText("Concluídas");
+        btnConcluida.setBackground(new Color(255, 152, 0));
+        btnConcluida.setForeground(Color.BLACK);
+        btnConcluida.addActionListener(e -> {
+            filtroStatus = 3;
+            aplicarFiltros();
+        });
+        filtro.add(btnConcluida);
+
+        Button btnTodos = new Button();
+        btnTodos.setText("Todas");
+        btnTodos.addActionListener(e -> {
+            filtroStatus = null;
+            aplicarFiltros();
+        });
+        filtro.add(btnTodos);
+
+        txtBusca = new JTextField(15);
+        txtBusca.getDocument().addDocumentListener(new DocumentListener() {
+            @Override
+            public void insertUpdate(DocumentEvent e) {
+                aplicarFiltros();
+            }
+
+            @Override
+            public void removeUpdate(DocumentEvent e) {
+                aplicarFiltros();
+            }
+
+            @Override
+            public void changedUpdate(DocumentEvent e) {
+                aplicarFiltros();
+            }
+        });
+        filtro.add(new JLabel("Pesquisar:"));
+        filtro.add(txtBusca);
+
+        btnNovo = new Button();
+        btnNovo.setBackground(new Color(63, 81, 181));
+        btnNovo.setForeground(Color.WHITE);
+        btnNovo.setIcon(IconFontSwing.buildIcon(GoogleMaterialDesignIcons.ADD, 20, Color.WHITE));
+        btnNovo.setPreferredSize(new Dimension(30, 30));
+        btnNovo.addActionListener(e -> adicionarRotina());
+        filtro.add(btnNovo);
+
+        filtroWrapper.add(filtro, BorderLayout.CENTER);
+        top.add(filtroWrapper, BorderLayout.CENTER);
+        add(top, BorderLayout.NORTH);
+
+        table = new Table();
+        table.setModel(new DefaultTableModel(new Object[][]{}, new String[]{
+            "Ícone", "Nome", "Período", "Status", "Pontos", "Usuário", "Ações"
+        }) {
+            @Override
+            public boolean isCellEditable(int row, int column) {
+                return column == 6;
+            }
+
+            @Override
+            public Class<?> getColumnClass(int columnIndex) {
+                return columnIndex == 0 ? ImageIcon.class : Object.class;
+            }
+        });
+        table.setRowHeight(40);
+        JScrollPane scroll = new JScrollPane(table);
+        table.fixTable(scroll);
+        table.setRowSelectionAllowed(false);
+        add(scroll, BorderLayout.CENTER);
+
+        btnPrevPage = new JButton("Anterior");
+        btnNextPage = new JButton("Próximo");
+        btnPrevPage.addActionListener(e -> {
+            if (currentPage > 0) {
+                currentPage--;
+                updatePage();
+            }
+        });
+        btnNextPage.addActionListener(e -> {
+            if ((currentPage + 1) * PAGE_SIZE < (filtradas != null ? filtradas.size() : 0)) {
+                currentPage++;
+                updatePage();
+            }
+        });
+        JPanel pagination = new JPanel(new FlowLayout(FlowLayout.CENTER));
+        pagination.setBackground(Color.WHITE);
+        pagination.add(btnPrevPage);
+        pagination.add(btnNextPage);
+        add(pagination, BorderLayout.SOUTH);
+    }
+
+    private void carregarRotinas() {
+        rotinas = controller.listar();
+        aplicarFiltros();
+    }
+
+    private void aplicarFiltros() {
+        if (rotinas == null) {
+            return;
+        }
+        String busca = txtBusca.getText();
+        String filtro = (busca != null && !busca.isEmpty()) ? busca.toLowerCase() : null;
+        filtradas = rotinas.stream()
+                .filter(r -> filtroStatus == null || (r.getStatus() != null && filtroStatus.equals(r.getStatus())))
+                .filter(r -> filtro == null || matchesBusca(r, filtro))
+                .collect(Collectors.toList());
+        atualizarCards(filtradas);
+        currentPage = 0;
+        updatePage();
+    }
+
+    private boolean matchesBusca(Rotina r, String filtro) {
+        return (r.getNome() != null && r.getNome().toLowerCase().contains(filtro))
+                || (r.getDescricao() != null && r.getDescricao().toLowerCase().contains(filtro));
+    }
+
+    private void atualizarCards(List<Rotina> lista) {
+        long ativas = lista.stream().filter(r -> r.getStatus() != null && r.getStatus() == 1).count();
+        long concluidas = lista.stream().filter(r -> r.getStatus() != null && r.getStatus() == 3).count();
+        cardTotal.setData(new ModelCard("Rotinas", lista.size(), 0, iconTotal));
+        cardAtivas.setData(new ModelCard("Ativas", (int) ativas, 0, iconAtiva));
+        cardConcluidas.setData(new ModelCard("Concluídas", (int) concluidas, 0, iconConcluida));
+    }
+
+    private void atualizarTabela(List<Rotina> lista) {
+        DefaultTableModel model = (DefaultTableModel) table.getModel();
+        model.setRowCount(0);
+        EventAction<Rotina> eventAction = new EventAction<Rotina>() {
+            @Override
+            public void delete(Rotina r) {
+                excluirRotina(r);
+            }
+
+            @Override
+            public void update(Rotina r) {
+                editarRotina(r);
+            }
+        };
+        ImageIcon avatarIcon = (ImageIcon) IconFontSwing.buildIcon(GoogleMaterialDesignIcons.EVENT_NOTE, 35, Color.WHITE,
+                new Color(63, 81, 181, 80));
+        for (Rotina r : lista) {
+            model.addRow(new Object[]{
+                avatarIcon,
+                r.getNome(),
+                periodoTexto(r),
+                statusTexto(r.getStatus()),
+                r.getPonto(),
+                r.getIdUsuario(),
+                new ModelAction<>(r, eventAction)
+            });
+        }
+        table.getColumnModel().getColumn(0).setCellRenderer(new TableCellRenderer() {
+            @Override
+            public Component getTableCellRendererComponent(JTable tbl, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+                ImageAvatar avatar = new ImageAvatar();
+                avatar.setPreferredSize(new Dimension(40, 40));
+                if (value instanceof ImageIcon) {
+                    avatar.setIcon((ImageIcon) value);
+                }
+                return avatar;
+            }
+        });
+    }
+
+    private String periodoTexto(Rotina r) {
+        String inicio = r.getInicio() != null ? r.getInicio().format(formatter) : "";
+        String fim = r.getFim() != null ? r.getFim().format(formatter) : "";
+        if (inicio.isEmpty() && fim.isEmpty()) {
+            return "";
+        }
+        return inicio + " - " + fim;
+    }
+
+    private void updatePage() {
+        List<Rotina> page = getCurrentPage();
+        atualizarTabela(page);
+        updatePaginationButtons();
+    }
+
+    private List<Rotina> getCurrentPage() {
+        if (filtradas == null) {
+            return Collections.emptyList();
+        }
+        int start = currentPage * PAGE_SIZE;
+        int end = Math.min(start + PAGE_SIZE, filtradas.size());
+        return filtradas.subList(start, end);
+    }
+
+    private void updatePaginationButtons() {
+        int size = filtradas != null ? filtradas.size() : 0;
+        btnPrevPage.setEnabled(currentPage > 0);
+        btnNextPage.setEnabled((currentPage + 1) * PAGE_SIZE < size);
+    }
+
+    private void adicionarRotina() {
+        Frame frame = (Frame) SwingUtilities.getWindowAncestor(this);
+        RotinaDialog dialog = new RotinaDialog(frame, null);
+        dialog.setVisible(true);
+        if (dialog.isConfirmed()) {
+            try {
+                controller.criar(dialog.getRotina());
+                carregarRotinas();
+            } catch (Exception ex) {
+                JOptionPane.showMessageDialog(this, ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+
+    private void editarRotina(Rotina r) {
+        try {
+            Rotina completa = controller.buscarPorId(r.getIdRotina());
+            Frame frame = (Frame) SwingUtilities.getWindowAncestor(this);
+            RotinaDialog dialog = new RotinaDialog(frame, completa);
+            dialog.setVisible(true);
+            if (dialog.isConfirmed()) {
+                try {
+                    controller.atualizar(dialog.getRotina());
+                    carregarRotinas();
+                } catch (Exception ex) {
+                    JOptionPane.showMessageDialog(this, ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+                }
+            }
+        } catch (Exception ex) {
+            JOptionPane.showMessageDialog(this, ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+        }
+    }
+
+    private void excluirRotina(Rotina r) {
+        int opt = JOptionPane.showConfirmDialog(this, "Excluir rotina?", "Confirmação", JOptionPane.YES_NO_OPTION);
+        if (opt == JOptionPane.YES_OPTION) {
+            try {
+                controller.remover(r.getIdRotina());
+                carregarRotinas();
+            } catch (Exception ex) {
+                JOptionPane.showMessageDialog(this, ex.getMessage(), "Erro", JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+
+    private String statusTexto(Integer status) {
+        if (status == null) {
+            return "";
+        }
+        switch (status) {
+            case 1:
+                return "Ativa";
+            case 2:
+                return "Pausada";
+            case 3:
+                return "Concluída";
+            default:
+                return status.toString();
+        }
+    }
+}

--- a/src/main/java/main/Main.java
+++ b/src/main/java/main/Main.java
@@ -12,6 +12,11 @@ import form.MainForm;
 import form.MovimentacaoForm;
 import form.CaixaForm;
 import form.CofreForm;
+import form.ExercicioForm;
+import form.RotinaForm;
+import form.FornecedorForm;
+import form.IngredienteForm;
+import form.MonitoramentoForm;
 import form.CarteiraForm;
 import form.CadernoForm;
 import form.MetaForm;
@@ -92,16 +97,26 @@ public class Main extends javax.swing.JFrame {
                     } else if (subMenuIndex == 6) {
                         main.showForm(new CofreForm());
                     } else if (subMenuIndex == 7) {
-                        main.showForm(new CarteiraForm());
+                        main.showForm(new ExercicioForm());
                     } else if (subMenuIndex == 8) {
-                        main.showForm(new CadernoForm());
+                        main.showForm(new RotinaForm());
                     } else if (subMenuIndex == 9) {
-                        main.showForm(new MetaForm());
+                        main.showForm(new FornecedorForm());
                     } else if (subMenuIndex == 10) {
-                        main.showForm(new SiteForm());
+                        main.showForm(new IngredienteForm());
                     } else if (subMenuIndex == 11) {
-                        main.showForm(new ObjetoForm());
+                        main.showForm(new MonitoramentoForm());
                     } else if (subMenuIndex == 12) {
+                        main.showForm(new CarteiraForm());
+                    } else if (subMenuIndex == 13) {
+                        main.showForm(new CadernoForm());
+                    } else if (subMenuIndex == 14) {
+                        main.showForm(new MetaForm());
+                    } else if (subMenuIndex == 15) {
+                        main.showForm(new SiteForm());
+                    } else if (subMenuIndex == 16) {
+                        main.showForm(new ObjetoForm());
+                    } else if (subMenuIndex == 17) {
                         main.showForm(new PapelForm());
                     }
                 } else if (menuIndex == 1) {


### PR DESCRIPTION
## Summary
- add forms and dialogs for Exercicio, Rotina, Fornecedor, Ingrediente and Monitoramento mirroring the Cofre experience
- wire new dashboard submenu entries and navigation handlers for the new entities

## Testing
- `mvn -q -DskipTests compile` *(fails: unable to resolve maven-enforcer-plugin because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68cf24e86c1483259f9bfe3e3f939b14