### PR TITLE
Adicionar filtro de horário de explosão em KM_ANALISE_003

### DIFF
--- a/robo/KM_ANALISE_003.txt
+++ b/robo/KM_ANALISE_003.txt
@@ -32,6 +32,7 @@ bolRangeTravadoValido:boolean;
 intQtdRenkosAlta,intQtdRenkosBaixa:integer;
 bolBloqueioVendaExplosao,bolBloqueioCompraExplosao:boolean;
 bolHorarioBloqueadoEntrada:boolean;
+bolHorarioExplosao_1,bolHorarioExplosao_2,bolHorarioExplosao_3,bolHorarioPermitido:boolean;
 
 Inicio
 // =============================================================
@@ -50,6 +51,19 @@ renkoReversaoAlta:=(fechamento[0] < abertura[0]) e (fechamento[1]>abertura[1]);
 renkoReversaoBaixa:= (fechamento[0]>abertura[0]) e  (fechamento[1] < abertura[1]);
 
 renkoConsecutivo :=  (abertura[0]<>abertura[1]) e (abertura[1]<>abertura[2]);
+
+// =============================================================
+// 1.1) ADICIONAR NOVAS VARIAVEIS CHATGPT - INICIO
+// =============================================================
+bolHorarioExplosao_1:= (Time >= 0850) e (Time <= 0910);
+
+bolHorarioExplosao_2:= (Time >= 0950) e (Time <= 1010);
+
+bolHorarioExplosao_3:= (Time >= 1050) e (Time <= 1110);
+
+bolHorarioPermitido:= (bolHorarioExplosao_1=false) e 
+                      (bolHorarioExplosao_2=false) e 
+                      (bolHorarioExplosao_3=false);
 
 // =============================================================
 // 3) CONTADORES DE RENKOS CONSECUTIVOS (NOVO)
@@ -144,8 +158,8 @@ bolHorarioBloqueadoEntrada :=
 // =============================================================
 // 7) SINAIS ORIGINAIS (MANTIDOS)
 // =============================================================
-bolSinalVenda:= (Fechamento > MediaMax) e (fechamento > Abertura);
-bolSinalCompra:=(Fechamento < MediaMin) e (fechamento < Abertura);
+bolSinalVenda:= (Fechamento > MediaMax) e (fechamento > Abertura) e (bolHorarioPermitido);
+bolSinalCompra:=(Fechamento < MediaMin) e (fechamento < Abertura) e (bolHorarioPermitido);
 
 if(bolSinalVenda) e (bolEntreRengeTravado) e (podeOperar=false)entao
 begin


### PR DESCRIPTION
### Motivation
- Inserir filtros de horário que bloqueiem entradas em três janelas de maior volatilidade preservando a lógica original do robô.
- Garantir que, quando qualquer janela estiver ativa, compras e vendas fiquem bloqueadas, e fora dessas janelas a lógica original permanece inalterada.

### Description
- Adiciona as variáveis booleanas `bolHorarioExplosao_1`, `bolHorarioExplosao_2`, `bolHorarioExplosao_3` e `bolHorarioPermitido` ao bloco `var` em `robo/KM_ANALISE_003.txt` sem remover variáveis existentes. 
- Insere as atribuições das três janelas de horário (`bolHorarioExplosao_1:= (Time >= 0850) e (Time <= 0910);`, `bolHorarioExplosao_2:= (Time >= 0950) e (Time <= 1010);`, `bolHorarioExplosao_3:= (Time >= 1050) e (Time <= 1110);`) e a composição `bolHorarioPermitido:= (bolHorarioExplosao_1=false) e (bolHorarioExplosao_2=false) e (bolHorarioExplosao_3=false);` no bloco indicado para novas variáveis/regras. 
- Acrescenta apenas a condição `e (bolHorarioPermitido)` ao final das duas expressões de sinal `bolSinalVenda` e `bolSinalCompra`, preservando todas as demais condições e lógica do arquivo. 
- Todas as mudanças foram feitas exclusivamente em `robo/KM_ANALISE_003.txt` e são acréscimos pontuais, sem remoção, reorganização ou refatoração de código existente.

### Testing
- Aplicação do patch automática retornou sucesso indicando as linhas adicionadas conforme especificado. 
- Inspeção do arquivo com comandos de leitura (`sed` e `nl`) confirmou presença das variáveis novas no bloco `var` e das atribuições das janelas no local correto. 
- Verificação de diff confirmou que somente as linhas solicitadas foram adicionadas e nenhuma lógica pré-existente foi removida.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d79dbdd958832589b2b9ed4b94ba70)