### PR TITLE
Highlight stochastic extremes in Renko strategy

### DIFF
--- a/robo/Kadu_Topo_fundo.txt
+++ b/robo/Kadu_Topo_fundo.txt
@@ -219,7 +219,9 @@ If isSold then
          
 End;
 
-  if (stoFast - stoSlow) >= DiferencaMinimaStoch then
+  if (stoFast = 100) or (stoSlow = 100) or (stoFast = 0) or (stoSlow = 0) then
+    PaintBar(clYellow)
+  else if (stoFast - stoSlow) >= DiferencaMinimaStoch then
     PaintBar(corVerdeEscuro)
   else if (stoSlow - stoFast) >= DiferencaMinimaStoch then
     PaintBar(corVermelhoEscuro);


### PR DESCRIPTION
## Summary
- paint the Renko bars yellow whenever the stochastic fast or slow line hits 0 or 100
- keep the existing green and red coloring for bullish or bearish stochastic spreads otherwise

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69162e1b777c8325a35ec93e6c3809b7)