### PR TITLE
Limita entradas por direção e desbloqueia após candle oposto em KM_002_REPLAY

### DIFF
--- a/robo/KM_002_REPLAY.txt
+++ b/robo/KM_002_REPLAY.txt
@@ -11,16 +11,27 @@ AtrDesvio4(4);
 
 bolSinalCompra(true);
 bolSinalVenda(false);
+quantidadeMaximaEntrada(3);
 
 periodo(20);
 Var
   Atr1, Atr2, Atr3,Atr4 : Float;
   SinalC, SinalV   : Boolean;
- amp, t, f : Float;
+  amp, t, f : Float;
+  contEntradasCompra, contEntradasVenda : Integer;
+  aguardandoCandleBaixa, aguardandoCandleAlta : Boolean;
 
 
 Begin
   amp := Round(Abs(Abertura[1] - Fechamento[1]));
+
+  Se CurrentBar = 1 entao
+  inicio
+    contEntradasCompra := 0;
+    contEntradasVenda := 0;
+    aguardandoCandleBaixa := false;
+    aguardandoCandleAlta := false;
+  fim;
 
   Se Abertura[1] > Fechamento[1] então
   inicio
@@ -66,13 +77,38 @@ Begin
 
      Se  (time >= HorarioInicio)  and  (Time <= HorarioFinal)   entao
   Inicio
-    Se SinalC  e (bolSinalCompra) e (bolSinalVenda=false)  entao
+    Se aguardandoCandleBaixa e (Abertura[1] > Fechamento[1]) entao
+    inicio
+      aguardandoCandleBaixa := false;
+      contEntradasCompra := 0;
+    fim;
+
+    Se aguardandoCandleAlta e (Fechamento[1] > Abertura[1]) entao
+    inicio
+      aguardandoCandleAlta := false;
+      contEntradasVenda := 0;
+    fim;
+
+    Se SinalC  e (bolSinalCompra) e (bolSinalVenda=false) e (aguardandoCandleBaixa=false) entao
     begin
-    BuyStop(t,t);
+      BuyStop(t,t);
+      contEntradasCompra := contEntradasCompra + 1;
+
+      Se contEntradasCompra >= quantidadeMaximaEntrada entao
+      inicio
+        aguardandoCandleBaixa := true;
+      fim;
     end;
-    Se SinalV e (bolSinalVenda) e (bolSinalCompra=false) entao 
+
+    Se SinalV e (bolSinalVenda) e (bolSinalCompra=false) e (aguardandoCandleAlta=false) entao 
     begin
-    SellShortStop(f,f);
+      SellShortStop(f,f);
+      contEntradasVenda := contEntradasVenda + 1;
+
+      Se contEntradasVenda >= quantidadeMaximaEntrada entao
+      inicio
+        aguardandoCandleAlta := true;
+      fim;
     end;
   fim;
 


### PR DESCRIPTION
### Motivation
- Implementar um limite parametrizável de entradas por direção para evitar entradas excessivas durante um mesmo viés.
- Após atingir o limite, exigir a ocorrência de um candle oposto para liberar novas entradas na mesma direção.
- Permitir configurar a quantidade máxima por meio do parâmetro `quantidadeMaximaEntrada` para maior flexibilidade.

### Description
- Adiciona o `Input` `quantidadeMaximaEntrada(3)` e declara as variáveis de controle `contEntradasCompra`, `contEntradasVenda`, `aguardandoCandleBaixa` e `aguardandoCandleAlta` no arquivo `robo/KM_002_REPLAY.txt`.
- Inicializa os contadores e flags em `Se CurrentBar = 1` e incrementa os contadores a cada execução de `BuyStop` ou `SellShortStop` dentro da janela de horário existente.
- Ao atingir `quantidadeMaximaEntrada` para compras ou vendas, ativa a flag de bloqueio correspondente (`aguardandoCandleBaixa` ou `aguardandoCandleAlta`) e somente reseta o contador quando for detectado um candle oposto (`Abertura[1] > Fechamento[1]` para liberar compras e `Fechamento[1] > Abertura[1]` para liberar vendas).

### Testing
- Executei a comparação de diferenças com `git -C /workspace/RotinaMaisDesktop diff -- robo/KM_002_REPLAY.txt` para validar o delta do arquivo e a verificação retornou com sucesso.
- Verifiquei o estado do repositório com `git -C /workspace/RotinaMaisDesktop status --short` e a checagem retornou com sucesso.
- Inspecionei o conteúdo final do arquivo com `nl -ba /workspace/RotinaMaisDesktop/robo/KM_002_REPLAY.txt | sed -n '1,220p'` para confirmar a presença e posição das alterações, e a inspeção retornou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0291d5b7483259d1c5bf82c9d24d8)