### PR TITLE
Ajustes pontuais no KM_ANALISE_003: validação de range e limite de reentradas

### DIFF
--- a/robo/KM_ANALISE_003.txt
+++ b/robo/KM_ANALISE_003.txt
@@ -26,6 +26,7 @@ renkoAlta,renkoBaixa,renkoReversaoAlta,renkoReversaoBaixa,
 podeOperar,renkoConsecutivo,rangeNaoPodeOperar:boolean;
 valorReversaoTopo,valorReversaoFundo:float;
 bolSinalCompra,bolSinalVenda,bolEntreRengeTravado:boolean;
+bolRangeTravadoValido:boolean;
 
 // ===== CONTROLES ADICIONADOS =====
 intQtdRenkosAlta,intQtdRenkosBaixa:integer;
@@ -103,7 +104,9 @@ end;
 
 // CORREÇÃO CIRÚRGICA:
 // Dentro do range travado somente quando preço estiver ENTRE fundo e topo.
-bolEntreRengeTravado:= (fechamento <= valorReversaoTopo) e (fechamento >= valorReversaoFundo);
+// ALTERAÇÃO PONTUAL: também exige faixa válida (topo maior que fundo) para evitar range "travado" inválido.
+bolRangeTravadoValido := (valorReversaoTopo > valorReversaoFundo);
+bolEntreRengeTravado:= bolRangeTravadoValido e (fechamento <= valorReversaoTopo) e (fechamento >= valorReversaoFundo);
 
 // =============================================================
 // 5) BLOQUEIO POR EXPLOSÃO + LIBERAÇÃO POR RESPIRO (NOVO)
@@ -184,7 +187,8 @@ Inicio
   // Reentrada comprada: mantém lógica original, mas com limite + distância + filtros
   Se (bolHorarioBloqueadoEntrada = false) e (bolSinalCompra) e (IsBought) e
      (bolBloqueioCompraExplosao = false) e
-     (BuyPosition < MaxEntradas) e
+     // ALTERAÇÃO PONTUAL: MaxEntradas limita reentradas adicionais reais (posição atual + entrada inicial).
+     (BuyPosition < (MaxEntradas + 1)) e
      ((BuyPosition = 0) ou (Fechamento <= (BuyPrice - DistanciaMinimaReentrada))) entao
   Inicio
     BuyAtMarket;
@@ -193,7 +197,8 @@ Inicio
   // Reentrada vendida: mantém lógica original, mas com limite + distância + filtros
   Se (bolHorarioBloqueadoEntrada = false) e (bolSinalVenda) e (IsSold) e
      (bolBloqueioVendaExplosao = false) e
-     (SellPosition < MaxEntradas) e
+     // ALTERAÇÃO PONTUAL: MaxEntradas limita reentradas adicionais reais (posição atual + entrada inicial).
+     (SellPosition < (MaxEntradas + 1)) e
      ((SellPosition = 0) ou (Fechamento >= (SellPrice + DistanciaMinimaReentrada))) entao
   Inicio
     SellShortAtMarket;


### PR DESCRIPTION
### Motivation
- Preservar a lógica contra tendência existente e aplicar apenas correções cirúrgicas solicitadas para evitar falso reconhecimento de "range travado" e controlar reentradas.
- Garantir que o preço seja considerado dentro do range apenas quando a faixa entre `valorReversaoTopo` e `valorReversaoFundo` for válida.
- Ajustar o limite de reentradas para que `MaxEntradas` represente entradas adicionais reais sem alterar o tipo de ordem a mercado.
- Manter todos os filtros já existentes (contadores de renkos, bloqueios por explosão, respiro, distância mínima e janelas de horário) sem substituir a lógica original.

### Description
- Adicionado o booleano `bolRangeTravadoValido` e alterado o cálculo de `bolEntreRengeTravado` para exigir `valorReversaoTopo > valorReversaoFundo` antes de verificar se o fechamento está entre topo e fundo. 
- Alterada a condição de limite de reentradas de `BuyPosition < MaxEntradas` / `SellPosition < MaxEntradas` para `BuyPosition < (MaxEntradas + 1)` / `SellPosition < (MaxEntradas + 1)` para considerar a entrada inicial mais `MaxEntradas` adicionais. 
- Inseridos comentários explicativos nas partes alteradas para indicar que são alterações pontuais e para preservar a intenção original do robô. 
- Não foram introduzidos novos indicadores (ATR/ADX/RSI/etc.), nem alterada a base dos sinais (`MediaExp`) ou o tipo de entrada (`BuyAtMarket` / `SellShortAtMarket`).

### Testing
- Apliquei o patch no arquivo `robo/KM_ANALISE_003.txt` com `apply_patch` e a alteração foi aplicada com sucesso. (sucesso)
- Verifiquei o estado do repositório com `git status --short` e confirmei a alteração com `git commit -m "Ajusta faixa de range e limite real de reentradas no KM_ANALISE_003"` sem erros. (sucesso)
- Confirmei o diff do `HEAD` com `git show --stat --oneline HEAD` para validar as linhas alteradas. (sucesso)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d66a7de5b0832596596c441257d143)