### PR TITLE
Add gain and stop targets to KM_001_10R_WIN

### DIFF
--- a/robo/KM_001_10R_WIN.txt
+++ b/robo/KM_001_10R_WIN.txt
@@ -145,21 +145,36 @@ end;
   consecutivosAbaixo:=0;
  end;
 
-  se(compraKeltnerValida)entao
+ se(compraKeltnerValida)entao
  begin
- BuyAtMarket(ContratosTotal);
+  BuyAtMarket(ContratosTotal);
+  Entrada := Fechamento;
  end;
 
  se(vendaKeltnerValida)entao
  begin
- SellShortAtMarket(ContratosTotal);
+  SellShortAtMarket(ContratosTotal);
+  Entrada := Fechamento;
  end;
 
 
  if(HasPosition) and (cohenWeisWaveAnterior >= 300000)entao
  ClosePosition;
 
- 
+
+  if IsBought then
+  begin
+    SellToCoverLimit(Entrada + 90, ContratosTotal);
+    SellToCoverStop(Entrada - 250, (Entrada - 250) - MinPriceIncrement, ContratosTotal);
+  end;
+
+  if IsSold then
+  begin
+    BuyToCoverLimit(Entrada - 90, ContratosTotal);
+    BuyToCoverStop(Entrada + 250, (Entrada + 250) + MinPriceIncrement, ContratosTotal);
+  end;
+
+
 
 
 end;


### PR DESCRIPTION
## Summary
- capture entry price when opening buy or sell positions
- add fixed 90-point gain targets for both long and short trades
- place 250-point protective stops for open positions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f033c1e6083259e90e14c70e80c26)