### PR TITLE
Add help file to robo directory

### DIFF
--- a/robo/help.txt
+++ b/robo/help.txt
@@ -1,0 +1,14 @@
+# Help do diretório `robo`
+
+Este diretório armazena arquivos de configuração e scripts de apoio para o robô de produção. Abaixo segue um resumo do conteúdo e algumas orientações rápidas:
+
+- **KM_001_10R_WIN.txt** / **KM_001_10R_WIN.txt.bak** / **KM_002_10R_WIN_GRAD.txt** / **KM_100_10R_WIN_COR.txt** / **KM_V2.txt** / **KM_AUTO.txt**: arquivos de configuração de rotinas com diferentes variações. Use o mais adequado ao cenário desejado e mantenha o backup (`.bak`) intacto para referência.
+- **Kadu_Topo_fundo.txt** / **Kadu_topo_fundo_com_filtro.txt**: ajustes específicos para deteção de topo/fundo com e sem filtro adicional.
+- **_NTB_TopBottomDetector_Breakout.psf**: perfil de detecção de topo e fundo utilizado pelo detector NTB.
+- **Robo.txt**: script padrão utilizado na execução principal do robô.
+- **simulacao_robo_2025_2026.xlsx**: planilha de simulação para validar estratégias com dados de 2025–2026.
+
+## Dicas rápidas
+1. Mantenha um backup atualizado sempre que alterar qualquer configuração crítica.
+2. Documente mudanças significativas diretamente neste arquivo para facilitar o histórico.
+3. Ao testar uma nova rotina, duplique o arquivo de configuração original e trabalhe na cópia para preservar a referência.


### PR DESCRIPTION
## Summary
- add a help file inside the `robo` directory
- describe the purpose of the existing configuration and script files
- include quick tips for working with the robot configurations

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693717a9e8e883258bdcec82592500ec)