### PR TITLE
Fix missing icon constant for IngredienteForm

### DIFF
--- a/src/main/java/form/IngredienteForm.java
+++ b/src/main/java/form/IngredienteForm.java
@@ -94,7 +94,7 @@ public class IngredienteForm extends JPanel {
         cardComFoto.setData(new ModelCard("Com foto", 0, 0, iconComFoto));
         cards.add(cardComFoto);
 
-        iconSemFoto = IconFontSwing.buildIcon(GoogleMaterialDesignIcons.IMAGE_NOT_SUPPORTED, 60, Color.WHITE,
+        iconSemFoto = IconFontSwing.buildIcon(GoogleMaterialDesignIcons.BROKEN_IMAGE, 60, Color.WHITE,
                 new Color(255, 255, 255, 15));
         cardSemFoto = new Card();
         cardSemFoto.setBackground(new Color(255, 152, 0));


### PR DESCRIPTION
## Summary
- replace the unavailable Google Material Design icon constant in `IngredienteForm` with the existing `BROKEN_IMAGE` value so the form compiles again

## Testing
- mvn -q -DskipTests package *(fails: unable to download maven-enforcer-plugin because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68cf347fc8d08325adaa142c7e702cbe